### PR TITLE
Export `FlushResult`

### DIFF
--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -49,6 +49,7 @@ module OpenTelemetry.Trace.Core (
   createTracerProvider,
   shutdownTracerProvider,
   forceFlushTracerProvider,
+  FlushResult (..),
   getTracerProviderResources,
   getTracerProviderPropagators,
   getGlobalTracerProvider,


### PR DESCRIPTION
The return value of `forceFlushTracerProvider` is `FlushResult`, but that type isn't exported so it can't be used, and this change fixes that.