### PR TITLE
Enable it build on Windows by `unix` → `unix-compat` transition

### DIFF
--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -85,6 +85,7 @@ library
     , transformers
     , unagi-chan
     , unix
+    , unix-compat >=0.7.1
     , unordered-containers
     , vector
     , vector-builder
@@ -121,6 +122,7 @@ test-suite hs-opentelemetry-sdk-test
     , transformers
     , unagi-chan
     , unix
+    , unix-compat >=0.7.1
     , unordered-containers
     , vector
     , vector-builder

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -37,7 +37,7 @@ dependencies:
 - vector-builder
 - http-types
 - network-bsd
-- unix
+- unix-compat >= 0.7.1 # for getProcessID
 - transformers
 - random >= 1.2.0
 

--- a/sdk/src/OpenTelemetry/Resource/Process/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/Process/Detector.hs
@@ -1,6 +1,5 @@
 module OpenTelemetry.Resource.Process.Detector where
 
-import Control.Exception (throwIO, try)
 import qualified Data.Text as T
 import Data.Version
 import OpenTelemetry.Resource.Process
@@ -9,10 +8,8 @@ import System.Environment (
   getExecutablePath,
   getProgName,
  )
-import System.IO.Error
 import System.Info
-import System.Posix.Process (getProcessID)
-import System.Posix.User (getEffectiveUserName)
+import System.PosixCompat.Process (getProcessID)
 
 
 {- | Create a 'Process' 'Resource' based off of the current process' knowledge
@@ -29,19 +26,7 @@ detectProcess = do
     <*> pure Nothing
     <*> pure Nothing
     <*> (Just . map T.pack <$> getArgs)
-    <*> tryGetUser
-
-
-tryGetUser :: IO (Maybe T.Text)
-tryGetUser = do
-  eResult <- try getEffectiveUserName
-  case eResult of
-    Left err ->
-      if isDoesNotExistError err
-        then pure Nothing
-        else throwIO err
-    Right ok -> pure $ Just $ T.pack ok
-
+    <*> pure Nothing -- TODO: fix current user name detection on Windows
 
 {- | A 'ProcessRuntime' 'Resource' populated with the current process' knoweldge
  of itself.

--- a/stack.yaml
+++ b/stack.yaml
@@ -65,6 +65,7 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
+- unix-compat-0.7.1@sha256:bd5bb4e04b2ed707f3e3466470a452354310389506cf0a7a73bf10e4d533f6d1,3619
 - thread-utils-context-0.3.0.4
 - thread-utils-finalizers-0.1.1.0
 - proto-lens-0.7.1.1


### PR DESCRIPTION
Use `unix-compat` in place of `unix`, enabling the project to build for Windows too.

Unfortunately, had to leave `process.owner` field empty because a non-POSIX `getEffectiveUserID` implementation is absent in `unix-compat` (for reasons described in https://github.com/haskell-pkg-janitors/unix-compat/issues/2#issuecomment-1487446182). Please let me know if the conditional compilation approach is welcome here, I'll update the code appropriately.

A possible fix for #109.