### PR TITLE
Loosen the bounds `sdk` has on `exporter-otlp`, so v0.0.2 (containing bugfixes of the last two years) can actually be used

### DIFF
--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-exporter-otlp
-version:            0.0.1.5
+version:            0.0.2.0
 synopsis:           OpenTelemetry exporter supporting the standard OTLP protocol
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/otlp#readme>
 category:           OpenTelemetry, Telemetry, Monitoring, Observability, Metrics

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -1,5 +1,5 @@
 name:                hs-opentelemetry-exporter-otlp
-version:             0.0.1.5
+version:             0.0.2.0
 github:              "iand675/hs-opentelemetry"
 license:             BSD3
 author:              "Ian Duncan"

--- a/otlp/hs-opentelemetry-otlp.cabal
+++ b/otlp/hs-opentelemetry-otlp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-otlp
-version:            0.0.1.0
+version:            0.0.1.2
 synopsis:           OpenTelemetry protocol buffer modules generated for the OTLP protocol by the proto-lens package
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry#readme>
 category:           OpenTelemetry

--- a/otlp/package.yaml
+++ b/otlp/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../package-common.yaml"
 
 name:                hs-opentelemetry-otlp
-version:             0.0.1.0
+version:             0.0.1.2
 
 <<: *preface
 

--- a/sdk/ChangeLog.md
+++ b/sdk/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for hs-opentelemetry-sdk
 
+## 0.0.3.7
+
+- Widen version bounds of internal package  `hs-opentelemetry-exporter-otlp`
+
 ## 0.0.3.6
 
 - Raise minimum version bounds for `random` to 1.2.0. This fixes duplicate ID generation issues in highly concurrent systems.

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.22
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-sdk
-version:        0.0.3.6
+version:        0.0.3.7
 synopsis:       OpenTelemetry SDK for use in applications.
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/sdk#readme>
 category:       OpenTelemetry, Telemetry, Monitoring, Observability, Metrics

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -4,19 +4,19 @@ cabal-version: 1.22
 --
 -- see: https://github.com/sol/hpack
 
-name:               hs-opentelemetry-sdk
-version:            0.0.3.6
-synopsis:           OpenTelemetry SDK for use in applications.
-description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/sdk#readme>
-category:           OpenTelemetry, Telemetry, Monitoring, Observability, Metrics
-homepage:           https://github.com/iand675/hs-opentelemetry#readme
-bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
-author:             Ian Duncan, Jade Lovelace
-maintainer:         ian@iankduncan.com
-copyright:          2023 Ian Duncan, Mercury Technologies
-license:            BSD3
-license-file:       LICENSE
-build-type:         Simple
+name:           hs-opentelemetry-sdk
+version:        0.0.3.6
+synopsis:       OpenTelemetry SDK for use in applications.
+description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/sdk#readme>
+category:       OpenTelemetry, Telemetry, Monitoring, Observability, Metrics
+homepage:       https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
+author:         Ian Duncan, Jade Lovelace
+maintainer:     ian@iankduncan.com
+copyright:      2023 Ian Duncan, Mercury Technologies
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
 extra-source-files:
     README.md
     ChangeLog.md
@@ -74,7 +74,7 @@ library
     , base >=4.7 && <5
     , bytestring
     , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-exporter-otlp ==0.0.1.*
+    , hs-opentelemetry-exporter-otlp >=0.0.1 && <0.0.3
     , hs-opentelemetry-propagator-b3 ==0.0.1.*
     , hs-opentelemetry-propagator-w3c ==0.0.1.*
     , http-types
@@ -108,7 +108,7 @@ test-suite hs-opentelemetry-sdk-test
     , bytestring
     , clock
     , hs-opentelemetry-api
-    , hs-opentelemetry-exporter-otlp ==0.0.1.*
+    , hs-opentelemetry-exporter-otlp >=0.0.1 && <0.0.3
     , hs-opentelemetry-propagator-b3 ==0.0.1.*
     , hs-opentelemetry-propagator-w3c ==0.0.1.*
     , hs-opentelemetry-sdk

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -26,7 +26,7 @@ dependencies:
 # These are "distribution" packages
 - hs-opentelemetry-api >= 0.0.3 && < 0.2
 - hs-opentelemetry-propagator-w3c == 0.0.1.*
-- hs-opentelemetry-exporter-otlp == 0.0.1.*
+- hs-opentelemetry-exporter-otlp >= 0.0.1 && < 0.0.3
 - hs-opentelemetry-propagator-b3 ==0.0.1.*
 
 - async

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../package-common.yaml"
 
 name:                hs-opentelemetry-sdk
-version:             0.0.3.6
+version:             0.0.3.7
 
 <<: *preface
 


### PR DESCRIPTION
When using the libraries by depending on in `hs-opentelemetry-sdk`, you'll end up with a very outdated version of `hs-opentelemetry-exporter-otlp`, as the current bound was still `==0.0.1.*`. However version `0.0.2.0` contains many important bugfixes like for instance #42 and #89.

This PR loosens this bound. 