### PR TITLE
Refactored LogRecords to be mutable so that attributes can be modified after creation

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -106,6 +106,7 @@ test-suite hs-opentelemetry-api-test
   main-is: Spec.hs
   other-modules:
       OpenTelemetry.BaggageSpec
+      OpenTelemetry.Logging.CoreSpec
       OpenTelemetry.SemanticsConfigSpec
       OpenTelemetry.Trace.SamplerSpec
       OpenTelemetry.Trace.TraceFlagsSpec

--- a/api/src/OpenTelemetry/Internal/Common/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Common/Types.hs
@@ -89,6 +89,7 @@ data AnyValue
   | ByteStringValue ByteString
   | ArrayValue [AnyValue]
   | HashMapValue (H.HashMap Text AnyValue)
+  | NullValue
   deriving stock (Read, Show, Eq, Ord, Data, Generic)
   deriving anyclass (Hashable)
 

--- a/api/src/OpenTelemetry/Internal/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Core.hs
@@ -147,7 +147,7 @@ logDroppedAttributes = emitOTelLogRecord H.empty Warn "At least 1 attribute was 
 
 -- | WARNING: this function should only be used to emit logs from the hs-opentelemetry-api library. DO NOT USE this function in any other context.
 emitOTelLogRecord :: (MonadIO m) => H.HashMap Text LA.AnyValue -> SeverityNumber -> Text -> m ReadWriteLogRecord
-emitOTelLogRecord attrs severity body = do
+emitOTelLogRecord attrs severity bodyText = do
   glp <- getGlobalLoggerProvider
   let gl =
         makeLogger glp $
@@ -159,8 +159,9 @@ emitOTelLogRecord attrs severity body = do
             }
 
   emitLogRecord gl $
-    (emptyLogRecordArguments body)
+    emptyLogRecordArguments
       { severityNumber = Just severity
+      , body = toValue bodyText
       , attributes = attrs
       }
 

--- a/api/src/OpenTelemetry/Internal/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Core.hs
@@ -179,8 +179,7 @@ emitLogRecord
   -> m (LogRecord body)
 emitLogRecord l args = do
   ilr <- createImmutableLogRecord l args
-  lr <- liftIO $ newIORef ilr
-  pure $ LogRecord lr
+  liftIO $ mkLogRecord ilr
 
 
 {- | Add an attribute to a @LogRecord@.
@@ -201,10 +200,10 @@ For example, the 'otel.library.name' attribute is used to record the instrumenta
 
 Any additions to the 'otel.*' namespace MUST be approved as part of OpenTelemetry specification.
 -}
-addAttribute :: (MonadIO m, ToValue a) => LogRecord body -> Text -> a -> m ()
-addAttribute (LogRecord lr) k v =
+addAttribute :: (ReadWriteLogRecord r, MonadIO m, ToValue a) => r body -> Text -> a -> m ()
+addAttribute lr k v =
   liftIO $
-    modifyIORef'
+    modifyLogRecord
       lr
       ( \ilr@ImmutableLogRecord {logRecordAttributes, logRecordLogger} ->
           ilr
@@ -222,10 +221,10 @@ addAttribute (LogRecord lr) k v =
 
  This function may be slightly more performant than repeatedly calling 'addAttribute'.
 -}
-addAttributes :: (MonadIO m, ToValue a) => LogRecord body -> HashMap Text a -> m ()
-addAttributes (LogRecord lr) attrs =
+addAttributes :: (ReadWriteLogRecord r, MonadIO m, ToValue a) => r body -> HashMap Text a -> m ()
+addAttributes lr attrs =
   liftIO $
-    modifyIORef'
+    modifyLogRecord
       lr
       ( \ilr@ImmutableLogRecord {logRecordAttributes, logRecordLogger} ->
           ilr
@@ -242,5 +241,5 @@ addAttributes (LogRecord lr) attrs =
  using it to copy / otherwise use the data to further enrich
  instrumentation.
 -}
