### PR TITLE
Fix callerAttributes in the presence of frozen call stacks

### DIFF
--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- `callerAttributes` and `ownCodeAttributes` now work properly if the call stack has been frozen. Hence most
+  span-construction functions should now get correct source code attributes in this situation also.
+
 ## 0.1.0.0
 
 - Use `HashMap Text Attribute` instead of `[(Text, Attribute)]` as attributes


### PR DESCRIPTION
Freezing the call stack is common when writing your own utility wrappers around e.g. `withSpan`. In this case you want to freeze the call stack before calling your utility, so that `withSpan` and friends see the "application" function as the top of the call stack.

However, the functions for getting information from call stacks just generally didn't work right in the presence of frozen call stacks. They assumed that the call stack was unfrozen, and hence that they could look up a fixed number of steps to find the caller info.

We can't in general tell directly if the call stack is frozen, but we use a pretty decent heuristic here: is the top element exactly our own function? If so, we probably have an unfrozen call stack. Otherwise we might have a frozen call stack and we have to try and do something else.