### PR TITLE
Make it easier to make links

### DIFF
--- a/api/src/OpenTelemetry/Internal/Trace/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/Types.hs
@@ -270,7 +270,7 @@ data ImmutableSpan = ImmutableSpan
   , spanEnd :: Maybe Timestamp
   -- ^ A timestamp that corresponds to the end of the span, if the span has ended.
   , spanAttributes :: Attributes
-  , spanLinks :: FrozenBoundedCollection Link
+  , spanLinks :: AppendOnlyBoundedCollection Link
   -- ^ Zero or more links to related spans. Links can be useful for connecting causal relationships between things like web requests that enqueue asynchronous tasks to be processed.
   , spanEvents :: AppendOnlyBoundedCollection Event
   -- ^ Events, which denote a point in time occurrence. These can be useful for recording data about a span such as when an exception was thrown, or to emit structured logs into the span tree.

--- a/api/src/OpenTelemetry/Util.hs
+++ b/api/src/OpenTelemetry/Util.hs
@@ -36,10 +36,6 @@ module OpenTelemetry.Util (
   appendOnlyBoundedCollectionSize,
   appendOnlyBoundedCollectionValues,
   appendOnlyBoundedCollectionDroppedElementCount,
-  FrozenBoundedCollection,
-  frozenBoundedCollection,
-  frozenBoundedCollectionValues,
-  frozenBoundedCollectionDroppedElementCount,
 ) where
 
 import Control.Exception (SomeException)
@@ -138,27 +134,6 @@ appendToBoundedCollection c@(AppendOnlyBoundedCollection b ms d) x =
   if appendOnlyBoundedCollectionSize c < ms
     then AppendOnlyBoundedCollection (b <> Builder.singleton x) ms d
     else AppendOnlyBoundedCollection b ms (d + 1)
-
-
-data FrozenBoundedCollection a = FrozenBoundedCollection
-  { collection :: !(V.Vector a)
-  , dropped :: !Int
-  }
-  deriving (Show)
-
-
-frozenBoundedCollection :: (Foldable f) => Int -> f a -> FrozenBoundedCollection a
-frozenBoundedCollection maxSize_ coll = FrozenBoundedCollection (V.fromListN maxSize_ $ toList coll) (collLength - maxSize_)
-  where
-    collLength = length coll
-
-
-frozenBoundedCollectionValues :: FrozenBoundedCollection a -> V.Vector a
-frozenBoundedCollectionValues (FrozenBoundedCollection coll _) = coll
-
-
-frozenBoundedCollectionDroppedElementCount :: FrozenBoundedCollection a -> Int
-frozenBoundedCollectionDroppedElementCount (FrozenBoundedCollection _ dropped_) = dropped_
 
 
 {- | Like 'Context.Exception.bracket', but provides the @after@ function with information about

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -429,9 +429,9 @@ makeSpan completedSpan = do
       & Trace_Fields.droppedEventsCount
         .~ fromIntegral (appendOnlyBoundedCollectionDroppedElementCount (OT.spanEvents completedSpan))
       & Trace_Fields.vec'links
-        .~ fmap makeLink (frozenBoundedCollectionValues $ OT.spanLinks completedSpan)
+        .~ fmap makeLink (appendOnlyBoundedCollectionValues $ OT.spanLinks completedSpan)
       & Trace_Fields.droppedLinksCount
-        .~ fromIntegral (frozenBoundedCollectionDroppedElementCount (OT.spanLinks completedSpan))
+        .~ fromIntegral (appendOnlyBoundedCollectionDroppedElementCount (OT.spanLinks completedSpan))
       & Trace_Fields.status
         .~ ( case OT.spanStatus completedSpan of
               OT.Unset ->

--- a/sdk/src/OpenTelemetry/Trace.hs
+++ b/sdk/src/OpenTelemetry/Trace.hs
@@ -115,6 +115,7 @@ module OpenTelemetry.Trace (
   SpanArguments (..),
   SpanKind (..),
   NewLink (..),
+  addLink,
   inSpan',
   updateName,
   addAttribute,


### PR DESCRIPTION
Fixes https://github.com/iand675/hs-opentelemetry/issues/141

- Add `addEvent`
    - This requires making the span link collection no longer frozen. At this point `FrozenBoundedCollection` is dead, so I dropped it.
- Export `getSpanContext` from the SDK.
    - This makes it easier to actually make `NewLink`s.