### PR TITLE
Add hspec instrumentation

### DIFF
--- a/examples/hspec/.gitignore
+++ b/examples/hspec/.gitignore
@@ -1,0 +1,4 @@
+*.aes
+*.hi
+*.o
+*.cabal

--- a/examples/hspec/README.md
+++ b/examples/hspec/README.md
@@ -1,0 +1,24 @@
+# hspec instrumentation example
+
+This directory contains a project demonstrating instrumenting a test suite with
+the hspec instrumentation.
+
+Note that this uses `cabal run`: `cabal test` doesn't allow owning the test
+entry point.
+
+Sample output:
+
+```
+$ cabal run hspec-example:test
+....
+Target
+  adds two
+    adds 2 to 2 [✔]
+
+Finished in 0.0001 seconds
+1 example, 0 failures
+Done
+Trace link: (some service)/504136ca94f41ab5f9afda25612280ea
+"504136ca94f41ab5f9afda25612280ea" "8794b7b2dba28bbf" Timestamp (TimeSpec {sec = 1661367581, nsec = 198794000}) adds 2 to 2
+"504136ca94f41ab5f9afda25612280ea" "4e6d6ccd2ccd0369" Timestamp (TimeSpec {sec = 1661367581, nsec = 197769000}) Run tests
+```

--- a/examples/hspec/package.yaml
+++ b/examples/hspec/package.yaml
@@ -1,0 +1,27 @@
+name: hspec-example
+
+dependencies:
+# minimal example dependencies
+- base
+- hspec
+- unliftio
+- text
+# opentelemetry dependencies
+- hs-opentelemetry-sdk
+- hs-opentelemetry-api
+- hs-opentelemetry-exporter-handle
+- hs-opentelemetry-instrumentation-hspec
+
+ghc-options:
+  - -Wall
+
+tests:
+  test:
+    dependencies:
+      - hspec-example
+    main: Main.hs
+    source-dirs:
+      - test
+
+library:
+  source-dirs: src

--- a/examples/hspec/src/TestTarget.hs
+++ b/examples/hspec/src/TestTarget.hs
@@ -1,0 +1,4 @@
+module TestTarget where
+
+addTwo :: Int -> Int
+addTwo = (+2)

--- a/examples/hspec/test/Main.hs
+++ b/examples/hspec/test/Main.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Control.Monad (void)
+import Data.Text (Text, unpack)
+import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Context.ThreadLocal (attachContext, getContext)
+import OpenTelemetry.Exporter.Handle
+import OpenTelemetry.Instrumentation.Hspec (wrapSpec)
+import OpenTelemetry.Processor.Batch
+import OpenTelemetry.Trace hiding (inSpan)
+import qualified OpenTelemetry.Trace as Trace
+import OpenTelemetry.Trace.Core (getSpanContext)
+import OpenTelemetry.Trace.Id (Base (..), traceIdBaseEncodedText)
+import OpenTelemetry.Trace.Sampler
+import qualified Spec
+import Test.Hspec
+import Test.Hspec.Runner (defaultConfig, hspecWith)
+import UnliftIO (MonadUnliftIO, bracket, finally, throwString)
+
+-- | Initialize the global tracing provider for the application and run an action
+--   (that action is generally the entry point of the application), cleaning
+--   up the provider afterwards.
+--
+--   This also sets up an empty context (creating a new trace ID).
+withGlobalTracing :: Sampler -> IO a -> IO a
+withGlobalTracing sampler act = do
+  void $ attachContext Context.empty
+  bracket
+    (initializeTracing sampler)
+    shutdownTracerProvider
+    $ const act
+
+printTraceLink :: IO ()
+printTraceLink = do
+  -- It's helpful to print out a trace link for the run so the user can look at it.
+  -- The precise link to view a trace by ID is left as an exercise to the reader
+  -- as it depends on which service you use.
+  --
+  -- For Honeycomb, see https://docs.honeycomb.io/api/direct-trace-links/
+  theSpan <- maybe (throwString "no context?") pure . Context.lookupSpan =<< getContext
+  theTraceId <- traceIdBaseEncodedText Base16 . traceId <$> getSpanContext theSpan
+
+  putStrLn $ "Trace link: (some service)/" <> unpack theTraceId
+
+initializeTracing :: Sampler -> IO TracerProvider
+initializeTracing sampler = do
+  (processors, tracerOptions') <- getTracerProviderInitializationOptions
+
+  -- forcibly adds a stderr exporter; this is just for demo purposes
+  stderrProc <- batchProcessor batchTimeoutConfig $ stderrExporter' (pure . defaultFormatter)
+  let processors' = stderrProc : processors
+
+  provider <- createTracerProvider processors' (tracerOptions' {tracerProviderOptionsSampler = sampler})
+  setGlobalTracerProvider provider
+
+  pure provider
+
+inSpan :: (MonadUnliftIO m, HasCallStack) => Text -> SpanArguments -> m a -> m a
+inSpan name args act = do
+  tp <- getGlobalTracerProvider
+  let tracer = makeTracer tp "hspec-example" tracerOptions
+  Trace.inSpan tracer name args act
+
+main :: IO ()
+main = do
+  putStrLn "Begin tests"
+  withGlobalTracing alwaysOn $
+    inSpan "Run tests" defaultSpanArguments $
+      runTests `finally` printTraceLink
+
+runTests :: IO ()
+runTests = do
+  wrapper <- wrapSpec
+  hspecWith
+    defaultConfig
+    $ wrapper (parallel Spec.spec)
+  putStrLn "Done"

