### PR TITLE
Fix reading boolean environment variables

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -86,7 +86,6 @@ library
     , base >=4.7 && <5
     , binary
     , bytestring
-    , case-insensitive
     , charset
     , clock
     , containers
@@ -129,7 +128,6 @@ test-suite hs-opentelemetry-api-test
     , base >=4.7 && <5
     , binary
     , bytestring
-    , case-insensitive
     , charset
     , clock
     , containers

--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -34,6 +34,7 @@ library
       OpenTelemetry.Context.ThreadLocal
       OpenTelemetry.Contrib.CarryOns
       OpenTelemetry.Contrib.SpanTraversals
+      OpenTelemetry.Environment
       OpenTelemetry.Exporter
       OpenTelemetry.Exporter.LogRecord
       OpenTelemetry.Exporter.Span
@@ -85,6 +86,7 @@ library
     , base >=4.7 && <5
     , binary
     , bytestring
+    , case-insensitive
     , charset
     , clock
     , containers
@@ -127,6 +129,7 @@ test-suite hs-opentelemetry-api-test
     , base >=4.7 && <5
     , binary
     , bytestring
+    , case-insensitive
     , charset
     , clock
     , containers

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -45,7 +45,6 @@ dependencies:
 - unliftio-core
 - vector-builder
 - safe-exceptions
-- case-insensitive
 
 library:
   source-dirs: src

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -45,6 +45,7 @@ dependencies:
 - unliftio-core
 - vector-builder
 - safe-exceptions
+- case-insensitive
 
 library:
   source-dirs: src

--- a/api/src/OpenTelemetry/Environment.hs
+++ b/api/src/OpenTelemetry/Environment.hs
@@ -13,5 +13,5 @@ isTrue :: String -> Bool
 isTrue = ("true" ==) . map C.toLower
 
 
-lookupBooleanEnv :: String -> IO (Maybe Bool)
-lookupBooleanEnv = fmap (fmap isTrue) . lookupEnv
+lookupBooleanEnv :: String -> IO Bool
+lookupBooleanEnv = fmap (maybe False isTrue) . lookupEnv

--- a/api/src/OpenTelemetry/Environment.hs
+++ b/api/src/OpenTelemetry/Environment.hs
@@ -1,12 +1,17 @@
 module OpenTelemetry.Environment (
-  isTrue,
+  lookupBooleanEnv,
 ) where
 
-import qualified Data.CaseInsensitive as CI
+import qualified Data.Char as C
+import System.Environment (lookupEnv)
 
 
--- Have a look here for the specification.
--- https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean-value
-
+{- | Does the given value of an environment variable correspond to "true" according
+to [the OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean-value)?
+-}
 isTrue :: String -> Bool
-isTrue = ("true" ==) . CI.mk
+isTrue = ("true" ==) . map C.toLower
+
+
+lookupBooleanEnv :: String -> IO (Maybe Bool)
+lookupBooleanEnv = fmap (fmap isTrue) . lookupEnv

--- a/api/src/OpenTelemetry/Environment.hs
+++ b/api/src/OpenTelemetry/Environment.hs
@@ -1,0 +1,12 @@
+module OpenTelemetry.Environment (
+  isTrue,
+) where
+
+import qualified Data.CaseInsensitive as CI
+
+
+-- Have a look here for the specification.
+-- https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean-value
+
+isTrue :: String -> Bool
+isTrue = ("true" ==) . CI.mk

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -72,7 +72,7 @@ import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
 import OpenTelemetry.Attributes
 import qualified OpenTelemetry.Baggage as Baggage
-import qualified OpenTelemetry.Environment as Env
+import OpenTelemetry.Environment
 import OpenTelemetry.Exporter.Span
 import OpenTelemetry.Resource
 import OpenTelemetry.Trace.Core (timestampNanoseconds)
@@ -137,9 +137,9 @@ loadExporterEnvironmentVariables = liftIO $ do
     <$> lookupEnv "OTEL_EXPORTER_OTLP_ENDPOINT"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
-    <*> (fmap Env.isTrue <$> lookupEnv "OTEL_EXPORTER_OTLP_INSECURE")
-    <*> (fmap Env.isTrue <$> lookupEnv "OTEL_EXPORTER_OTLP_SPAN_INSECURE")
-    <*> (fmap Env.isTrue <$> lookupEnv "OTEL_EXPORTER_OTLP_METRIC_INSECURE")
+    <*> lookupBooleanEnv "OTEL_EXPORTER_OTLP_INSECURE"
+    <*> lookupBooleanEnv "OTEL_EXPORTER_OTLP_SPAN_INSECURE"
+    <*> lookupBooleanEnv "OTEL_EXPORTER_OTLP_METRIC_INSECURE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_CERTIFICATE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -72,6 +72,7 @@ import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
 import OpenTelemetry.Attributes
 import qualified OpenTelemetry.Baggage as Baggage
+import qualified OpenTelemetry.Environment as Env
 import OpenTelemetry.Exporter.Span
 import OpenTelemetry.Resource
 import OpenTelemetry.Trace.Core (timestampNanoseconds)
@@ -136,9 +137,9 @@ loadExporterEnvironmentVariables = liftIO $ do
     <$> lookupEnv "OTEL_EXPORTER_OTLP_ENDPOINT"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
-    <*> (fmap (== "true") <$> lookupEnv "OTEL_EXPORTER_OTLP_INSECURE")
-    <*> (fmap (== "true") <$> lookupEnv "OTEL_EXPORTER_OTLP_SPAN_INSECURE")
-    <*> (fmap (== "true") <$> lookupEnv "OTEL_EXPORTER_OTLP_METRIC_INSECURE")
+    <*> (fmap Env.isTrue <$> lookupEnv "OTEL_EXPORTER_OTLP_INSECURE")
+    <*> (fmap Env.isTrue <$> lookupEnv "OTEL_EXPORTER_OTLP_SPAN_INSECURE")
+    <*> (fmap Env.isTrue <$> lookupEnv "OTEL_EXPORTER_OTLP_METRIC_INSECURE")
     <*> lookupEnv "OTEL_EXPORTER_OTLP_CERTIFICATE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -109,9 +109,9 @@ data OTLPExporterConfig = OTLPExporterConfig
   { otlpEndpoint :: Maybe String
   , otlpTracesEndpoint :: Maybe String
   , otlpMetricsEndpoint :: Maybe String
-  , otlpInsecure :: Maybe Bool
-  , otlpSpanInsecure :: Maybe Bool
-  , otlpMetricInsecure :: Maybe Bool
+  , otlpInsecure :: Bool
+  , otlpSpanInsecure :: Bool
+  , otlpMetricInsecure :: Bool
   , otlpCertificate :: Maybe FilePath
   , otlpTracesCertificate :: Maybe FilePath
   , otlpMetricCertificate :: Maybe FilePath


### PR DESCRIPTION
As written in the specification [1], a boolean environment variable is true iff is equal to the case-insensitive string "true".

[1] https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean-value

Waiting for https://github.com/iand675/hs-opentelemetry/pull/148.