### PR TITLE
Set exception details when using WAI and Yesod instrumentation together

### DIFF
--- a/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
+++ b/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -261,8 +261,10 @@ openTelemetryYesodMiddleware rr m = do
           recordException waiSpan mempty Nothing ex
           setStatus waiSpan $ Error $ T.pack $ displayException ex
 
+
 shouldMarkException :: SomeException -> Bool
 shouldMarkException = maybe True isInternalError . fromException
+
 
 -- We want to mark the span as an error if it's an InternalError, the other
 -- HCError values are 4xx status codes which don't really count as a server

--- a/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
+++ b/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
@@ -256,6 +256,10 @@ openTelemetryYesodMiddleware rr m = do
         Right normal -> pure normal
     Just waiSpan -> do
       addAttributes waiSpan sharedAttributes
+
+      -- Explicitly record any exceptions here. When Yesod is in use, exceptions
+      -- are handled as error-pages before reaching the WAI middleware's inSpan,
+      -- meaning the exception details would not be otherwise attached.
       withException m $ \ex -> do
         when (shouldMarkException ex) $ do
           recordException waiSpan mempty Nothing ex


### PR DESCRIPTION
### [Address warnings and HLint](https://github.com/iand675/hs-opentelemetry/pull/121/commits/23743a3297e67078e12684ca7115011f6cc4296d)
[23743a3](https://github.com/iand675/hs-opentelemetry/pull/121/commits/23743a3297e67078e12684ca7115011f6cc4296d)

### [Extract isInternalError](https://github.com/iand675/hs-opentelemetry/pull/121/commits/0d9cc2e336c39a4bd633848dcdb8aaef652cf0ce)
[0d9cc2e](https://github.com/iand675/hs-opentelemetry/pull/121/commits/0d9cc2e336c39a4bd633848dcdb8aaef652cf0ce)

### [Set exception details when using WAI and Yesod instrumentation together](https://github.com/iand675/hs-opentelemetry/pull/121/commits/9610e0fea06c548f3bc159718f30ce73a6f83df3)
[9610e0f](https://github.com/iand675/hs-opentelemetry/pull/121/commits/9610e0fea06c548f3bc159718f30ce73a6f83df3)

When the WAI instrumentation is used (so there is a span on the
request), this instrumentation only sets the shared attributes. Since
exceptions never reach WAI when used with Yesod (since they're caught to
error pages), this means that error traces don't include any details. By
calling `recordException` and `setStatus` here, we can address that.

Fixes https://github.com/iand675/hs-opentelemetry/issues/102