### PR TITLE
Allow to manually provide trace id

### DIFF
--- a/api/src/OpenTelemetry/Context.hs
+++ b/api/src/OpenTelemetry/Context.hs
@@ -66,6 +66,9 @@ module OpenTelemetry.Context (
   insertBaggage,
   lookupBaggage,
   removeBaggage,
+  lookupExternalTraceId,
+  insertExternalTraceId,
+  removeExternalTraceId,
 ) where
 
 import Control.Monad.IO.Class
@@ -73,8 +76,10 @@ import Data.Text (Text)
 import qualified Data.Vault.Strict as V
 import OpenTelemetry.Baggage (Baggage)
 import OpenTelemetry.Context.Types
+import OpenTelemetry.Internal.Trace.Id (TraceId)
 import OpenTelemetry.Internal.Trace.Types
 import OpenTelemetry.Internal.UnpackedMaybe
+import System.IO.Unsafe
 import Unsafe.Coerce (unsafeCoerce)
 import Prelude hiding (lookup)
 
@@ -162,3 +167,20 @@ insertBaggage bag (Context s _ v) = Context s (UJust bag) v
 removeBaggage :: Context -> Context
 removeBaggage (Context s _ v) = Context s UNothing v
 {-# INLINE removeBaggage #-}
+
+
+externalTraceIdKey :: Key TraceId
+externalTraceIdKey = unsafePerformIO $ newKey "traceId"
+{-# NOINLINE externalTraceIdKey #-}
+
+
+lookupExternalTraceId :: Context -> Maybe TraceId
+lookupExternalTraceId = lookup externalTraceIdKey
+
+
+insertExternalTraceId :: TraceId -> Context -> Context
+insertExternalTraceId = insert externalTraceIdKey
+
+
+removeExternalTraceId :: Context -> Context
+removeExternalTraceId = delete externalTraceIdKey

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -410,7 +410,11 @@ createSpanHelper t ctxt n args@SpanArguments {..} extraAttrs !tidInt = do
           -- fresh regardless of sampling outcome, which this satisfies.
           -- Child spans: inherit TraceId, generate only SpanId (1 call).
           (!tId, !preSpanId) <- case parentSc of
-            Nothing -> newTraceAndSpanId idGen
+            Nothing -> case lookupExternalTraceId ctxt of
+              Just etid -> do
+                !sid <- newSpanId idGen
+                pure (etid, sid)
+              Nothing -> newTraceAndSpanId idGen
             Just sc -> do
               !sid <- newSpanId idGen
               pure (traceId sc, sid)


### PR DESCRIPTION
Allow user to bypass trace id generator and provide it externally. The use case I have for this is [the AWS XRay extractor](https://github.com/kfigiela/hs-opentelemetry-awsxray/blob/8b73924181bf2cbf8f2befb950ea879a4a233fe1/library/OpenTelemetry/AWSXRay/Propagator.hs#L38) running in `ALB` mode. As described below, we can't insert a parent span in our use case, as our upstream only provides a trace id, but does really implement tracing. To provide loose-coupling an external trace id can be provided via Context.

### Use case

We're using this library to push traces to AWS X-Ray with the help of the [forked](https://github.com/kfigiela/hs-opentelemetry-awsxray/tree/external-trace-id) library to accomodate trace id format that AWS uses. We are using AWS Load Balancer as the entry-point. AWS LB provides `X-Amzn-Trace-Id` that can be used for [request tracing](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html) and has the format that XRay expects. It's very convenient to have a single correlation id that can be used across the whole system (load balancer access logs, X-Ray, application logs, etc). Having separate lookalike ids causes only confusion.

In a typical scenario, extractor would get trace id and parent span id. However, LB is not fully integrated with X-Ray – it does not communicate a trace to X-Ray. The header is also not in the expected format – only trace id is present with no span id (e.g. `X-Amzn-Trace-Id: Root=1-63441c4a-abcdef012345678912345678`). I have tried to deterministically generate span id based on trace id for the root span, this however caused only issues – since the root span has been never reported, X-Ray did not display traces correctly wrt. to timing or response statuses. That's why an external trace id is needed.


