### PR TITLE
Add LoggerProvider to create Loggers and allow registering a global LoggerProvider

### DIFF
--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE InstanceSigs #-}
 
 module OpenTelemetry.Internal.Logging.Types (
+  LoggerProvider (..),
   Logger (..),
   LogRecord (..),
   LogRecordArguments (..),
@@ -20,10 +21,15 @@ import OpenTelemetry.LogAttributes (LogAttributes)
 import OpenTelemetry.Resource (MaterializedResources)
 
 
+data LoggerProvider = LoggerProvider
+  { loggerProviderResource :: Maybe MaterializedResources
+  }
+
+
 -- | LogRecords can be Created from Loggers
 data Logger = Logger
   { loggerInstrumentationScope :: InstrumentationLibrary
-  , loggerResource :: Maybe MaterializedResources
+  , loggerProvider :: LoggerProvider
   }
 
 

--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -23,7 +23,7 @@ import OpenTelemetry.Resource (MaterializedResources)
 
 -- | @Logger@s can be created from @LoggerProvider@s
 data LoggerProvider = LoggerProvider
-  { loggerProviderResource :: Maybe MaterializedResources
+  { loggerProviderResource :: MaterializedResources
   }
 
 
@@ -100,7 +100,7 @@ data LogRecord body = LogRecord
   --    - A byte array,
   --    - An array (a list) of any values,
   --    - A map<string, any>.
-  , logRecordResource :: Maybe MaterializedResources
+  , logRecordResource :: MaterializedResources
   -- ^ Describes the source of the log, aka resource. Multiple occurrences of events coming from the same event source can happen across time and they all have the same value of Resource.
   -- Can contain for example information about the application that emits the record or about the infrastructure where the application runs. Data formats that represent this data model
   -- may be designed in a manner that allows the Resource field to be recorded only once per batch of log records that come from the same source. SHOULD follow OpenTelemetry semantic conventions for Resources.

--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -21,15 +21,20 @@ import OpenTelemetry.LogAttributes (LogAttributes)
 import OpenTelemetry.Resource (MaterializedResources)
 
 
+-- | @Logger@s can be created from @LoggerProvider@s
 data LoggerProvider = LoggerProvider
   { loggerProviderResource :: Maybe MaterializedResources
   }
 
 
--- | LogRecords can be Created from Loggers
+{- | @LogRecords@ can be created from @Loggers@. @Logger@s are uniquely identified by the @libraryName@, @libraryVersion@, @schemaUrl@ fields of @InstrumentationLibrary@.
+Creating two @Logger@s with the same identity but different @libraryAttributes@ is a user error.
+-}
 data Logger = Logger
   { loggerInstrumentationScope :: InstrumentationLibrary
+  -- ^ Details about the library that the @Logger@ instruments.
   , loggerProvider :: LoggerProvider
+  -- ^ The @LoggerProvider@ that created this @Logger@. All configuration for the @Logger@ is contained in the @LoggerProvider@.
   }
 
 
@@ -110,7 +115,8 @@ data LogRecord body = LogRecord
 
 
 {- | Arguments that may be set on LogRecord creation. If observedTimestamp is not set, it will default to the current timestamp.
-If context is not specified it will default to the current context.
+If context is not specified it will default to the current context. Refer to the documentation of @LogRecord@ for descriptions
+of the fields.
 -}
 data LogRecordArguments body = LogRecordArguments
   { timestamp :: Maybe Timestamp

--- a/api/src/OpenTelemetry/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Logging/Core.hs
@@ -63,12 +63,12 @@ emptyLoggerProviderOptions =
 
  You should generally use @getGlobalLoggerProvider@ for most applications.
 -}
-createLoggerProvider :: (MonadIO m) => LoggerProviderOptions -> m LoggerProvider
-createLoggerProvider LoggerProviderOptions {..} = pure LoggerProvider {loggerProviderResource = loggerProviderOptionsResource}
+createLoggerProvider :: LoggerProviderOptions -> LoggerProvider
+createLoggerProvider LoggerProviderOptions {..} = LoggerProvider {loggerProviderResource = loggerProviderOptionsResource}
 
 
 globalLoggerProvider :: IORef LoggerProvider
-globalLoggerProvider = unsafePerformIO $ newIORef =<< createLoggerProvider emptyLoggerProviderOptions
+globalLoggerProvider = unsafePerformIO $ newIORef $ createLoggerProvider emptyLoggerProviderOptions
 {-# NOINLINE globalLoggerProvider #-}
 
 

--- a/api/src/OpenTelemetry/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Logging/Core.hs
@@ -45,7 +45,7 @@ getCurrentTimestamp :: (MonadIO m) => m Timestamp
 getCurrentTimestamp = liftIO $ coerce @(IO TimeSpec) @(IO Timestamp) $ getTime Realtime
 
 
-data LoggerProviderOptions = LoggerProviderOptions {loggerProviderOptionsResource :: Maybe MaterializedResources}
+data LoggerProviderOptions = LoggerProviderOptions {loggerProviderOptionsResource :: MaterializedResources}
 
 
 {- | Options for creating a @LoggerProvider@ with no resources and default limits.
@@ -55,7 +55,7 @@ data LoggerProviderOptions = LoggerProviderOptions {loggerProviderOptionsResourc
 emptyLoggerProviderOptions :: LoggerProviderOptions
 emptyLoggerProviderOptions =
   LoggerProviderOptions
-    { loggerProviderOptionsResource = Just emptyMaterializedResources
+    { loggerProviderOptionsResource = emptyMaterializedResources
     }
 
 


### PR DESCRIPTION
# Context
Adds `LoggerProvider`s according to the [OTel spec](https://opentelemetry.io/docs/specs/otel/logs/bridge-api/#loggerprovider). Allows registering and getting a global `LoggerProvider`. Some methods of `LoggerProvider` like [`shutdown`](https://opentelemetry.io/docs/specs/otel/logs/sdk/#shutdown) will be implemented when the SDK is created.

## Testing
- `stack build` runs