### PR TITLE
Add instrumentSpec function

### DIFF
--- a/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
+++ b/instrumentation/hspec/src/OpenTelemetry/Instrumentation/Hspec.hs
@@ -4,6 +4,7 @@
 module OpenTelemetry.Instrumentation.Hspec (
   wrapSpec,
   wrapExampleInSpan,
+  instrumentSpec,
 ) where
 
 import Control.Monad (void)
@@ -15,7 +16,8 @@ import OpenTelemetry.Attributes (Attributes)
 import OpenTelemetry.Context
 import OpenTelemetry.Context.ThreadLocal (adjustContext, attachContext, getContext)
 import OpenTelemetry.Trace.Core
-import Test.Hspec.Core.Spec (ActionWith, Item (..), Spec, SpecWith, mapSpecItem_)
+import Test.Hspec.Core.Spec (ActionWith, Item (..), Tree(..), Spec, SpecWith, mapSpecItem_, mapSpecForest)
+import qualified Data.List as List
 
 
 {- | Creates a wrapper function that you can pass a spec into.
@@ -52,3 +54,28 @@ wrapExampleInSpan tp traceContext item@Item {itemExample = ex, itemRequirement =
 
         ex params aroundAction' pcb
     }
+
+-- | Instrument each test case. Each 'describe' and friends will add
+-- a span, and the final test will be in a span described by 'it'.
+instrumentSpec :: Tracer -> Context -> SpecWith a -> SpecWith a
+instrumentSpec tracer traceContext spec = do
+  mapSpecForest (map (go [])) spec
+    where
+      go spans t = case t of
+        Node str rest ->
+          Node str (map (go (str : spans)) rest)
+        NodeWithCleanup mloc c rest ->
+          NodeWithCleanup mloc c (map (go spans) rest)
+        Leaf item ->
+          Leaf item
+            { itemExample = \params aroundAction pcb -> do
+                let aroundAction' a = do
+                      -- we need to reattach the context, since we are on a forked thread
+                      void $ attachContext traceContext
+                      addSpans spans $ inSpan tracer (T.pack (itemRequirement item)) defaultSpanArguments (aroundAction a)
+
+                itemExample item params aroundAction' pcb
+            }
+
+      addSpans spans k =
+        List.foldl' (\acc x -> inSpan tracer (T.pack x) defaultSpanArguments acc) k spans


### PR DESCRIPTION
This PR adds `instrumentSpec`, which (thanks to @solomon-b in #78 ) is a potential replacement for `wrapSpec` that also includes the various `describe` messages.