### PR TITLE
sdk: Crash if -threaded is unset

### DIFF
--- a/sdk/src/OpenTelemetry/Processor/Batch.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch.hs
@@ -226,6 +226,9 @@ data ProcessorMessage = Flush | Shutdown
 {- |
  The batch processor accepts spans and places them into batches. Batching helps better compress the data and reduce the number of outgoing connections
  required to transmit the data. This processor supports both size and time based batching.
+
+ NOTE: this function requires the program be compiled with the @-threaded@ GHC
+ option and will throw an error if this is not the case.
 -}
 batchProcessor :: MonadIO m => BatchTimeoutConfig -> Exporter ImmutableSpan -> m Processor
 batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do

--- a/sdk/src/OpenTelemetry/Processor/Batch.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch.hs
@@ -22,6 +22,7 @@ module OpenTelemetry.Processor.Batch (
   -- , BatchProcessorOperations
 ) where
 
+import Control.Concurrent (rtsSupportsBoundThreads)
 import Control.Concurrent.Async
 import Control.Concurrent.STM
 import Control.Exception
@@ -228,6 +229,7 @@ data ProcessorMessage = Flush | Shutdown
 -}
 batchProcessor :: MonadIO m => BatchTimeoutConfig -> Exporter ImmutableSpan -> m Processor
 batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
+  unless rtsSupportsBoundThreads $ error "The hs-opentelemetry batch processor does not work without the -threaded GHC flag!"
   batch <- newIORef $ boundedMap maxQueueSize
   workSignal <- newEmptyTMVarIO
   shutdownSignal <- newEmptyTMVarIO


### PR DESCRIPTION
registerDelay will throw an exception, which we will silently swallow, if we
don't preemptively just blow up the program. It's never correct to start up
without a threaded runtime.
