### PR TITLE
Decode percent-encoded baggage headers

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -96,6 +96,7 @@ test-suite hs-opentelemetry-api-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      OpenTelemetry.BaggageSpec
       OpenTelemetry.Trace.SamplerSpec
       OpenTelemetry.Trace.TraceFlagsSpec
       Paths_hs_opentelemetry_api

--- a/api/src/OpenTelemetry/Baggage.hs
+++ b/api/src/OpenTelemetry/Baggage.hs
@@ -249,7 +249,7 @@ decodeBaggageHeaderP = do
           ]
     tokenP :: P.Parser Token
     tokenP = Token <$> P.takeWhile1 (`C.member` tokenCharacters)
-    valP = decodeUtf8 <$> P.takeWhile (`C.member` valueSet)
+    valP = decodeUtf8 . urlDecode False <$> P.takeWhile (`C.member` valueSet)
     propertyP :: P.Parser Property
     propertyP = do
       key <- tokenP

--- a/api/test/OpenTelemetry/BaggageSpec.hs
+++ b/api/test/OpenTelemetry/BaggageSpec.hs
@@ -9,7 +9,7 @@ spec :: Spec
 spec = describe "Baggage" $ do
   it "decodes simple header" $ do
     let baggage = values <$> decodeBaggageHeader "x-api-key=asdf"
-    HashMap.mapKeys tokenValue <$> baggage `shouldBe` Right (HashMap.fromList [("x-api-key",Element {value = "asdf", properties = []})])
+    HashMap.mapKeys tokenValue <$> baggage `shouldBe` Right (HashMap.fromList [("x-api-key", Element {value = "asdf", properties = []})])
   it "decodes percent encoded header" $ do
     let baggage = values <$> decodeBaggageHeader "Authorization=Basic%20asdf"
-    HashMap.mapKeys tokenValue <$> baggage `shouldBe` Right (HashMap.fromList [("Authorization",Element {value = "Basic asdf", properties = []})])
+    HashMap.mapKeys tokenValue <$> baggage `shouldBe` Right (HashMap.fromList [("Authorization", Element {value = "Basic asdf", properties = []})])

--- a/api/test/OpenTelemetry/BaggageSpec.hs
+++ b/api/test/OpenTelemetry/BaggageSpec.hs
@@ -1,0 +1,15 @@
+module OpenTelemetry.BaggageSpec where
+
+import qualified Data.HashMap.Strict as HashMap
+import OpenTelemetry.Baggage
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "Baggage" $ do
+  it "decodes simple header" $ do
+    let baggage = values <$> decodeBaggageHeader "x-api-key=asdf"
+    HashMap.mapKeys tokenValue <$> baggage `shouldBe` Right (HashMap.fromList [("x-api-key",Element {value = "asdf", properties = []})])
+  it "decodes percent encoded header" $ do
+    let baggage = values <$> decodeBaggageHeader "Authorization=Basic%20asdf"
+    HashMap.mapKeys tokenValue <$> baggage `shouldBe` Right (HashMap.fromList [("Authorization",Element {value = "Basic asdf", properties = []})])

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -9,11 +9,11 @@ import Data.IORef
 import Data.Maybe (isJust)
 import qualified Data.Vector as V
 import OpenTelemetry.Attributes (lookupAttribute)
-import OpenTelemetry.Context
-import OpenTelemetry.Trace.Core
 -- Specs
 
 import qualified OpenTelemetry.BaggageSpec as Baggage
+import OpenTelemetry.Context
+import OpenTelemetry.Trace.Core
 import qualified OpenTelemetry.Trace.SamplerSpec as Sampler
 import qualified OpenTelemetry.Trace.TraceFlagsSpec as TraceFlags
 import OpenTelemetry.Util

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -13,6 +13,7 @@ import OpenTelemetry.Context
 import OpenTelemetry.Trace.Core
 -- Specs
 
+import qualified OpenTelemetry.BaggageSpec as Baggage
 import qualified OpenTelemetry.Trace.SamplerSpec as Sampler
 import qualified OpenTelemetry.Trace.TraceFlagsSpec as TraceFlags
 import OpenTelemetry.Util
@@ -50,5 +51,6 @@ main = hspec $ do
   -- describe "inSpan" $ do
   --   it "records exceptions" $ do
   --     exceptionTest
+  Baggage.spec
   Sampler.spec
   TraceFlags.spec


### PR DESCRIPTION
Headers are percent-encoded to allow spaces etc. as per https://w3c.github.io/baggage/#examples-of-http-headers but not decoded as such