### PR TITLE
Fix compilation error for cabal users

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,9 +4,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
-        with:
-          enable-stack: true
       - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixos-22.05
@@ -25,9 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
-        with:
-          enable-stack: true
       - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixos-22.05
@@ -46,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
       - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixos-22.05

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,6 @@
 on: [push]
 jobs:
-  ghc-9_0:
+  stack-ghc-9_0:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
       - run: stack build --only-dependencies
       - run: stack build
       - run: stack test
-  ghc-9_2:
+  stack-ghc-9_2:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,4 +42,18 @@ jobs:
       - run: stack --stack-yaml stack-ghc-9.2.yaml build --only-dependencies
       - run: stack --stack-yaml stack-ghc-9.2.yaml build
       - run: stack --stack-yaml stack-ghc-9.2.yaml test
-
+  cabal-ghc-8_10:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2
+      - uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cabal
+          key: cabal-${{ runner.os }}-8.10
+      - run: cabal build --only-dependencies all
+      - run: cabal build all
+      - run: cabal test all

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+CABALS := \
+  api/hs-opentelemetry-api.cabal\
+  examples/hspec/hspec-example.cabal\
+  examples/yesod-minimal/yesod-minimal.cabal\
+  exporters/handle/hs-opentelemetry-exporter-handle.cabal\
+  exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal\
+  exporters/jaeger/hs-opentelemetry-exporter-jaeger.cabal\
+  exporters/otlp/hs-opentelemetry-exporter-otlp.cabal\
+  exporters/prometheus/hs-opentelemetry-exporter-prometheus.cabal\
+  exporters/zipkin/hs-opentelemetry-exporter-zipkin.cabal\
+  instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal\
+  instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal\
+  instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal\
+  instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal\
+  instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal\
+  instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal\
+  instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal\
+  instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal\
+  otlp/hs-opentelemetry-otlp.cabal\
+  propagators/b3/hs-opentelemetry-propagator-b3.cabal\
+  propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal\
+  propagators/w3c/hs-opentelemetry-propagator-w3c.cabal\
+  sdk/hs-opentelemetry-sdk.cabal\
+  utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
+
+.PHONY: hpack
+hpack: $(CABALS)
+
+api/hs-opentelemetry-api.cabal: api/package.yaml FORCE
+	(cd api; hpack)
+
+examples/hspec/hspec-example.cabal: examples/hspec/package.yaml FORCE
+	(cd examples/hspec; hpack)
+
+examples/yesod-minimal/yesod-minimal.cabal: examples/yesod-minimal/package.yaml FORCE
+	(cd examples/yesod-minimal; hpack)
+
+exporters/handle/hs-opentelemetry-exporter-handle.cabal: exporters/handle/package.yaml FORCE
+	(cd exporters/handle; hpack)
+
+exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal: exporters/in-memory/package.yaml FORCE
+	(cd exporters/in-memory; hpack)
+
+exporters/jaeger/hs-opentelemetry-exporter-jaeger.cabal: exporters/jaeger/package.yaml FORCE
+	(cd exporters/jaeger; hpack)
+
+exporters/otlp/hs-opentelemetry-exporter-otlp.cabal: exporters/otlp/package.yaml FORCE
+	(cd exporters/otlp; hpack)
+
+exporters/prometheus/hs-opentelemetry-exporter-prometheus.cabal: exporters/prometheus/package.yaml FORCE
+	(cd exporters/prometheus; hpack)
+
+exporters/zipkin/hs-opentelemetry-exporter-zipkin.cabal: exporters/zipkin/package.yaml FORCE
+	(cd exporters/zipkin; hpack)
+
+instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal: instrumentation/cloudflare/package.yaml FORCE
+	(cd instrumentation/cloudflare; hpack)
+
+instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal: instrumentation/conduit/package.yaml FORCE
+	(cd instrumentation/conduit; hpack)
+
+instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal: instrumentation/hspec/package.yaml FORCE
+	(cd instrumentation/hspec; hpack)
+
+instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal: instrumentation/http-client/package.yaml FORCE
+	(cd instrumentation/http-client; hpack)
+
+instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal: instrumentation/persistent/package.yaml FORCE
+	(cd instrumentation/persistent; hpack)
+
+instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal: instrumentation/postgresql-simple/package.yaml FORCE
+	(cd instrumentation/postgresql-simple; hpack)
+
+instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal: instrumentation/wai/package.yaml FORCE
+	(cd instrumentation/wai; hpack)
+
+instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal: instrumentation/yesod/package.yaml FORCE
+	(cd instrumentation/yesod; hpack)
+
+otlp/hs-opentelemetry-otlp.cabal: otlp/package.yaml FORCE
+	(cd otlp; hpack)
+
+propagators/b3/hs-opentelemetry-propagator-b3.cabal: propagators/b3/package.yaml FORCE
+	(cd propagators/b3; hpack)
+
+propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal: propagators/jaeger/package.yaml FORCE
+	(cd propagators/jaeger; hpack)
+
+propagators/w3c/hs-opentelemetry-propagator-w3c.cabal: propagators/w3c/package.yaml FORCE
+	(cd propagators/w3c; hpack)
+
+sdk/hs-opentelemetry-sdk.cabal: sdk/package.yaml FORCE
+	(cd sdk; hpack)
+
+utils/exceptions/hs-opentelemetry-utils-exceptions.cabal: utils/exceptions/package.yaml FORCE
+	(cd utils/exceptions; hpack)
+
+# Hack https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
+FORCE:

