### PR TITLE
Refactored attribute limits to be controlled by the LoggerProvider

### DIFF
--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -11,19 +11,22 @@ module OpenTelemetry.Internal.Logging.Types (
   severityInt,
 ) where
 
+import qualified Data.HashMap.Strict as H
 import Data.Int (Int64)
 import Data.Text (Text)
+import OpenTelemetry.Attributes (AttributeLimits)
 import OpenTelemetry.Common (Timestamp, TraceFlags)
 import OpenTelemetry.Context.Types
 import OpenTelemetry.Internal.Common.Types (InstrumentationLibrary)
 import OpenTelemetry.Internal.Trace.Id (SpanId, TraceId)
-import OpenTelemetry.LogAttributes (LogAttributes)
+import OpenTelemetry.LogAttributes (AnyValue, LogAttributes)
 import OpenTelemetry.Resource (MaterializedResources)
 
 
 -- | @Logger@s can be created from @LoggerProvider@s
 data LoggerProvider = LoggerProvider
   { loggerProviderResource :: MaterializedResources
+  , loggerProviderAttributeLimits :: AttributeLimits
   }
 
 
@@ -125,7 +128,7 @@ data LogRecordArguments body = LogRecordArguments
   , severityText :: Maybe Text
   , severityNumber :: Maybe Int
   , body :: body
-  , attributes :: LogAttributes
+  , attributes :: H.HashMap Text AnyValue
   }
 
 

--- a/api/src/OpenTelemetry/LogAttributes.hs
+++ b/api/src/OpenTelemetry/LogAttributes.hs
@@ -162,6 +162,11 @@ instance (ToValue a) => ToValue (H.HashMap Text a) where
   toValue = HashMapValue . fmap toValue
 
 
+instance ToValue AnyValue where
+  toValue :: AnyValue -> AnyValue
+  toValue = id
+
+
 unsafeMergeLogAttributesIgnoringLimits :: LogAttributes -> LogAttributes -> LogAttributes
 unsafeMergeLogAttributesIgnoringLimits (LogAttributes l lc ld) (LogAttributes r rc rd) = LogAttributes (l <> r) (lc + rc) (ld + rd)
 


### PR DESCRIPTION
# Context
[`LoggerProvider`s should control the `AttributeLimit`s for `Logger`s](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecord-limits). Previously, the entirety of `LogAttributes` was provided to the `emitLogRecord` function instead of passing the attributes via a `HashMap Text AnyValue` and `AttributeLimit`s via a `LoggerProvider` accessed through the provided `Logger`. Relatedly, [`LogAttributes` should be able to be changed after the creation of the `Logger`](https://opentelemetry.io/docs/specs/otel/logs/sdk/#readwritelogrecord), but that will be added later.

## Testing
- `stack build` runs