--- a/examples/hspec/test/Spec.hs
+++ b/examples/hspec/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/examples/hspec/test/TargetSpec.hs
+++ b/examples/hspec/test/TargetSpec.hs
@@ -1,0 +1,7 @@
+module TargetSpec where
+import TestTarget
+import Test.Hspec
+
+spec = describe "adds two" $ do
+  it "adds 2 to 2" $ do
+    addTwo 2 `shouldBe` 4

--- a/instrumentation/hspec/.gitignore
+++ b/instrumentation/hspec/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/instrumentation/hspec/ChangeLog.md
+++ b/instrumentation/hspec/ChangeLog.md
@@ -1,0 +1,7 @@
+# Changelog for hs-opentelemetry-instrumentation-hspec
+
+## 0.0.1.0
+
+- Initial release
+
+## Unreleased changes

--- a/instrumentation/hspec/LICENSE
+++ b/instrumentation/hspec/LICENSE
@@ -1,0 +1,30 @@
+Copyright Ian Duncan (c) 2021
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Ian Duncan nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/instrumentation/hspec/README.md
+++ b/instrumentation/hspec/README.md
@@ -1,0 +1,1 @@
+# hs-opentelemetry-instrumentation-hspec

--- a/instrumentation/hspec/README.md
+++ b/instrumentation/hspec/README.md
@@ -1,1 +1,10 @@
 # hs-opentelemetry-instrumentation-hspec
+
+Instrumentation for Hspec for OpenTelemetry. This creates a span for each test
+case inside a test suite.
+
+## Usage
+
+See the example in [examples/hspec](../../examples/hspec) for an instrumented
+test suite.
+

--- a/instrumentation/hspec/Setup.hs
+++ b/instrumentation/hspec/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
+++ b/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
@@ -1,0 +1,64 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.5.
+--
+-- see: https://github.com/sol/hpack
+
+name:           hs-opentelemetry-instrumentation-hspec
+version:        0.0.1.0
+description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/hspec#readme>
+homepage:       https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
+author:         Ian Duncan
+maintainer:     ian@iankduncan.com
+copyright:      2021 Ian Duncan
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Instrumentation.Hspec
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_hspec
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.0.3.*
+    , hspec >=2.9.4
+    , hspec-core >=2.9.4
+    , mtl
+    , resourcet
+    , text
+    , unliftio
+    , vault
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-hspec-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_hspec
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.0.3.*
+    , hs-opentelemetry-instrumentation-hspec
+    , hspec >=2.9.4
+    , hspec-core >=2.9.4
+    , mtl
+    , resourcet
+    , text
+    , unliftio
+    , vault
+  default-language: Haskell2010

--- a/instrumentation/hspec/package.yaml
+++ b/instrumentation/hspec/package.yaml
@@ -1,0 +1,45 @@
+_common/lib: !include "../../package-common.yaml"
+
+name:                hs-opentelemetry-instrumentation-hspec
+version:             0.0.1.0
+
+<<: *preface
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/hspec#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+- hs-opentelemetry-api == 0.0.3.*
+- hspec >= 2.9.4
+- hspec-core >= 2.9.4
+- text
+- vault
+- resourcet
+- unliftio # TODO, unliftio-core
+- mtl
+
+library:
+  # ghc-options: -Wall
+  source-dirs: src
+
+tests:
+  hs-opentelemetry-hspec-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-hspec

