### PR TITLE
bugfix: Batch processor did not shut down cleanly, losing metrics

### DIFF
--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 
@@ -83,6 +83,7 @@ library
     , random-bytestring
     , stm
     , text
+    , transformers
     , unagi-chan
     , unix
     , unordered-containers
@@ -119,6 +120,7 @@ test-suite hs-opentelemetry-sdk-test
     , random-bytestring
     , stm
     , text
+    , transformers
     , unagi-chan
     , unix
     , unordered-containers

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 - http-types
 - network-bsd
 - unix
+- transformers
 # todo get rid of this when enough of the ecosystem has upgraded
 - random
 - mwc-random


### PR DESCRIPTION
When the process exited, the sending of metrics to OTLP was rudely
interrupted by `cancel`. This meant that the root span would often go
missing if you instrumented some kind of command line application with
the root span created at process creation.

This patch changes the shutdown logic to first ask the exporter to send
what it has and shut down, then forcibly kill it if that takes too long.