--- a/cabal.project
+++ b/cabal.project
@@ -17,12 +17,6 @@ packages:
   -- , examples/yesod-minimal
   , utils/exceptions
 
-source-repository-package
-    type: git
-    location: https://github.com/ysangkok/proto-lens
-    tag: d135bf048cc3eeaf307b7d2e62c70d8ce919dac4
-    subdir: proto-lens proto-lens-runtime
-
 -- https://github.com/vincenthz/hs-memory/pull/93
 source-repository-package
     type: git

--- a/exporters/jaeger/hs-opentelemetry-exporter-jaeger.cabal
+++ b/exporters/jaeger/hs-opentelemetry-exporter-jaeger.cabal
@@ -1,12 +1,12 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-jaeger
-version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry-exporter-jaeger#readme>
+version:        0.0.1.0
+description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/jaeger#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
 author:         Ian Duncan

--- a/exporters/prometheus/hs-opentelemetry-exporter-prometheus.cabal
+++ b/exporters/prometheus/hs-opentelemetry-exporter-prometheus.cabal
@@ -1,12 +1,12 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-prometheus
-version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry-exporter-prometheus#readme>
+version:        0.0.1.0
+description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/prometheus#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
 author:         Ian Duncan
@@ -25,14 +25,14 @@ source-repository head
 
 library
   exposed-modules:
-      OpenTelemetry.Exporters.Prometheus
+      OpenTelemetry.Exporter.Prometheus
   other-modules:
       Paths_hs_opentelemetry_exporter_prometheus
   hs-source-dirs:
       src
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api
+    , hs-opentelemetry-api ==0.0.1.*
   default-language: Haskell2010
 
 test-suite hs-opentelemetry-exporter-prometheus-test
@@ -45,6 +45,6 @@ test-suite hs-opentelemetry-exporter-prometheus-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api
+    , hs-opentelemetry-api ==0.0.1.*
     , hs-opentelemetry-exporter-prometheus
   default-language: Haskell2010

--- a/hie.yaml
+++ b/hie.yaml
@@ -45,6 +45,12 @@ cradle:
     - path: "instrumentation/conduit/test"
       component: "hs-opentelemetry-instrumentation-conduit:test:hs-opentelemetry-instrumentation-conduit-test"
 
+    - path: "instrumentation/hspec/src"
+      component: "hs-opentelemetry-instrumentation-hspec:lib"
+
+    - path: "instrumentation/hspec/test"
+      component: "hs-opentelemetry-instrumentation-hspec:test:hs-opentelemetry-hspec-test"
+
     - path: "instrumentation/http-client/src"
       component: "hs-opentelemetry-instrumentation-http-client:lib"
 

--- a/propagators/b3/hs-opentelemetry-propagator-b3.cabal
+++ b/propagators/b3/hs-opentelemetry-propagator-b3.cabal
@@ -1,12 +1,12 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-propagator-b3
-version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry-propagator-b3#readme>
+version:        0.0.1.0
+description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/propagators/b3#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
 author:         Ian Duncan

--- a/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
+++ b/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
@@ -1,12 +1,12 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-propagator-jaeger
-version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry-propagator-jaeger#readme>
+version:        0.0.1.0
+description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/propagators/jaeger#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
 author:         Ian Duncan

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ in
       ghc
       cabal-install
       stack
+      hpack
 
       haskell.packages.${compiler}.implicit-hie
       haskell.packages.${compiler}.haskell-language-server

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ in
       niv
 
       ghc
+      cabal-install
       stack
 
       haskell.packages.${compiler}.implicit-hie

--- a/shell.nix
+++ b/shell.nix
@@ -14,5 +14,8 @@ in
       haskell.packages.${compiler}.implicit-hie
       haskell.packages.${compiler}.haskell-language-server
       haskell.packages.${compiler}.hspec-discover
+
+      postgresql
+      zlib
     ];
   }


### PR DESCRIPTION
No code changes too

- proto-lens 0.7.1.2 already supports GHC 9.4
    - https://github.com/google/proto-lens/pull/440
- adds C libraries to _shell.nix_
- adds a CI job using Cabal
- updates the hie.yaml
- updates cabal files
    - runs hpack