### PR TITLE
Fix git conflict in hs-opentelemetry-utils-exceptions.cabal

### DIFF
--- a/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
+++ b/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
@@ -1,6 +1,5 @@
 cabal-version: 1.12
 
-<<<<<<< HEAD
 -- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
@@ -16,23 +15,7 @@ copyright:          2023 Ian Duncan, Mercury Technologies
 license:            BSD3
 license-file:       LICENSE
 build-type:         Simple
-=======
--- This file has been generated from package.yaml by hpack version 0.35.0.
---
--- see: https://github.com/sol/hpack
 
-name:           hs-opentelemetry-utils-exceptions
-version:        0.2.0.0
-description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/utils/exceptions#readme>
-homepage:       https://github.com/iand675/hs-opentelemetry#readme
-bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
-author:         Ian Duncan, Jade Lovelace
-maintainer:     ian@iankduncan.com
-copyright:      2022 Ian Duncan
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
->>>>>>> origin/main
 extra-source-files:
     README.md
     ChangeLog.md


### PR DESCRIPTION
There is a committed git conflict in utils/exceptions/hs-opentelemetry-utils-exceptions.cabal, which prevents the example project from running.

This commit fixes it.