### PR TITLE
Added instrumentationScope to Logger and LogRecord

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -35,6 +35,7 @@ library
       OpenTelemetry.Contrib.CarryOns
       OpenTelemetry.Contrib.SpanTraversals
       OpenTelemetry.Exporter
+      OpenTelemetry.Internal.Common.Types
       OpenTelemetry.Internal.Logging.Types
       OpenTelemetry.Internal.Trace.Id
       OpenTelemetry.LogAttributes

--- a/api/src/OpenTelemetry/Attributes.hs
+++ b/api/src/OpenTelemetry/Attributes.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StrictData #-}
 
 {- |
@@ -75,7 +74,10 @@ data Attributes = Attributes
   , attributesCount :: {-# UNPACK #-} !Int
   , attributesDropped :: {-# UNPACK #-} !Int
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Generic, Eq, Ord)
+
+
+instance Hashable Attributes
 
 
 emptyAttributes :: Attributes

--- a/api/src/OpenTelemetry/Attributes.hs
+++ b/api/src/OpenTelemetry/Attributes.hs
@@ -74,10 +74,7 @@ data Attributes = Attributes
   , attributesCount :: {-# UNPACK #-} !Int
   , attributesDropped :: {-# UNPACK #-} !Int
   }
-  deriving stock (Show, Generic, Eq, Ord)
-
-
-instance Hashable Attributes
+  deriving stock (Show, Eq, Ord)
 
 
 emptyAttributes :: Attributes

--- a/api/src/OpenTelemetry/Attributes.hs
+++ b/api/src/OpenTelemetry/Attributes.hs
@@ -74,7 +74,10 @@ data Attributes = Attributes
   , attributesCount :: {-# UNPACK #-} !Int
   , attributesDropped :: {-# UNPACK #-} !Int
   }
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Generic, Eq, Ord)
+
+
+instance Hashable Attributes
 
 
 emptyAttributes :: Attributes

--- a/api/src/OpenTelemetry/Internal/Common/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Common/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE InstanceSigs #-}
 
 module OpenTelemetry.Internal.Common.Types (InstrumentationLibrary (..)) where
@@ -46,7 +47,10 @@ data InstrumentationLibrary = InstrumentationLibrary
   , librarySchemaUrl :: {-# UNPACK #-} !Text
   , libraryAttributes :: Attributes
   }
-  deriving (Ord, Eq, Show)
+  deriving (Ord, Eq, Generic, Show)
+
+
+instance Hashable InstrumentationLibrary
 
 
 instance IsString InstrumentationLibrary where

--- a/api/src/OpenTelemetry/Internal/Common/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Common/Types.hs
@@ -29,6 +29,7 @@ import OpenTelemetry.Attributes (Attributes, emptyAttributes)
 
  import qualified Data.Text as T
  import Data.Version (showVersion)
+ import OpenTelemetry.Attributes (emptyAttributes)
  import Paths_your_package_name
 
  instrumentationLibrary :: InstrumentationLibrary

--- a/api/src/OpenTelemetry/Internal/Common/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Common/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module OpenTelemetry.Internal.Common.Types (InstrumentationLibrary (..)) where
 
@@ -46,11 +46,9 @@ data InstrumentationLibrary = InstrumentationLibrary
   , librarySchemaUrl :: {-# UNPACK #-} !Text
   , libraryAttributes :: Attributes
   }
-  deriving (Ord, Eq, Generic, Show)
-
-
-instance Hashable InstrumentationLibrary
+  deriving (Ord, Eq, Show)
 
 
 instance IsString InstrumentationLibrary where
+  fromString :: String -> InstrumentationLibrary
   fromString str = InstrumentationLibrary (fromString str) "" "" emptyAttributes

--- a/api/src/OpenTelemetry/Internal/Common/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Common/Types.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module OpenTelemetry.Internal.Common.Types (InstrumentationLibrary (..)) where
+
+import Data.Hashable (Hashable)
+import Data.String (IsString (fromString))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import OpenTelemetry.Attributes (Attributes, emptyAttributes)
+
+
+{- | An identifier for the library that provides the instrumentation for a given Instrumented Library.
+ Instrumented Library and Instrumentation Library may be the same library if it has built-in OpenTelemetry instrumentation.
+
+ The inspiration of the OpenTelemetry project is to make every library and application observable out of the box by having them call OpenTelemetry API directly.
+ However, many libraries will not have such integration, and as such there is a need for a separate library which would inject such calls, using mechanisms such as wrapping interfaces,
+ subscribing to library-specific callbacks, or translating existing telemetry into the OpenTelemetry model.
+
+ A library that enables OpenTelemetry observability for another library is called an Instrumentation Library.
+
+ An instrumentation library should be named to follow any naming conventions of the instrumented library (e.g. 'middleware' for a web framework).
+
+ If there is no established name, the recommendation is to prefix packages with "hs-opentelemetry-instrumentation", followed by the instrumented library name itself.
+
+ In general, you can initialize the instrumentation library like so:
+
+ @
+
+ import qualified Data.Text as T
+ import Data.Version (showVersion)
+ import Paths_your_package_name
+
+ instrumentationLibrary :: InstrumentationLibrary
+ instrumentationLibrary = InstrumentationLibrary
+   { libraryName = "your_package_name"
+   , libraryVersion = T.pack $ showVersion version
+   }
+
+ @
+-}
+data InstrumentationLibrary = InstrumentationLibrary
+  { libraryName :: {-# UNPACK #-} !Text
+  -- ^ The name of the instrumentation library
+  , libraryVersion :: {-# UNPACK #-} !Text
+  -- ^ The version of the instrumented library
+  , librarySchemaUrl :: {-# UNPACK #-} !Text
+  , libraryAttributes :: Attributes
+  }
+  deriving (Ord, Eq, Generic, Show)
+
+
+instance Hashable InstrumentationLibrary
+
+
+instance IsString InstrumentationLibrary where
+  fromString str = InstrumentationLibrary (fromString str) "" "" emptyAttributes

--- a/api/src/OpenTelemetry/Internal/Common/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Common/Types.hs
@@ -35,6 +35,8 @@ import OpenTelemetry.Attributes (Attributes, emptyAttributes)
  instrumentationLibrary = InstrumentationLibrary
    { libraryName = "your_package_name"
    , libraryVersion = T.pack $ showVersion version
+   , librarySchemaUrl = T.pack "" -- to specify a URL, refer to this documentation: https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+   , libraryAttributes = emptyAttributes
    }
 
  @

--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -14,6 +14,7 @@ import Data.Int (Int64)
 import Data.Text (Text)
 import OpenTelemetry.Common (Timestamp, TraceFlags)
 import OpenTelemetry.Context.Types
+import OpenTelemetry.Internal.Common.Types (InstrumentationLibrary)
 import OpenTelemetry.Internal.Trace.Id (SpanId, TraceId)
 import OpenTelemetry.LogAttributes (LogAttributes)
 import OpenTelemetry.Resource (MaterializedResources)
@@ -21,7 +22,8 @@ import OpenTelemetry.Resource (MaterializedResources)
 
 -- | LogRecords can be Created from Loggers
 data Logger = Logger
-  { loggerResource :: Maybe MaterializedResources
+  { loggerInstrumentationScope :: InstrumentationLibrary
+  , loggerResource :: Maybe MaterializedResources
   }
 
 
@@ -92,6 +94,7 @@ data LogRecord body = LogRecord
   -- Can contain for example information about the application that emits the record or about the infrastructure where the application runs. Data formats that represent this data model
   -- may be designed in a manner that allows the Resource field to be recorded only once per batch of log records that come from the same source. SHOULD follow OpenTelemetry semantic conventions for Resources.
   -- This field is optional.
+  , logRecordInstrumentationScope :: InstrumentationLibrary
   , logRecordAttributes :: LogAttributes
   -- ^ Additional information about the specific event occurrence. Unlike the Resource field, which is fixed for a particular source, Attributes can vary for each occurrence of the event coming from the same source.
   -- Can contain information about the request context (other than Trace Context Fields). The log attribute model MUST support any type, a superset of standard Attribute, to preserve the semantics of structured attributes

--- a/api/src/OpenTelemetry/Internal/Trace/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/Types.hs
@@ -24,6 +24,7 @@ import Network.HTTP.Types (RequestHeaders, ResponseHeaders)
 import OpenTelemetry.Attributes
 import OpenTelemetry.Common
 import OpenTelemetry.Context.Types
+import OpenTelemetry.Internal.Common.Types
 import OpenTelemetry.Internal.Logging.Types
 import OpenTelemetry.Propagator (Propagator)
 import OpenTelemetry.Resource
@@ -36,51 +37,6 @@ import OpenTelemetry.Util
 data ExportResult
   = Success
   | Failure (Maybe SomeException)
-
-
-{- | An identifier for the library that provides the instrumentation for a given Instrumented Library.
- Instrumented Library and Instrumentation Library may be the same library if it has built-in OpenTelemetry instrumentation.
-
- The inspiration of the OpenTelemetry project is to make every library and application observable out of the box by having them call OpenTelemetry API directly.
- However, many libraries will not have such integration, and as such there is a need for a separate library which would inject such calls, using mechanisms such as wrapping interfaces,
- subscribing to library-specific callbacks, or translating existing telemetry into the OpenTelemetry model.
-
- A library that enables OpenTelemetry observability for another library is called an Instrumentation Library.
-
- An instrumentation library should be named to follow any naming conventions of the instrumented library (e.g. 'middleware' for a web framework).
-
- If there is no established name, the recommendation is to prefix packages with "hs-opentelemetry-instrumentation", followed by the instrumented library name itself.
-
- In general, you can initialize the instrumentation library like so:
-
- @
-
- import qualified Data.Text as T
- import Data.Version (showVersion)
- import Paths_your_package_name
-
- instrumentationLibrary :: InstrumentationLibrary
- instrumentationLibrary = InstrumentationLibrary
-   { libraryName = "your_package_name"
-   , libraryVersion = T.pack $ showVersion version
-   }
-
- @
--}
-data InstrumentationLibrary = InstrumentationLibrary
-  { libraryName :: {-# UNPACK #-} !Text
-  -- ^ The name of the instrumentation library
-  , libraryVersion :: {-# UNPACK #-} !Text
-  -- ^ The version of the instrumented library
-  }
-  deriving (Ord, Eq, Generic, Show)
-
-
-instance Hashable InstrumentationLibrary
-
-
-instance IsString InstrumentationLibrary where
-  fromString str = InstrumentationLibrary (fromString str) ""
 
 
 data Exporter a = Exporter

--- a/api/src/OpenTelemetry/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Logging/Core.hs
@@ -37,7 +37,7 @@ emitLogRecord
   => Logger
   -> LogRecordArguments body
   -> m (LogRecord body)
-emitLogRecord logger LogRecordArguments {..} = do
+emitLogRecord Logger {..} LogRecordArguments {..} = do
   currentTimestamp <- getCurrentTimestamp
   let logRecordObservedTimestamp = fromMaybe currentTimestamp observedTimestamp
 
@@ -55,6 +55,7 @@ emitLogRecord logger LogRecordArguments {..} = do
       , logRecordSeverityNumber = fmap mkSeverityNumber severityNumber
       , logRecordSeverityText = severityText <|> (shortName . mkSeverityNumber =<< severityNumber)
       , logRecordBody = body
-      , logRecordResource = loggerResource logger
+      , logRecordResource = loggerResource
+      , logRecordInstrumentationScope = loggerInstrumentationScope
       , logRecordAttributes = attributes
       }

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -165,6 +165,7 @@ import qualified OpenTelemetry.Attributes as A
 import OpenTelemetry.Common
 import OpenTelemetry.Context
 import OpenTelemetry.Context.ThreadLocal
+import OpenTelemetry.Internal.Common.Types
 import OpenTelemetry.Internal.Logging.Types (LogRecord)
 import OpenTelemetry.Internal.Trace.Types
 import qualified OpenTelemetry.Internal.Trace.Types as Types


### PR DESCRIPTION
# Context
To comply with the spec, [`LogRecord` must have a field `instrumentationScope`](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-instrumentationscope). `Logger` provides this field to `LogRecord`s. This PR updates the codebase to match that spec. The `InstrumentationLibrary` data type was also [updated to include `schema_url` and `attributes`](https://opentelemetry.io/docs/specs/otel/logs/bridge-api/#get-a-logger). The haddock documentation about how to initialize an `instrumentationLibrary` has not yet been updated because I am unsure about how adding fields to `instrumentationScope` will affect things and whether it is necessary to add the fields.

## Testing
- `stack build` runs
- I am not sure how adding fields to `instrumentationScope` will affect things but it should maybe be tested