### PR TITLE
add protobuf nix dependency to stack.yaml

### DIFF
--- a/stack-ghc-8.10.yaml
+++ b/stack-ghc-8.10.yaml
@@ -99,4 +99,4 @@ extra-deps:
 
 nix:
   enable: true
-  packages: [libffi, mysql80, openssl, pcre, postgresql, zlib, zstd]
+  packages: [libffi, mysql80, openssl, pcre, postgresql, protobuf, zlib, zstd]

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -97,4 +97,4 @@ extra-deps:
 
 nix:
   enable: true
-  packages: [libffi, mysql80, openssl, pcre, postgresql, zlib, zstd]
+  packages: [libffi, mysql80, openssl, pcre, postgresql, protobuf, zlib, zstd]

--- a/stack.yaml
+++ b/stack.yaml
@@ -100,4 +100,4 @@ extra-deps:
 
 nix:
   enable: true
-  packages: [libffi, mysql80, openssl, pcre, postgresql, zlib, zstd]
+  packages: [libffi, mysql80, openssl, pcre, postgresql, protobuf, zlib, zstd]


### PR DESCRIPTION
This PR will add protobuf as Nix dependency because hs-opentelemetry-otlp requires `protoc` newly.

I need help to add the protobuf package to flake.nix. It is required by cabal-install users.