--- a/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
+++ b/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenTelemetry.Instrumentation.Hspec
+  ( wrapSpec,
+    wrapExampleInSpan,
+  )
+where
+
+import Control.Monad.IO.Class
+import Control.Monad.Reader
+import Data.Text (Text)
+import qualified Data.Text as T
+import OpenTelemetry.Attributes (Attributes)
+import OpenTelemetry.Context
+import OpenTelemetry.Context.ThreadLocal (adjustContext, attachContext, getContext)
+import OpenTelemetry.Trace.Core
+import Test.Hspec.Core.Spec (ActionWith, Item (..), Spec, SpecWith, mapSpecItem_)
+
+wrapSpec :: MonadIO m => m (SpecWith a -> SpecWith a)
+wrapSpec = do
+  tp <- getGlobalTracerProvider
+  let tracer = makeTracer tp "hs-opentelemetry-instrumentation-hspec" tracerOptions
+  context <- getContext
+
+  -- FIXME: this kind of just dumps everything flat into one span. We could
+  -- possibly do better, e.g. finding the `describe`s and making them into spans
+  -- but I am not sure how that interacts with the evaluator
+  pure $ \spec -> mapSpecItem_ (wrapExampleInSpan tracer context) spec
+
+wrapExampleInSpan :: Tracer -> Context -> Item a -> Item a
+wrapExampleInSpan tp traceContext item@Item {itemExample = ex, itemRequirement = req} =
+  item
+    { itemExample = \params aroundAction pcb -> do
+        let aroundAction' a = do
+              -- we need to reattach the context, since we are on a forked thread
+              void $ attachContext traceContext
+              inSpan tp (T.pack req) defaultSpanArguments (aroundAction a)
+
+        ex params aroundAction' pcb
+    }

--- a/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
+++ b/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
@@ -1,3 +1,4 @@
+-- | Instrumentation for Hspec test suites
 {-# LANGUAGE OverloadedStrings #-}
 
 module OpenTelemetry.Instrumentation.Hspec
@@ -16,17 +17,26 @@ import OpenTelemetry.Context.ThreadLocal (adjustContext, attachContext, getConte
 import OpenTelemetry.Trace.Core
 import Test.Hspec.Core.Spec (ActionWith, Item (..), Spec, SpecWith, mapSpecItem_)
 
+-- | Creates a wrapper function that you can pass a spec into.
+--
+--   This function will wrap each @it@ test case with a span with the name of
+--   the test case.
+--
+--   The context in which this is called determines the parent span of all of
+--   the spec items.
 wrapSpec :: MonadIO m => m (SpecWith a -> SpecWith a)
 wrapSpec = do
   tp <- getGlobalTracerProvider
   let tracer = makeTracer tp "hs-opentelemetry-instrumentation-hspec" tracerOptions
   context <- getContext
 
-  -- FIXME: this kind of just dumps everything flat into one span. We could
-  -- possibly do better, e.g. finding the `describe`s and making them into spans
-  -- but I am not sure how that interacts with the evaluator
+  -- FIXME: this kind of just dumps everything flat into one span per `it`. We
+  -- could possibly do better, e.g. finding the `describe`s and making them into
+  -- spans but I am not sure how that would be achieved.
   pure $ \spec -> mapSpecItem_ (wrapExampleInSpan tracer context) spec
 
+-- | Wraps one example in a span parented by the specified context, and ensures
+--   the thread running the spec item will have a context available.
 wrapExampleInSpan :: Tracer -> Context -> Item a -> Item a
 wrapExampleInSpan tp traceContext item@Item {itemExample = ex, itemRequirement = req} =
   item

--- a/instrumentation/hspec/test/Spec.hs
+++ b/instrumentation/hspec/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"


### PR DESCRIPTION
It would be useful to have instrumentation of test suites. My
original use case for this is to validate a change in Persistent
instrumentation, for which hitting it really hard with the Mercury test
suite seems like a reasonable strategy.