### PR TITLE
newOpenTelemetryWaiMiddleware' is now not an IO action

### DIFF
--- a/instrumentation/wai/ChangeLog.md
+++ b/instrumentation/wai/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for hs-opentelemetry-instrumentation-wai
 
+## Unreleased changes
+
+- Change a type of `newOpenTelemetryWaiMiddleware'` from `TracerProvider -> IO Middleware` to `TracerProvider -> Middleware` #86
+
 ## 0.0.1.1
 
 - Bump version bounds for hs-opentelemetry-api to == 0.0.2.0
@@ -7,5 +11,3 @@
 ## 0.0.1.0
 
 - Initial release
-
-## Unreleased changes

--- a/instrumentation/wai/src/OpenTelemetry/Instrumentation/Wai.hs
+++ b/instrumentation/wai/src/OpenTelemetry/Instrumentation/Wai.hs
@@ -25,19 +25,18 @@ import System.IO.Unsafe
 
 
 newOpenTelemetryWaiMiddleware :: IO Middleware
-newOpenTelemetryWaiMiddleware = getGlobalTracerProvider >>= newOpenTelemetryWaiMiddleware'
+newOpenTelemetryWaiMiddleware = newOpenTelemetryWaiMiddleware' <$> getGlobalTracerProvider
 
 
 newOpenTelemetryWaiMiddleware' ::
   TracerProvider ->
-  IO Middleware
-newOpenTelemetryWaiMiddleware' tp = do
-  waiTracer <-
-    getTracer
+  Middleware
+newOpenTelemetryWaiMiddleware' tp =
+  middleware $
+    makeTracer
       tp
       "opentelemetry-instrumentation-wai"
       (TracerOptions Nothing)
-  pure $ middleware waiTracer
   where
     middleware :: Tracer -> Middleware
     middleware tracer app req sendResp = do


### PR DESCRIPTION
- replace use of deprecated `getTracer` to `makeTracer`
- it is unnecessary that `newOpenTelemetryWaiMiddleware'` is an IO action