### PR TITLE
add instances for monad-tracer

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -83,6 +83,7 @@ library
     , template-haskell
     , text
     , thread-utils-context ==0.2.*
+    , transformers
     , unliftio-core
     , unordered-containers
     , vault
@@ -122,6 +123,7 @@ test-suite hs-opentelemetry-api-test
     , template-haskell
     , text
     , thread-utils-context ==0.2.*
+    , transformers
     , unliftio-core
     , unordered-containers
     , vault

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - clock
 - memory
 - mtl
+- transformers
 - http-types
 - attoparsec
 - template-haskell

--- a/api/src/OpenTelemetry/Trace/Monad.hs
+++ b/api/src/OpenTelemetry/Trace/Monad.hs
@@ -37,6 +37,9 @@ module OpenTelemetry.Trace.Monad (
 ) where
 
 import Control.Monad.IO.Unlift
+import Control.Monad.Identity (IdentityT)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Trans (MonadTrans (lift))
 import Data.Text (Text)
 import GHC.Stack
 import OpenTelemetry.Trace.Core (
@@ -80,3 +83,11 @@ inSpan'' ::
 inSpan'' cs n args f = do
   t <- getTracer
   OpenTelemetry.Trace.Core.inSpan'' t cs n args f
+
+
+instance MonadTracer m => MonadTracer (IdentityT m) where
+  getTracer = lift getTracer
+
+
+instance MonadTracer m => MonadTracer (ReaderT r m) where
+  getTracer = lift getTracer

--- a/api/src/OpenTelemetry/Trace/Monad.hs
+++ b/api/src/OpenTelemetry/Trace/Monad.hs
@@ -89,5 +89,5 @@ instance MonadTracer m => MonadTracer (IdentityT m) where
   getTracer = lift getTracer
 
 
-instance MonadTracer m => MonadTracer (ReaderT r m) where
+instance {-# OVERLAPPABLE #-} MonadTracer m => MonadTracer (ReaderT r m) where
   getTracer = lift getTracer

--- a/shell.nix
+++ b/shell.nix
@@ -20,5 +20,6 @@ in
 
       postgresql
       zlib
+      libffi
     ];
   }

--- a/stack-ghc-8.12.yaml
+++ b/stack-ghc-8.12.yaml
@@ -97,4 +97,4 @@ extra-deps:
 
 nix:
   enable: true
-  packages: [postgresql, zlib]
+  packages: [postgresql, zlib, libffi]

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -96,4 +96,4 @@ extra-deps:
 
 nix:
   enable: true
-  packages: [postgresql, zlib]
+  packages: [postgresql, zlib, libffi]

--- a/stack.yaml
+++ b/stack.yaml
@@ -98,4 +98,4 @@ extra-deps:
 
 nix:
   enable: true
-  packages: [postgresql, zlib]
+  packages: [postgresql, zlib, libffi]


### PR DESCRIPTION
To add instances for monad-tracer because of utility.