-logRecordGetAttributes :: (MonadIO m) => LogRecord a -> m LogAttributes
-logRecordGetAttributes (LogRecord lr) = liftIO $ logRecordAttributes <$> readIORef lr
+logRecordGetAttributes :: (ReadableLogRecord r, MonadIO m) => r a -> m LogAttributes
+logRecordGetAttributes lr = liftIO $ logRecordAttributes <$> readLogRecord lr

--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -21,7 +21,7 @@ import OpenTelemetry.Common (Timestamp, TraceFlags)
 import OpenTelemetry.Context.Types (Context)
 import OpenTelemetry.Internal.Common.Types (InstrumentationLibrary)
 import OpenTelemetry.Internal.Trace.Id (SpanId, TraceId)
-import OpenTelemetry.LogAttributes (AnyValue, AttributeLimits, LogAttributes)
+import OpenTelemetry.LogAttributes
 import OpenTelemetry.Resource (MaterializedResources)
 
 

--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -218,15 +218,15 @@ data LogRecordArguments = LogRecordArguments
   }
 
 
-emptyLogRecordArguments :: (ToValue body) => body -> LogRecordArguments
-emptyLogRecordArguments body =
+emptyLogRecordArguments :: LogRecordArguments
+emptyLogRecordArguments =
   LogRecordArguments
     { timestamp = Nothing
     , observedTimestamp = Nothing
     , context = Nothing
     , severityText = Nothing
     , severityNumber = Nothing
-    , body = toValue body
+    , body = NullValue
     , attributes = H.empty
     }
 

--- a/api/src/OpenTelemetry/Internal/Logging/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logging/Types.hs
@@ -67,8 +67,8 @@ mkReadWriteLogRecord l = fmap (ReadWriteLogRecord l) . newIORef
 newtype ReadableLogRecord = ReadableLogRecord {readableLogRecord :: ReadWriteLogRecord}
 
 
