### PR TITLE
Update instrumentation-hspec for mtl-2.3/GHC-9.6

### DIFF
--- a/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
+++ b/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
@@ -6,6 +6,7 @@ module OpenTelemetry.Instrumentation.Hspec (
   wrapExampleInSpan,
 ) where
 
+import Control.Monad (void)
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Data.Text (Text)


### PR DESCRIPTION
mtl-2.3 removed `Control.Monad` reexports