-mkReadableLogRecord :: Logger -> ImmutableLogRecord -> IO ReadableLogRecord
-mkReadableLogRecord l = fmap ReadableLogRecord . mkReadWriteLogRecord l
+mkReadableLogRecord :: ReadWriteLogRecord -> ReadableLogRecord
+mkReadableLogRecord = ReadableLogRecord
 
 
 {- | This is a typeclass representing @LogRecord@s that can be read from.

--- a/api/src/OpenTelemetry/LogAttributes.hs
+++ b/api/src/OpenTelemetry/LogAttributes.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE InstanceSigs #-}
 
 module OpenTelemetry.LogAttributes (
   LogAttributes (..),
@@ -35,6 +31,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
 import OpenTelemetry.Attributes (AttributeLimits (..), defaultAttributeLimits)
+import OpenTelemetry.Internal.Common.Types
 
 
 data LogAttributes = LogAttributes
@@ -88,87 +85,6 @@ limitLengths limit (TextValue t) = TextValue (T.take limit t)
 limitLengths limit (ArrayValue arr) = ArrayValue $ fmap (limitLengths limit) arr
 limitLengths limit (HashMapValue h) = HashMapValue $ fmap (limitLengths limit) h
 limitLengths _ val = val
-
-
-{- | An attribute represents user-provided metadata about a span, link, or event.
-
- 'Any' values are used in place of 'Standard Attributes' in logs because third-party
- logs may not conform to the 'Standard Attribute' format.
-
- Telemetry tools may use this data to support high-cardinality querying, visualization
- in waterfall diagrams, trace sampling decisions, and more.
--}
-data AnyValue
-  = TextValue Text
-  | BoolValue Bool
-  | DoubleValue Double
-  | IntValue Int64
-  | ByteStringValue ByteString
-  | ArrayValue [AnyValue]
-  | HashMapValue (H.HashMap Text AnyValue)
-  deriving stock (Read, Show, Eq, Ord, Data, Generic)
-  deriving anyclass (Hashable)
-
-
--- | Create a `TextAttribute` from the string value.
-instance IsString AnyValue where
-  fromString :: String -> AnyValue
-  fromString = TextValue . fromString
-
-
-{- | Convert a Haskell value to an 'Any' value.
-
- @
-
- data Foo = Foo
-
- instance ToValue Foo where
-   toValue Foo = TextValue "Foo"
-
- @
--}
-class ToValue a where
-  toValue :: a -> AnyValue
-
-
-instance ToValue Text where
-  toValue :: Text -> AnyValue
-  toValue = TextValue
-
-
-instance ToValue Bool where
-  toValue :: Bool -> AnyValue
-  toValue = BoolValue
-
-
-instance ToValue Double where
-  toValue :: Double -> AnyValue
-  toValue = DoubleValue
-
-
-instance ToValue Int64 where
-  toValue :: Int64 -> AnyValue
-  toValue = IntValue
-
-
-instance ToValue ByteString where
-  toValue :: ByteString -> AnyValue
-  toValue = ByteStringValue
-
-
-instance (ToValue a) => ToValue [a] where
-  toValue :: (ToValue a) => [a] -> AnyValue
-  toValue = ArrayValue . fmap toValue
-
-
-instance (ToValue a) => ToValue (H.HashMap Text a) where
-  toValue :: (ToValue a) => H.HashMap Text a -> AnyValue
-  toValue = HashMapValue . fmap toValue
-
-
-instance ToValue AnyValue where
-  toValue :: AnyValue -> AnyValue
-  toValue = id
 
 
 unsafeMergeLogAttributesIgnoringLimits :: LogAttributes -> LogAttributes -> LogAttributes

--- a/api/src/OpenTelemetry/LogAttributes.hs
+++ b/api/src/OpenTelemetry/LogAttributes.hs
@@ -16,6 +16,10 @@ module OpenTelemetry.LogAttributes (
   AnyValue (..),
   ToValue (..),
 
+  -- * Attribute limits
+  AttributeLimits (..),
+  defaultAttributeLimits,
+
   -- * unsafe utilities
   unsafeLogAttributesFromListIgnoringLimits,
   unsafeMergeLogAttributesIgnoringLimits,
@@ -30,7 +34,7 @@ import Data.String (IsString (..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
-import OpenTelemetry.Attributes (AttributeLimits (..))
+import OpenTelemetry.Attributes (AttributeLimits (..), defaultAttributeLimits)
 
 
 data LogAttributes = LogAttributes

--- a/api/src/OpenTelemetry/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Logging/Core.hs
@@ -13,10 +13,13 @@ module OpenTelemetry.Logging.Core (
   makeLogger,
 
   -- * @LogRecord@ operations
-  LogRecord,
-  ReadableLogRecord (..),
-  ReadWriteLogRecord (..),
+  ReadableLogRecord,
+  ReadWriteLogRecord,
+  IsReadableLogRecord (..),
+  IsReadWriteLogRecord (..),
   LogRecordArguments (..),
+  AnyValue (..),
+  ToValue (..),
   SeverityNumber (..),
   toShortName,
   emitLogRecord,

--- a/api/src/OpenTelemetry/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Logging/Core.hs
@@ -13,7 +13,9 @@ module OpenTelemetry.Logging.Core (
   makeLogger,
 
   -- * @LogRecord@ operations
-  LogRecord (..),
+  LogRecord,
+  ReadableLogRecord (..),
+  ReadWriteLogRecord (..),
   LogRecordArguments (..),
   SeverityNumber (..),
   toShortName,

--- a/api/src/OpenTelemetry/Logging/Core.hs
+++ b/api/src/OpenTelemetry/Logging/Core.hs
@@ -18,6 +18,9 @@ module OpenTelemetry.Logging.Core (
   SeverityNumber (..),
   toShortName,
   emitLogRecord,
+  addAttribute,
+  addAttributes,
+  logRecordGetAttributes,
 ) where
 
 import OpenTelemetry.Internal.Common.Types

--- a/api/src/OpenTelemetry/Resource.hs
+++ b/api/src/OpenTelemetry/Resource.hs
@@ -176,6 +176,7 @@ data MaterializedResources = MaterializedResources
   { materializedResourcesSchema :: Maybe String
   , materializedResourcesAttributes :: Attributes
   }
+  deriving (Show, Eq)
 
 
 {- | A placeholder for 'MaterializedResources' when no resource information is

--- a/api/test/OpenTelemetry/Logging/CoreSpec.hs
+++ b/api/test/OpenTelemetry/Logging/CoreSpec.hs
@@ -16,57 +16,44 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Core" $ do
-  describe "getGlobalLoggerProvider" $ do
+  describe "The global logger provider" $ do
     it "Returns a no-op LoggerProvider when not initialized" $ do
       LoggerProvider {..} <- getGlobalLoggerProvider
       loggerProviderResource `shouldBe` emptyMaterializedResources
       loggerProviderAttributeLimits `shouldBe` LA.defaultAttributeLimits
-  describe "setGlobalLoggerProvider" $ do
-    it "works" $ do
-      lp <-
-        createLoggerProvider $
-          LoggerProviderOptions
-            { loggerProviderOptionsResource =
-                materializeResources $
-                  toResource
-                    OperatingSystem
-                      { osType = "exampleOs"
-                      , osDescription = Nothing
-                      , osName = Nothing
-                      , osVersion = Nothing
+    it "Allows a LoggerProvider to be set and returns that with subsequent calls to getGlobalLoggerProvider" $ do
+      let lp =
+            createLoggerProvider $
+              LoggerProviderOptions
+                { loggerProviderOptionsResource =
+                    materializeResources $
+                      toResource
+                        OperatingSystem
+                          { osType = "exampleOs"
+                          , osDescription = Nothing
+                          , osName = Nothing
+                          , osVersion = Nothing
+                          }
+                , loggerProviderOptionsAttributeLimits =
+                    LA.AttributeLimits
+                      { attributeCountLimit = Just 50
+                      , attributeLengthLimit = Just 50
                       }
-            , loggerProviderOptionsAttributeLimits =
-                LA.AttributeLimits
-                  { attributeCountLimit = Just 50
-                  , attributeLengthLimit = Just 50
-                  }
-            }
+                }
+
       setGlobalLoggerProvider lp
+
       glp <- getGlobalLoggerProvider
       glp `shouldBe` lp
   describe "addAttribute" $ do
     it "works" $ do
       lp <- getGlobalLoggerProvider
       let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
-      lr <-
-        emitLogRecord
-          l
-          LogRecordArguments
-            { timestamp = Nothing
-            , observedTimestamp = Nothing
-            , context = Nothing
-            , severityText = Nothing
-            , severityNumber = Nothing
-            , body = Nothing
-            , attributes =
-                H.fromList
-                  [ ("something", "a thing")
-                  ]
-            }
+      lr <- emitLogRecord l $ (emptyLogRecordArguments ()) {attributes = H.fromList [("something", "a thing")]}
+
       addAttribute lr "anotherThing" ("another thing" :: LA.AnyValue)
 
       (_, attrs) <- LA.getAttributes <$> logRecordGetAttributes lr
-
       attrs
         `shouldBe` H.fromList
           [ ("anotherThing", "another thing")
@@ -76,21 +63,8 @@ spec = describe "Core" $ do
     it "works" $ do
       lp <- getGlobalLoggerProvider
       let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
-      lr <-
-        emitLogRecord
-          l
-          LogRecordArguments
-            { timestamp = Nothing
-            , observedTimestamp = Nothing
-            , context = Nothing
-            , severityText = Nothing
-            , severityNumber = Nothing
-            , body = Nothing
-            , attributes =
-                H.fromList
-                  [ ("something", "a thing")
-                  ]
-            }
+      lr <- emitLogRecord l $ (emptyLogRecordArguments ()) {attributes = H.fromList [("something", "a thing")]}
+
       addAttributes lr $
         H.fromList
           [ ("anotherThing", "another thing" :: LA.AnyValue)
@@ -98,7 +72,6 @@ spec = describe "Core" $ do
           ]
 
       (_, attrs) <- LA.getAttributes <$> logRecordGetAttributes lr
-
       attrs
         `shouldBe` H.fromList
           [ ("anotherThing", "another thing")

--- a/api/test/OpenTelemetry/Logging/CoreSpec.hs
+++ b/api/test/OpenTelemetry/Logging/CoreSpec.hs
@@ -5,6 +5,7 @@ module OpenTelemetry.Logging.CoreSpec where
 
 import qualified Data.HashMap.Strict as H
 import Data.IORef
+import qualified Data.Text as T
 import qualified OpenTelemetry.Attributes as A
 import OpenTelemetry.Internal.Logging.Types
 import qualified OpenTelemetry.LogAttributes as LA
@@ -49,7 +50,7 @@ spec = describe "Core" $ do
     it "works" $ do
       lp <- getGlobalLoggerProvider
       let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
-      lr <- emitLogRecord l $ (emptyLogRecordArguments ()) {attributes = H.fromList [("something", "a thing")]}
+      lr <- emitLogRecord l $ (emptyLogRecordArguments ("" :: LA.AnyValue)) {attributes = H.fromList [("something", "a thing")]}
 
       addAttribute lr "anotherThing" ("another thing" :: LA.AnyValue)
 
@@ -63,7 +64,7 @@ spec = describe "Core" $ do
     it "works" $ do
       lp <- getGlobalLoggerProvider
       let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
-      lr <- emitLogRecord l $ (emptyLogRecordArguments ()) {attributes = H.fromList [("something", "a thing")]}
+      lr <- emitLogRecord l $ (emptyLogRecordArguments ("" :: LA.AnyValue)) {attributes = H.fromList [("something", "a thing")]}
 
       addAttributes lr $
         H.fromList

--- a/api/test/OpenTelemetry/Logging/CoreSpec.hs
+++ b/api/test/OpenTelemetry/Logging/CoreSpec.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenTelemetry.Logging.CoreSpec where
+
+import qualified Data.HashMap.Strict as H
+import Data.IORef
+import qualified OpenTelemetry.Attributes as A
+import OpenTelemetry.Internal.Logging.Types
+import qualified OpenTelemetry.LogAttributes as LA
+import OpenTelemetry.Logging.Core
+import OpenTelemetry.Resource
+import OpenTelemetry.Resource.OperatingSystem
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "Core" $ do
+  describe "getGlobalLoggerProvider" $ do
+    it "Returns a no-op LoggerProvider when not initialized" $ do
+      LoggerProvider {..} <- getGlobalLoggerProvider
+      loggerProviderResource `shouldBe` emptyMaterializedResources
+      loggerProviderAttributeLimits `shouldBe` LA.defaultAttributeLimits
+  describe "setGlobalLoggerProvider" $ do
+    it "works" $ do
+      lp <-
+        createLoggerProvider $
+          LoggerProviderOptions
+            { loggerProviderOptionsResource =
+                materializeResources $
+                  toResource
+                    OperatingSystem
+                      { osType = "exampleOs"
+                      , osDescription = Nothing
+                      , osName = Nothing
+                      , osVersion = Nothing
+                      }
+            , loggerProviderOptionsAttributeLimits =
+                LA.AttributeLimits
+                  { attributeCountLimit = Just 50
+                  , attributeLengthLimit = Just 50
+                  }
+            }
+      setGlobalLoggerProvider lp
+      glp <- getGlobalLoggerProvider
+      glp `shouldBe` lp
+  describe "addAttribute" $ do
+    it "works" $ do
+      lp <- getGlobalLoggerProvider
+      let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
+      lr <-
+        emitLogRecord
+          l
+          LogRecordArguments
+            { timestamp = Nothing
+            , observedTimestamp = Nothing
+            , context = Nothing
+            , severityText = Nothing
+            , severityNumber = Nothing
+            , body = Nothing
+            , attributes =
+                H.fromList
+                  [ ("something", "a thing")
+                  ]
+            }
+      addAttribute lr "anotherThing" ("another thing" :: LA.AnyValue)
+
+      (_, attrs) <- LA.getAttributes <$> logRecordGetAttributes lr
+
+      attrs
+        `shouldBe` H.fromList
+          [ ("anotherThing", "another thing")
+          , ("something", "a thing")
+          ]
+  describe "addAttributes" $ do
+    it "works" $ do
+      lp <- getGlobalLoggerProvider
+      let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
+      lr <-
+        emitLogRecord
+          l
+          LogRecordArguments
+            { timestamp = Nothing
+            , observedTimestamp = Nothing
+            , context = Nothing
+            , severityText = Nothing
+            , severityNumber = Nothing
+            , body = Nothing
+            , attributes =
+                H.fromList
+                  [ ("something", "a thing")
+                  ]
+            }
+      addAttributes lr $
+        H.fromList
+          [ ("anotherThing", "another thing" :: LA.AnyValue)
+          , ("twoThing", "the second another thing")
+          ]
+
+      (_, attrs) <- LA.getAttributes <$> logRecordGetAttributes lr
+
+      attrs
+        `shouldBe` H.fromList
+          [ ("anotherThing", "another thing")
+          , ("something", "a thing")
+          , ("twoThing", "the second another thing")
+          ]

--- a/api/test/OpenTelemetry/Logging/CoreSpec.hs
+++ b/api/test/OpenTelemetry/Logging/CoreSpec.hs
@@ -50,7 +50,7 @@ spec = describe "Core" $ do
     it "works" $ do
       lp <- getGlobalLoggerProvider
       let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
-      lr <- emitLogRecord l $ (emptyLogRecordArguments ("" :: LA.AnyValue)) {attributes = H.fromList [("something", "a thing")]}
+      lr <- emitLogRecord l $ emptyLogRecordArguments {attributes = H.fromList [("something", "a thing")]}
 
       addAttribute lr "anotherThing" ("another thing" :: LA.AnyValue)
 
@@ -64,7 +64,7 @@ spec = describe "Core" $ do
     it "works" $ do
       lp <- getGlobalLoggerProvider
       let l = makeLogger lp InstrumentationLibrary {libraryName = "exampleLibrary", libraryVersion = "", librarySchemaUrl = "", libraryAttributes = A.emptyAttributes}
-      lr <- emitLogRecord l $ (emptyLogRecordArguments ("" :: LA.AnyValue)) {attributes = H.fromList [("something", "a thing")]}
+      lr <- emitLogRecord l $ emptyLogRecordArguments {attributes = H.fromList [("something", "a thing")]}
 
       addAttributes lr $
         H.fromList

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -13,6 +13,7 @@ import OpenTelemetry.Attributes (lookupAttribute)
 
 import qualified OpenTelemetry.BaggageSpec as Baggage
 import OpenTelemetry.Context
+import qualified OpenTelemetry.Logging.CoreSpec as CoreSpec
 import qualified OpenTelemetry.SemanticsConfigSpec as SemanticsConfigSpec
 import OpenTelemetry.Trace.Core
 import qualified OpenTelemetry.Trace.SamplerSpec as Sampler
@@ -56,3 +57,4 @@ main = hspec $ do
   Sampler.spec
   TraceFlags.spec
   SemanticsConfigSpec.spec
+  CoreSpec.spec


### PR DESCRIPTION
# Big Context
Logging Support is being added to hs-opentelemetry. [Logging spec](https://opentelemetry.io/docs/specs/otel/logs/)

## Small (This PR) Context
[`LogRecord`s should be modifiable](https://opentelemetry.io/docs/specs/otel/logs/sdk/#readwritelogrecord) after creation for the [purposes of `LogRecordProcessor`s](https://opentelemetry.io/docs/specs/otel/logs/sdk/#onemit). This PR refactors `LogRecord` to contain a mutable `IORef` to an `ImmutableLogRecord`. It also adds convenience functions for adding attributes to `LogRecord`s and a test suite that tests `LoggerProvider`s and `LogRecord`s. 

`LogRecord`s can only be read through the functions of `ReadableLogRecord` and modified by the functions of `ReadWriteLogRecord`. [This is in accordance with the spec](https://opentelemetry.io/docs/specs/otel/logs/sdk/#readablelogrecord).

The type of the `body` field was changed from a type variable to an `AnyValue` so that processors and exporters can process logs from various sources that might have different body types.

## Testing
- `stack build` runs
- New test suite under `stack test hs-opentelemetry` passes