### PR TITLE
UPKEEP: Clean up dependencies

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -88,8 +88,6 @@ library
     , bytestring
     , charset
     , clock
-    , containers
-    , ghc-prim
     , hashable
     , http-types
     , memory
@@ -125,29 +123,13 @@ test-suite hs-opentelemetry-api-test
       RecordWildCards
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      async
-    , attoparsec
-    , base >=4.7 && <5
-    , binary
-    , bytestring
-    , charset
-    , clock
-    , containers
-    , ghc-prim
-    , hashable
+      base >=4.7 && <5
     , hs-opentelemetry-api
     , hspec
-    , http-types
-    , memory
     , mtl
-    , safe-exceptions
-    , template-haskell
     , text
-    , thread-utils-context ==0.3.*
-    , transformers
     , unliftio-core
     , unordered-containers
-    , vault
     , vector
     , vector-builder
   default-language: Haskell2010

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -23,32 +23,31 @@ default-extensions:
 
 dependencies:
 - base >= 4.7 && < 5
-- async
-- bytestring
-- text
-- vault
-- containers
-- hashable
-- thread-utils-context == 0.3.*
-- unordered-containers
-- binary
-- vector
-- clock
-- memory
-- mtl
-- transformers
-- http-types
-- attoparsec
-- template-haskell
-- charset
-- ghc-prim
-- unliftio-core
-- vector-builder
-- safe-exceptions
 
 library:
   source-dirs: src
   ghc-options: -Wall
+  dependencies:
+  - async
+  - attoparsec
+  - binary
+  - bytestring
+  - charset
+  - clock
+  - hashable
+  - http-types
+  - memory
+  - mtl
+  - safe-exceptions
+  - template-haskell
+  - text
+  - thread-utils-context == 0.3.*
+  - transformers
+  - unliftio-core
+  - unordered-containers
+  - vault
+  - vector
+  - vector-builder
   other-modules:
   - OpenTelemetry.Context.Types
   - OpenTelemetry.Internal.Trace.Types
@@ -63,7 +62,11 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hspec
     - hs-opentelemetry-api
+    - hspec
+    - mtl
+    - text
+    - unliftio-core
+    - unordered-containers
     - vector
     - vector-builder

--- a/api/src/OpenTelemetry/Context/ThreadLocal.hs
+++ b/api/src/OpenTelemetry/Context/ThreadLocal.hs
@@ -54,11 +54,7 @@ module OpenTelemetry.Context.ThreadLocal (
 ) where
 
 import Control.Concurrent
--- import Control.Concurrent.Async
 import Control.Concurrent.Thread.Storage
--- import Control.Monad
-
-import Control.Monad (void)
 import Control.Monad.IO.Class
 import Data.Maybe (fromMaybe)
 import OpenTelemetry.Context (Context, empty)

--- a/api/src/OpenTelemetry/Contrib/CarryOns.hs
+++ b/api/src/OpenTelemetry/Contrib/CarryOns.hs
@@ -13,7 +13,6 @@ import OpenTelemetry.Context
 import qualified OpenTelemetry.Context as Context
 import OpenTelemetry.Context.ThreadLocal
 import OpenTelemetry.Internal.Trace.Types
-import OpenTelemetry.Trace.Core
 import System.IO.Unsafe (unsafePerformIO)
 
 

--- a/api/src/OpenTelemetry/Internal/Logs/Core.hs
+++ b/api/src/OpenTelemetry/Internal/Logs/Core.hs
@@ -41,7 +41,7 @@ import OpenTelemetry.Context.ThreadLocal
 import OpenTelemetry.Internal.Common.Types
 import OpenTelemetry.Internal.Logs.Types
 import OpenTelemetry.Internal.Trace.Types (SpanContext (..), getSpanContext)
-import OpenTelemetry.LogAttributes (LogAttributes, ToValue)
+import OpenTelemetry.LogAttributes (LogAttributes)
 import qualified OpenTelemetry.LogAttributes as LA
 import OpenTelemetry.Resource (MaterializedResources, emptyMaterializedResources)
 import Paths_hs_opentelemetry_api (version)

--- a/api/src/OpenTelemetry/Internal/Trace/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/Types.hs
@@ -8,18 +8,14 @@
 module OpenTelemetry.Internal.Trace.Types where
 
 import Control.Concurrent.Async (Async)
-import Control.Exception (SomeException)
 import Control.Monad.IO.Class
 import Data.Bits
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as H
-import Data.Hashable (Hashable)
 import Data.IORef (IORef, readIORef)
-import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Vector (Vector)
 import Data.Word (Word8)
-import GHC.Generics
 import Network.HTTP.Types (RequestHeaders, ResponseHeaders)
 import OpenTelemetry.Attributes
 import OpenTelemetry.Common

--- a/api/src/OpenTelemetry/LogAttributes.hs
+++ b/api/src/OpenTelemetry/LogAttributes.hs
@@ -21,15 +21,9 @@ module OpenTelemetry.LogAttributes (
   unsafeMergeLogAttributesIgnoringLimits,
 ) where
 
-import Data.ByteString (ByteString)
-import Data.Data (Data)
 import qualified Data.HashMap.Strict as H
-import Data.Hashable (Hashable)
-import Data.Int (Int64)
-import Data.String (IsString (..))
 import Data.Text (Text)
 import qualified Data.Text as T
-import GHC.Generics (Generic)
 import OpenTelemetry.Attributes (AttributeLimits (..), defaultAttributeLimits)
 import OpenTelemetry.Internal.Common.Types
 

--- a/api/src/OpenTelemetry/Util.hs
+++ b/api/src/OpenTelemetry/Util.hs
@@ -41,7 +41,6 @@ module OpenTelemetry.Util (
 import Control.Exception (SomeException)
 import qualified Control.Exception as EUnsafe
 import Control.Monad.IO.Unlift
-import Data.Foldable
 import Data.Kind
 import qualified Data.Vector as V
 import Foreign.C (CInt (..))

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -35,7 +35,7 @@ instance Exception TestException
 exceptionTest :: IO ()
 exceptionTest = do
   tp <- getGlobalTracerProvider
-  t <- OpenTelemetry.Trace.Core.getTracer tp "test" tracerOptions
+  let t = OpenTelemetry.Trace.Core.makeTracer tp "test" tracerOptions
   spanToCheck <- newIORef undefined
   handle (\(TestException _) -> pure ()) $ do
     inSpan' t "test" defaultSpanArguments $ \span -> do

--- a/examples/hspec/hspec-example.cabal
+++ b/examples/hspec/hspec-example.cabal
@@ -17,14 +17,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base
-    , hs-opentelemetry-api
-    , hs-opentelemetry-exporter-handle
-    , hs-opentelemetry-instrumentation-hspec
-    , hs-opentelemetry-sdk
-    , hspec
-    , text
-    , unliftio
+      base >=4.7 && <5
   default-language: Haskell2010
 
 test-suite test
@@ -38,7 +31,7 @@ test-suite test
       test
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base
+      base >=4.7 && <5
     , hs-opentelemetry-api
     , hs-opentelemetry-exporter-handle
     , hs-opentelemetry-instrumentation-hspec

--- a/examples/hspec/package.yaml
+++ b/examples/hspec/package.yaml
@@ -1,16 +1,7 @@
 name: hspec-example
 
 dependencies:
-# minimal example dependencies
-- base
-- hspec
-- unliftio
-- text
-# opentelemetry dependencies
-- hs-opentelemetry-sdk
-- hs-opentelemetry-api
-- hs-opentelemetry-exporter-handle
-- hs-opentelemetry-instrumentation-hspec
+- base >= 4.7 && < 5
 
 ghc-options:
   - -Wall
@@ -18,7 +9,16 @@ ghc-options:
 tests:
   test:
     dependencies:
+      # minimal example dependencies
+      - hspec
       - hspec-example
+      - text
+      - unliftio
+      # opentelemetry dependencies
+      - hs-opentelemetry-sdk
+      - hs-opentelemetry-api
+      - hs-opentelemetry-exporter-handle
+      - hs-opentelemetry-instrumentation-hspec
     main: Main.hs
     source-dirs:
       - test
@@ -26,5 +26,6 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+
 library:
   source-dirs: src

--- a/examples/hspec/test/Main.hs
+++ b/examples/hspec/test/Main.hs
@@ -5,7 +5,7 @@ import Data.Text (Text, unpack)
 import qualified OpenTelemetry.Context as Context
 import OpenTelemetry.Context.ThreadLocal (attachContext, getContext)
 import OpenTelemetry.Exporter.Handle.Span
-import OpenTelemetry.Instrumentation.Hspec (instrumentSpec, wrapSpec)
+import OpenTelemetry.Instrumentation.Hspec (instrumentSpec)
 import OpenTelemetry.Processor.Batch.Span
 import OpenTelemetry.Trace hiding (inSpan)
 import qualified OpenTelemetry.Trace as Trace

--- a/examples/hspec/test/TargetSpec.hs
+++ b/examples/hspec/test/TargetSpec.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 import TestTarget
 
 
+spec :: Spec
 spec = describe "adds two" $ do
   it "adds 2 to 2" $ do
     addTwo 2 `shouldBe` 4

--- a/examples/yesod-minimal/package.yaml
+++ b/examples/yesod-minimal/package.yaml
@@ -1,46 +1,32 @@
 name: yesod-minimal
 
 dependencies:
-# minimal example dependencies
-- base
-- bytestring
-- conduit
-- yesod-core
-- yesod-form
-- http-client
-- http-types
-- wai
-- warp
-- text
-- vault
-- unliftio
-# database
-- yesod-persistent
-- monad-logger
-- persistent >= 2.13.3
-- persistent-postgresql >= 2.13.4
-- persistent-qq
-- resource-pool
-# convenience
-- microlens
-# opentelemetry dependencies
-- hs-opentelemetry-sdk
-- hs-opentelemetry-exporter-handle
-- hs-opentelemetry-instrumentation-wai
-- hs-opentelemetry-instrumentation-yesod
-- hs-opentelemetry-instrumentation-http-client
-- hs-opentelemetry-instrumentation-persistent
-- hs-opentelemetry-instrumentation-postgresql-simple
-- hs-opentelemetry-propagator-w3c
-- hs-opentelemetry-exporter-otlp
+  - base >= 4.7 && < 5
 
 executables:
   yesod-minimal:
     main: Minimal
     source-dirs: src
-    dependencies:
-    - yesod-minimal
     ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
-
-library:
-    source-dirs: src
+    dependencies:
+      # minimal example dependencies
+      - bytestring
+      - conduit
+      - yesod-core
+      - warp
+      - text
+      - unliftio
+      # database
+      - yesod-persistent
+      - monad-logger
+      - persistent >= 2.13.3
+      - persistent-postgresql >= 2.13.4
+      - persistent-qq
+      - resource-pool
+      # opentelemetry dependencies
+      - hs-opentelemetry-sdk
+      - hs-opentelemetry-instrumentation-wai
+      - hs-opentelemetry-instrumentation-yesod
+      - hs-opentelemetry-instrumentation-http-client
+      - hs-opentelemetry-instrumentation-persistent
+      - hs-opentelemetry-instrumentation-postgresql-simple

--- a/examples/yesod-minimal/src/Minimal.hs
+++ b/examples/yesod-minimal/src/Minimal.hs
@@ -9,34 +9,30 @@
 module Minimal where
 
 import Conduit
-import Control.Monad.IO.Class
 import Control.Monad.Logger
 import qualified Data.ByteString.Lazy as L
-import Data.Conduit.List as CL
-import Data.Pool (Pool, withResource)
+import Data.Pool (Pool)
 import Data.Text (Text, pack)
 import Data.Text.Encoding (decodeUtf8)
 import Database.Persist.Postgresql
-import Database.Persist.Sql
+-- import Database.Persist.Sql
 import Database.Persist.Sql.Raw.QQ
-import Database.Persist.SqlBackend
+-- import Database.Persist.SqlBackend
 import Database.Persist.SqlBackend.SqlPoolHooks
 import GHC.Stack
-import Lens.Micro (lens)
-import Network.HTTP.Types
 import Network.Wai.Handler.Warp (run)
-import OpenTelemetry.Context (Context, HasContext (..))
-import qualified OpenTelemetry.Context as Context
-import OpenTelemetry.Context.ThreadLocal
-import OpenTelemetry.Exporter.OTLP.Span
+-- import OpenTelemetry.Context (Context, HasContext (..))
+-- import qualified OpenTelemetry.Context as Context
+-- import OpenTelemetry.Context.ThreadLocal
+-- import OpenTelemetry.Exporter.OTLP.Span
 import OpenTelemetry.Instrumentation.HttpClient
 import OpenTelemetry.Instrumentation.Persistent
 import OpenTelemetry.Instrumentation.PostgresqlSimple (staticConnectionAttributes)
 import OpenTelemetry.Instrumentation.Wai
 import OpenTelemetry.Instrumentation.Yesod
-import OpenTelemetry.Processor.Batch.Span
-import OpenTelemetry.Propagator.W3CBaggage
-import OpenTelemetry.Propagator.W3CTraceContext
+-- import OpenTelemetry.Processor.Batch.Span
+-- import OpenTelemetry.Propagator.W3CBaggage
+-- import OpenTelemetry.Propagator.W3CTraceContext
 import OpenTelemetry.Trace hiding (inSpan, inSpan', inSpan'')
 import OpenTelemetry.Trace.Monad
 import UnliftIO hiding (Handler)
@@ -44,7 +40,7 @@ import Yesod.Core (
   RenderRoute (..),
   Yesod (..),
   defaultYesodMiddleware,
-  getYesod,
+  -- getYesod,
   mkYesod,
   parseRoutes,
   toWaiApp,

--- a/examples/yesod-minimal/src/Minimal.hs
+++ b/examples/yesod-minimal/src/Minimal.hs
@@ -15,24 +15,15 @@ import Data.Pool (Pool)
 import Data.Text (Text, pack)
 import Data.Text.Encoding (decodeUtf8)
 import Database.Persist.Postgresql
--- import Database.Persist.Sql
 import Database.Persist.Sql.Raw.QQ
--- import Database.Persist.SqlBackend
 import Database.Persist.SqlBackend.SqlPoolHooks
 import GHC.Stack
 import Network.Wai.Handler.Warp (run)
--- import OpenTelemetry.Context (Context, HasContext (..))
--- import qualified OpenTelemetry.Context as Context
--- import OpenTelemetry.Context.ThreadLocal
--- import OpenTelemetry.Exporter.OTLP.Span
 import OpenTelemetry.Instrumentation.HttpClient
 import OpenTelemetry.Instrumentation.Persistent
 import OpenTelemetry.Instrumentation.PostgresqlSimple (staticConnectionAttributes)
 import OpenTelemetry.Instrumentation.Wai
 import OpenTelemetry.Instrumentation.Yesod
--- import OpenTelemetry.Processor.Batch.Span
--- import OpenTelemetry.Propagator.W3CBaggage
--- import OpenTelemetry.Propagator.W3CTraceContext
 import OpenTelemetry.Trace hiding (inSpan, inSpan', inSpan'')
 import OpenTelemetry.Trace.Monad
 import UnliftIO hiding (Handler)
@@ -40,7 +31,6 @@ import Yesod.Core (
   RenderRoute (..),
   Yesod (..),
   defaultYesodMiddleware,
-  -- getYesod,
   mkYesod,
   parseRoutes,
   toWaiApp,

--- a/examples/yesod-minimal/yesod-minimal.cabal
+++ b/examples/yesod-minimal/yesod-minimal.cabal
@@ -8,44 +8,6 @@ name:          yesod-minimal
 version:       0.0.0
 build-type:    Simple
 
-library
-  exposed-modules:
-      Minimal
-  other-modules:
-      Paths_yesod_minimal
-  hs-source-dirs:
-      src
-  build-depends:
-      base
-    , bytestring
-    , conduit
-    , hs-opentelemetry-exporter-handle
-    , hs-opentelemetry-exporter-otlp
-    , hs-opentelemetry-instrumentation-http-client
-    , hs-opentelemetry-instrumentation-persistent
-    , hs-opentelemetry-instrumentation-postgresql-simple
-    , hs-opentelemetry-instrumentation-wai
-    , hs-opentelemetry-instrumentation-yesod
-    , hs-opentelemetry-propagator-w3c
-    , hs-opentelemetry-sdk
-    , http-client
-    , http-types
-    , microlens
-    , monad-logger
-    , persistent >=2.13.3
-    , persistent-postgresql >=2.13.4
-    , persistent-qq
-    , resource-pool
-    , text
-    , unliftio
-    , vault
-    , wai
-    , warp
-    , yesod-core
-    , yesod-form
-    , yesod-persistent
-  default-language: Haskell2010
-
 executable yesod-minimal
   main-is: Minimal.hs
   other-modules:
@@ -54,21 +16,15 @@ executable yesod-minimal
       src
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N -main-is Minimal
   build-depends:
-      base
+      base >=4.7 && <5
     , bytestring
     , conduit
-    , hs-opentelemetry-exporter-handle
-    , hs-opentelemetry-exporter-otlp
     , hs-opentelemetry-instrumentation-http-client
     , hs-opentelemetry-instrumentation-persistent
     , hs-opentelemetry-instrumentation-postgresql-simple
     , hs-opentelemetry-instrumentation-wai
     , hs-opentelemetry-instrumentation-yesod
-    , hs-opentelemetry-propagator-w3c
     , hs-opentelemetry-sdk
-    , http-client
-    , http-types
-    , microlens
     , monad-logger
     , persistent >=2.13.3
     , persistent-postgresql >=2.13.4
@@ -76,11 +32,7 @@ executable yesod-minimal
     , resource-pool
     , text
     , unliftio
-    , vault
-    , wai
     , warp
     , yesod-core
-    , yesod-form
-    , yesod-minimal
     , yesod-persistent
   default-language: Haskell2010

--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -37,15 +37,3 @@ library
     , hs-opentelemetry-api >=0.0.3 && <0.2
     , text
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-exporter-handle-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_exporter_handle
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -9,9 +9,9 @@ version:        0.0.1.1
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
-author:         Ian Duncan, Jade Lovelace
+author:         Ian Duncan
 maintainer:     ian@iankduncan.com
-copyright:      2024 Ian Duncan, Mercury Technologies
+copyright:      2021 Ian Duncan
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -9,9 +9,9 @@ version:        0.0.1.1
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
-author:         Ian Duncan
+author:         Ian Duncan, Jade Lovelace
 maintainer:     ian@iankduncan.com
-copyright:      2021 Ian Duncan
+copyright:      2024 Ian Duncan, Mercury Technologies
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
@@ -48,7 +48,4 @@ test-suite hs-opentelemetry-exporter-handle-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-exporter-handle
-    , text
   default-language: Haskell2010

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -1,9 +1,10 @@
-_common/lib: !include "../../package-common.yaml"
-
 name:                hs-opentelemetry-exporter-handle
 version:             0.0.1.1
-
-<<: *preface
+github:              "iand675/hs-opentelemetry"
+license:             BSD3
+author:              "Ian Duncan"
+maintainer:          "ian@iankduncan.com"
+copyright:           "2021 Ian Duncan"
 
 extra-source-files:
 - README.md
@@ -16,22 +17,22 @@ extra-source-files:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description: Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
+description:         Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
 
 dependencies:
-  - base >= 4.7 && < 5
+- base >= 4.7 && < 5
 
 library:
   source-dirs: src
   dependencies:
-    - hs-opentelemetry-api >= 0.0.3 && < 0.2
-    - text
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - text
 
 tests:
   hs-opentelemetry-exporter-handle-test:
-    main: Spec.hs
-    source-dirs: test
+    main:                Spec.hs
+    source-dirs:         test
     ghc-options:
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -28,7 +28,8 @@ library:
   - hs-opentelemetry-api >= 0.0.3 && < 0.2
   - text
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-exporter-handle-test:
     main:                Spec.hs
     source-dirs:         test
@@ -36,3 +37,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-exporter-handle

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -1,10 +1,9 @@
+_common/lib: !include "../../package-common.yaml"
+
 name:                hs-opentelemetry-exporter-handle
 version:             0.0.1.1
-github:              "iand675/hs-opentelemetry"
-license:             BSD3
-author:              "Ian Duncan"
-maintainer:          "ian@iankduncan.com"
-copyright:           "2021 Ian Duncan"
+
+<<: *preface
 
 extra-source-files:
 - README.md
@@ -17,23 +16,22 @@ extra-source-files:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
+description: Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
 
 dependencies:
-- base >= 4.7 && < 5
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- text
+  - base >= 4.7 && < 5
 
 library:
   source-dirs: src
+  dependencies:
+    - hs-opentelemetry-api >= 0.0.3 && < 0.2
+    - text
 
 tests:
   hs-opentelemetry-exporter-handle-test:
-    main:                Spec.hs
-    source-dirs:         test
+    main: Spec.hs
+    source-dirs: test
     ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-exporter-handle
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N

--- a/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
+++ b/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
@@ -39,15 +39,3 @@ library
     , hs-opentelemetry-api >=0.0.3 && <0.2
     , unagi-chan
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-exporter-in-memory-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_exporter_in_memory
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
+++ b/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
@@ -49,9 +49,5 @@ test-suite hs-opentelemetry-exporter-in-memory-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      async
-    , base >=4.7 && <5
-    , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-exporter-in-memory
-    , unagi-chan
+      base >=4.7 && <5
   default-language: Haskell2010

--- a/exporters/in-memory/package.yaml
+++ b/exporters/in-memory/package.yaml
@@ -30,7 +30,8 @@ library:
   - async
   - unagi-chan
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-exporter-in-memory-test:
     main:                Spec.hs
     source-dirs:         test
@@ -38,3 +39,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-exporter-in-memory

--- a/exporters/in-memory/package.yaml
+++ b/exporters/in-memory/package.yaml
@@ -21,13 +21,14 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- async
-- unagi-chan
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - async
+  - unagi-chan
 
 tests:
   hs-opentelemetry-exporter-in-memory-test:
@@ -37,5 +38,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-exporter-in-memory

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -39,19 +39,16 @@ library
       base >=4.7 && <5
     , bytestring
     , case-insensitive
-    , clock
     , hs-opentelemetry-api >=0.0.3 && <0.2
     , hs-opentelemetry-otlp ==0.0.1.*
     , http-client
     , http-conduit
     , http-types
     , microlens
-    , mtl
     , proto-lens >=0.7.1.0
     , text
     , unordered-containers
     , vector
-    , vector-builder
     , zlib
   default-language: Haskell2010
 
@@ -65,21 +62,4 @@ test-suite hs-opentelemetry-exporter-otlp-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , case-insensitive
-    , clock
-    , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-exporter-otlp
-    , hs-opentelemetry-otlp ==0.0.1.*
-    , http-client
-    , http-conduit
-    , http-types
-    , microlens
-    , mtl
-    , proto-lens >=0.7.1.0
-    , text
-    , unordered-containers
-    , vector
-    , vector-builder
-    , zlib
   default-language: Haskell2010

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -51,15 +51,3 @@ library
     , vector
     , zlib
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-exporter-otlp-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_exporter_otlp
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -21,26 +21,24 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- hs-opentelemetry-otlp == 0.0.1.*
-- text
-- bytestring
-- case-insensitive
-- http-types
-- http-client
-- http-conduit
-- mtl
-- vector
-- vector-builder
-- proto-lens >= 0.7.1.0
-- microlens
-- clock
-- unordered-containers
-- zlib
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - bytestring
+  - case-insensitive
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-otlp == 0.0.1.*
+  - http-client
+  - http-conduit
+  - http-types
+  - microlens
+  - proto-lens >= 0.7.1.0
+  - text
+  - unordered-containers
+  - vector
+  - zlib
 
 tests:
   hs-opentelemetry-exporter-otlp-test:
@@ -50,5 +48,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-exporter-otlp

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -40,7 +40,8 @@ library:
   - vector
   - zlib
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-exporter-otlp-test:
     main:                Spec.hs
     source-dirs:         test
@@ -48,3 +49,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-exporter-otlp

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -281,9 +281,9 @@ otlpExporter conf = do
                 sendReq req (backoffCount + 1)
 
       case eResp of
-        Left err@(HttpExceptionRequest req e)
-          | HTTPClient.host req == "localhost"
-          , HTTPClient.port req == 4317 || HTTPClient.port req == 4318
+        Left err@(HttpExceptionRequest req' e)
+          | HTTPClient.host req' == "localhost"
+          , HTTPClient.port req' == 4317 || HTTPClient.port req' == 4318
           , ConnectionFailure _someExn <- e ->
               do
                 pure $ Failure Nothing

--- a/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
+++ b/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
@@ -35,7 +35,6 @@ library
     , case-insensitive
     , hs-opentelemetry-api ==0.1.*
     , hs-opentelemetry-instrumentation-wai
-    , http-types
     , text
     , unordered-containers
     , wai
@@ -51,12 +50,4 @@ test-suite cloudflare-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , case-insensitive
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-conduit
-    , hs-opentelemetry-instrumentation-wai
-    , http-types
-    , text
-    , unordered-containers
-    , wai
   default-language: Haskell2010

--- a/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
+++ b/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
@@ -39,15 +39,3 @@ library
     , unordered-containers
     , wai
   default-language: Haskell2010
-
-test-suite cloudflare-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_cloudflare
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/cloudflare/package.yaml
+++ b/instrumentation/cloudflare/package.yaml
@@ -20,16 +20,16 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- http-types
-- wai
-- hs-opentelemetry-api == 0.1.*
-- hs-opentelemetry-instrumentation-wai
-- case-insensitive
-- text
-- unordered-containers
 
 library:
   source-dirs: src
+  dependencies:
+  - case-insensitive
+  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-instrumentation-wai
+  - text
+  - unordered-containers
+  - wai
 
 tests:
   cloudflare-test:
@@ -39,5 +39,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-conduit

--- a/instrumentation/cloudflare/package.yaml
+++ b/instrumentation/cloudflare/package.yaml
@@ -31,7 +31,8 @@ library:
   - unordered-containers
   - wai
 
-tests:
+# Test suite not yet implemented
+_tests:
   cloudflare-test:
     main:                Spec.hs
     source-dirs:         test
@@ -39,3 +40,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-cloudflare

--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -48,8 +48,4 @@ test-suite hs-opentelemetry-instrumentation-conduit-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , conduit
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-conduit
-    , text
   default-language: Haskell2010

--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -37,15 +37,3 @@ library
     , hs-opentelemetry-api ==0.1.*
     , text
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-instrumentation-conduit-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_conduit
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -29,7 +29,8 @@ library:
   - text
   - hs-opentelemetry-api == 0.1.*
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-instrumentation-conduit-test:
     main:                Spec.hs
     source-dirs:         test
@@ -37,3 +38,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-conduit

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -20,13 +20,14 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- conduit
-- text
-- hs-opentelemetry-api == 0.1.*
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - conduit
+  - text
+  - hs-opentelemetry-api == 0.1.*
 
 tests:
   hs-opentelemetry-instrumentation-conduit-test:
@@ -36,5 +37,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-conduit

--- a/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
+++ b/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
@@ -37,15 +37,3 @@ library
     , mtl
     , text
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-hspec-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_hspec
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
+++ b/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
@@ -33,13 +33,9 @@ library
   build-depends:
       base >=4.7 && <5
     , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hspec >=2.9.4
     , hspec-core >=2.9.4
     , mtl
-    , resourcet
     , text
-    , unliftio
-    , vault
   default-language: Haskell2010
 
 test-suite hs-opentelemetry-hspec-test
@@ -52,13 +48,4 @@ test-suite hs-opentelemetry-hspec-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-instrumentation-hspec
-    , hspec >=2.9.4
-    , hspec-core >=2.9.4
-    , mtl
-    , resourcet
-    , text
-    , unliftio
-    , vault
   default-language: Haskell2010

--- a/instrumentation/hspec/package.yaml
+++ b/instrumentation/hspec/package.yaml
@@ -20,18 +20,15 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- hspec >= 2.9.4
-- hspec-core >= 2.9.4
-- text
-- vault
-- resourcet
-- unliftio # TODO, unliftio-core
-- mtl
 
 library:
   # ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hspec-core >= 2.9.4
+  - text
+  - mtl
 
 tests:
   hs-opentelemetry-hspec-test:
@@ -41,5 +38,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-hspec

--- a/instrumentation/hspec/package.yaml
+++ b/instrumentation/hspec/package.yaml
@@ -30,7 +30,8 @@ library:
   - text
   - mtl
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-hspec-test:
     main:                Spec.hs
     source-dirs:         test
@@ -38,3 +39,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-hspec

--- a/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
+++ b/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
@@ -48,15 +48,3 @@ library
     , unliftio
     , unordered-containers
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-instrumentation-http-client-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_http_client
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
+++ b/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
@@ -42,7 +42,6 @@ library
     , hs-opentelemetry-api ==0.1.*
     , hs-opentelemetry-instrumentation-conduit >=0.0.1 && <0.2
     , http-client
-    , http-client-tls
     , http-conduit
     , http-types
     , text
@@ -59,19 +58,5 @@ test-suite hs-opentelemetry-instrumentation-http-client-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson
-    , base >=4.7 && <5
-    , bytestring
-    , case-insensitive
-    , conduit
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-conduit >=0.0.1 && <0.2
-    , hs-opentelemetry-instrumentation-http-client
-    , http-client
-    , http-client-tls
-    , http-conduit
-    , http-types
-    , text
-    , unliftio
-    , unordered-containers
+      base >=4.7 && <5
   default-language: Haskell2010

--- a/instrumentation/http-client/package.yaml
+++ b/instrumentation/http-client/package.yaml
@@ -38,7 +38,8 @@ library:
   - unliftio
   - unordered-containers
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-instrumentation-http-client-test:
     main:                Spec.hs
     source-dirs:         test
@@ -46,3 +47,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-http-client

--- a/instrumentation/http-client/package.yaml
+++ b/instrumentation/http-client/package.yaml
@@ -20,23 +20,23 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- case-insensitive
-- conduit
-- http-client
-- http-client-tls
-- http-conduit
-- http-types
-- hs-opentelemetry-api == 0.1.*
-- text
-- bytestring
-- unliftio
-- aeson
-- hs-opentelemetry-instrumentation-conduit >= 0.0.1 && < 0.2
-- unordered-containers
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - aeson
+  - bytestring
+  - case-insensitive
+  - conduit
+  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-instrumentation-conduit >= 0.0.1 && < 0.2
+  - http-client
+  - http-conduit
+  - http-types
+  - text
+  - unliftio
+  - unordered-containers
 
 tests:
   hs-opentelemetry-instrumentation-http-client-test:
@@ -46,5 +46,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-http-client

--- a/instrumentation/persistent-mysql/hs-opentelemetry-instrumentation-persistent-mysql.cabal
+++ b/instrumentation/persistent-mysql/hs-opentelemetry-instrumentation-persistent-mysql.cabal
@@ -21,7 +21,6 @@ library
                  iproute,
                  monad-logger,
                  mysql,
-                 mysql-simple,
                  persistent,
                  persistent-mysql,
                  resource-pool,

--- a/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
+++ b/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
@@ -42,15 +42,3 @@ library
     , unordered-containers
     , vault
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-persistent-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_persistent
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
+++ b/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
@@ -53,14 +53,4 @@ test-suite hs-opentelemetry-persistent-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , clock
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-persistent
-    , mtl
-    , persistent >=2.13.3
-    , resourcet
-    , text
-    , unliftio
-    , unordered-containers
-    , vault
   default-language: Haskell2010

--- a/instrumentation/persistent/package.yaml
+++ b/instrumentation/persistent/package.yaml
@@ -20,19 +20,20 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- hs-opentelemetry-api == 0.1.*
-- persistent >= 2.13.3
-- text
-- vault
-- resourcet
-- unliftio # TODO, unliftio-core
-- mtl
-- unordered-containers
-- clock
 
 library:
   # ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - hs-opentelemetry-api == 0.1.*
+  - persistent >= 2.13.3
+  - text
+  - vault
+  - resourcet
+  - unliftio # TODO, unliftio-core
+  - mtl
+  - unordered-containers
+  - clock
 
 tests:
   hs-opentelemetry-persistent-test:
@@ -42,5 +43,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-persistent

--- a/instrumentation/persistent/package.yaml
+++ b/instrumentation/persistent/package.yaml
@@ -35,7 +35,8 @@ library:
   - unordered-containers
   - clock
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-persistent-test:
     main:                Spec.hs
     source-dirs:         test
@@ -43,3 +44,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-persistent

--- a/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
+++ b/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
@@ -42,15 +42,3 @@ library
     , unliftio-core
     , unordered-containers
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-instrumentation-postgresql-simple-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_postgresql_simple
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
+++ b/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
@@ -35,7 +35,6 @@ library
     , bytestring
     , hs-opentelemetry-api ==0.1.*
     , iproute
-    , network
     , postgresql-libpq
     , postgresql-simple
     , text
@@ -54,15 +53,4 @@ test-suite hs-opentelemetry-instrumentation-postgresql-simple-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-postgresql-simple
-    , iproute
-    , network
-    , postgresql-libpq
-    , postgresql-simple
-    , text
-    , unliftio
-    , unliftio-core
-    , unordered-containers
   default-language: Haskell2010

--- a/instrumentation/postgresql-simple/package.yaml
+++ b/instrumentation/postgresql-simple/package.yaml
@@ -34,7 +34,8 @@ library:
   - unliftio # todo, unliftio-core
   - unordered-containers
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-instrumentation-postgresql-simple-test:
     main:                Spec.hs
     source-dirs:         test
@@ -42,3 +43,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-postgresql-simple

--- a/instrumentation/postgresql-simple/package.yaml
+++ b/instrumentation/postgresql-simple/package.yaml
@@ -20,19 +20,19 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- hs-opentelemetry-api == 0.1.*
-- network
-- iproute
-- postgresql-simple
-- postgresql-libpq
-- text
-- bytestring
-- unliftio-core
-- unliftio # todo, unliftio-core
-- unordered-containers
 
 library:
   source-dirs: src
+  dependencies:
+  - hs-opentelemetry-api == 0.1.*
+  - iproute
+  - postgresql-simple
+  - postgresql-libpq
+  - text
+  - bytestring
+  - unliftio-core
+  - unliftio # todo, unliftio-core
+  - unordered-containers
 
 tests:
   hs-opentelemetry-instrumentation-postgresql-simple-test:
@@ -42,5 +42,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-postgresql-simple

--- a/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
+++ b/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
@@ -44,15 +44,3 @@ library
     , vault
     , wai
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-instrumentation-wai-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_wai
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
+++ b/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
@@ -35,7 +35,6 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , bytestring
     , hs-opentelemetry-api ==0.1.*
     , http-types
     , iproute
@@ -56,14 +55,4 @@ test-suite hs-opentelemetry-instrumentation-wai-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-wai
-    , http-types
-    , iproute
-    , network
-    , text
-    , unordered-containers
-    , vault
-    , wai
   default-language: Haskell2010

--- a/instrumentation/wai/package.yaml
+++ b/instrumentation/wai/package.yaml
@@ -34,7 +34,8 @@ library:
   - iproute
   - unordered-containers
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-instrumentation-wai-test:
     main:                Spec.hs
     source-dirs:         test
@@ -42,3 +43,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-wai

--- a/instrumentation/wai/package.yaml
+++ b/instrumentation/wai/package.yaml
@@ -20,19 +20,19 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- http-types
-- wai
-- hs-opentelemetry-api == 0.1.*
-- vault
-- text
-- bytestring
-- network
-- iproute
-- unordered-containers
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - http-types
+  - wai
+  - hs-opentelemetry-api == 0.1.*
+  - vault
+  - text
+  - network
+  - iproute
+  - unordered-containers
 
 tests:
   hs-opentelemetry-instrumentation-wai-test:
@@ -42,5 +42,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-wai

--- a/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
+++ b/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
@@ -45,15 +45,3 @@ library
     , wai
     , yesod-core
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-instrumentation-yesod-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_instrumentation_yesod
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
+++ b/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
@@ -38,7 +38,6 @@ library
     , hs-opentelemetry-api ==0.1.*
     , hs-opentelemetry-instrumentation-wai >=0.0.1 && <0.2
     , microlens
-    , mtl
     , template-haskell
     , text
     , unliftio
@@ -57,15 +56,4 @@ test-suite hs-opentelemetry-instrumentation-yesod-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-instrumentation-wai >=0.0.1 && <0.2
-    , hs-opentelemetry-instrumentation-yesod
-    , microlens
-    , mtl
-    , template-haskell
-    , text
-    , unliftio
-    , unordered-containers
-    , wai
-    , yesod-core
   default-language: Haskell2010

--- a/instrumentation/yesod/package.yaml
+++ b/instrumentation/yesod/package.yaml
@@ -20,20 +20,20 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- mtl
-- microlens
-- yesod-core
-- hs-opentelemetry-api == 0.1.*
-- hs-opentelemetry-instrumentation-wai >= 0.0.1 && < 0.2
-- unliftio
-- text
-- template-haskell
-- wai
-- unordered-containers
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-instrumentation-wai >= 0.0.1 && < 0.2
+  - microlens
+  - template-haskell
+  - text
+  - unliftio
+  - unordered-containers
+  - wai
+  - yesod-core
 
 tests:
   hs-opentelemetry-instrumentation-yesod-test:
@@ -43,5 +43,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-instrumentation-yesod

--- a/instrumentation/yesod/package.yaml
+++ b/instrumentation/yesod/package.yaml
@@ -35,7 +35,8 @@ library:
   - wai
   - yesod-core
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-instrumentation-yesod-test:
     main:                Spec.hs
     source-dirs:         test
@@ -43,3 +44,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-yesod

--- a/otlp/hs-opentelemetry-otlp.cabal
+++ b/otlp/hs-opentelemetry-otlp.cabal
@@ -81,6 +81,5 @@ library
       proto-lens-protoc:proto-lens-protoc
   build-depends:
       base >=4.7 && <5
-    , proto-lens
     , proto-lens-runtime
   default-language: Haskell2010

--- a/otlp/package.yaml
+++ b/otlp/package.yaml
@@ -28,7 +28,6 @@ build-tools: proto-lens-protoc:proto-lens-protoc
 
 dependencies:
 - base >= 4.7 && < 5
-- proto-lens
 - proto-lens-runtime
 
 library:

--- a/propagators/b3/hs-opentelemetry-propagator-b3.cabal
+++ b/propagators/b3/hs-opentelemetry-propagator-b3.cabal
@@ -42,15 +42,3 @@ library
     , http-types
     , text
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-propagator-b3-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_propagator_b3
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/propagators/b3/hs-opentelemetry-propagator-b3.cabal
+++ b/propagators/b3/hs-opentelemetry-propagator-b3.cabal
@@ -40,8 +40,6 @@ library
     , bytestring
     , hs-opentelemetry-api >=0.0.3 && <0.2
     , http-types
-    , memory
-    , primitive
     , text
   default-language: Haskell2010
 
@@ -54,13 +52,5 @@ test-suite hs-opentelemetry-propagator-b3-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      attoparsec
-    , base >=4.7 && <5
-    , bytestring
-    , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-propagator-b3
-    , http-types
-    , memory
-    , primitive
-    , text
+      base >=4.7 && <5
   default-language: Haskell2010

--- a/propagators/b3/package.yaml
+++ b/propagators/b3/package.yaml
@@ -20,18 +20,17 @@ category:            OpenTelemetry, Tracing, Web
 description:         Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/propagators/b3#readme>
 
 dependencies:
-- attoparsec
-- base >=4.7 && <5
-- bytestring
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- http-types
-- memory
-- primitive
-- text
+- base >= 4.7 && < 5
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - attoparsec
+  - bytestring
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - http-types
+  - text
 
 tests:
   hs-opentelemetry-propagator-b3-test:
@@ -41,5 +40,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-propagator-b3

--- a/propagators/b3/package.yaml
+++ b/propagators/b3/package.yaml
@@ -32,7 +32,8 @@ library:
   - http-types
   - text
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-propagator-b3-test:
     main:                Spec.hs
     source-dirs:         test
@@ -40,3 +41,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-propagator-b3

--- a/propagators/datadog/old-src/Raw.hs
+++ b/propagators/datadog/old-src/Raw.hs
@@ -128,12 +128,12 @@ indexByteArrayNbo ba offset =
 
 
 showWord64BS :: Word64 -> ByteString
-showWord64BS v =
+showWord64BS value =
   unsafeDupablePerformIO $
     BI.createUptoN 20 writeWord64Ptr -- 20 = length (show (maxBound :: Word64))
   where
     writeWord64Ptr ptr =
-      loop (19 :: Int) v 0 False
+      loop (19 :: Int) value 0 False
       where
         loop 0 v offset _ = do
           writeOffPtr ptr offset (word8ToAsciiWord8 $ fromIntegral v)

--- a/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
+++ b/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
@@ -23,6 +23,15 @@ source-repository head
   type: git
   location: https://github.com/iand675/hs-opentelemetry
 
+library
+  other-modules:
+      Paths_hs_opentelemetry_propagator_jaeger
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+  default-language: Haskell2010
+
 test-suite hs-opentelemetry-propagator-jaeger-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs

--- a/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
+++ b/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
@@ -23,15 +23,6 @@ source-repository head
   type: git
   location: https://github.com/iand675/hs-opentelemetry
 
-library
-  other-modules:
-      Paths_hs_opentelemetry_propagator_jaeger
-  hs-source-dirs:
-      src
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010
-
 test-suite hs-opentelemetry-propagator-jaeger-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs

--- a/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
+++ b/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
@@ -22,25 +22,3 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/iand675/hs-opentelemetry
-
-library
-  other-modules:
-      Paths_hs_opentelemetry_propagator_jaeger
-  hs-source-dirs:
-      src
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010
-
-test-suite hs-opentelemetry-propagator-jaeger-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_propagator_jaeger
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-    , hs-opentelemetry-propagator-jaeger
-  default-language: Haskell2010

--- a/propagators/jaeger/package.yaml
+++ b/propagators/jaeger/package.yaml
@@ -22,8 +22,8 @@ description:         Please see the README on GitHub at <https://github.com/iand
 dependencies:
 - base >= 4.7 && < 5
 
-library:
-  source-dirs: src
+# library:
+#   source-dirs: src
 
 tests:
   hs-opentelemetry-propagator-jaeger-test:

--- a/propagators/jaeger/package.yaml
+++ b/propagators/jaeger/package.yaml
@@ -22,10 +22,12 @@ description:         Please see the README on GitHub at <https://github.com/iand
 dependencies:
 - base >= 4.7 && < 5
 
-library:
+# Library not yet implemented
+_library:
   source-dirs: src
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-propagator-jaeger-test:
     main:                Spec.hs
     source-dirs:         test

--- a/propagators/jaeger/package.yaml
+++ b/propagators/jaeger/package.yaml
@@ -22,8 +22,8 @@ description:         Please see the README on GitHub at <https://github.com/iand
 dependencies:
 - base >= 4.7 && < 5
 
-# library:
-#   source-dirs: src
+library:
+  source-dirs: src
 
 tests:
   hs-opentelemetry-propagator-jaeger-test:

--- a/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
+++ b/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
@@ -40,7 +40,6 @@ library
     , bytestring
     , hs-opentelemetry-api >=0.0.3 && <0.2
     , http-types
-    , text
   default-language: Haskell2010
 
 test-suite hs-opentelemetry-propagator-w3c-test
@@ -52,11 +51,5 @@ test-suite hs-opentelemetry-propagator-w3c-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      attoparsec
-    , base >=4.7 && <5
-    , bytestring
-    , hs-opentelemetry-api >=0.0.3 && <0.2
-    , hs-opentelemetry-propagator-w3c
-    , http-types
-    , text
+      base >=4.7 && <5
   default-language: Haskell2010

--- a/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
+++ b/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
@@ -41,15 +41,3 @@ library
     , hs-opentelemetry-api >=0.0.3 && <0.2
     , http-types
   default-language: Haskell2010
-
-test-suite hs-opentelemetry-propagator-w3c-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
-  other-modules:
-      Paths_hs_opentelemetry_propagator_w3c
-  hs-source-dirs:
-      test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-depends:
-      base >=4.7 && <5
-  default-language: Haskell2010

--- a/propagators/w3c/package.yaml
+++ b/propagators/w3c/package.yaml
@@ -30,7 +30,8 @@ library:
   - http-types
   - attoparsec
 
-tests:
+# Test suite not yet implemented
+_tests:
   hs-opentelemetry-propagator-w3c-test:
     main:                Spec.hs
     source-dirs:         test
@@ -38,3 +39,5 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-propagator-w3c

--- a/propagators/w3c/package.yaml
+++ b/propagators/w3c/package.yaml
@@ -20,15 +20,15 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- bytestring
-- text
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- http-types
-- attoparsec
 
 library:
   ghc-options: -Wall
   source-dirs: src
+  dependencies:
+  - bytestring
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - http-types
+  - attoparsec
 
 tests:
   hs-opentelemetry-propagator-w3c-test:
@@ -38,5 +38,3 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
-    dependencies:
-    - hs-opentelemetry-propagator-w3c

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -129,4 +129,5 @@ test-suite hs-opentelemetry-sdk-test
     , hs-opentelemetry-sdk
     , hspec
     , text
+    , unordered-containers
   default-language: Haskell2010

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -91,16 +91,12 @@ library
     , random >=1.2.0
     , stm
     , text
-    , transformers
     , unagi-chan
     , unix-compat >=0.7.1
     , unordered-containers
     , vector
     , vector-builder
   default-language: Haskell2010
-  if !os(windows)
-    build-depends:
-        unix
   if os(windows)
     other-modules:
         OpenTelemetry.Platform
@@ -111,6 +107,8 @@ library
         OpenTelemetry.Platform
     hs-source-dirs:
         src/platform/unix
+    build-depends:
+        unix
 
 test-suite hs-opentelemetry-sdk-test
   type: exitcode-stdio-1.0
@@ -125,29 +123,10 @@ test-suite hs-opentelemetry-sdk-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      async
-    , base >=4.7 && <5
-    , bytestring
+      base >=4.7 && <5
     , clock
     , hs-opentelemetry-api
-    , hs-opentelemetry-exporter-otlp ==0.0.1.*
-    , hs-opentelemetry-propagator-b3 ==0.0.1.*
-    , hs-opentelemetry-propagator-datadog ==0.0.0.*
-    , hs-opentelemetry-propagator-w3c ==0.0.1.*
     , hs-opentelemetry-sdk
     , hspec
-    , http-types
-    , network-bsd
-    , random >=1.2.0
-    , stm
     , text
-    , transformers
-    , unagi-chan
-    , unix-compat >=0.7.1
-    , unordered-containers
-    , vector
-    , vector-builder
   default-language: Haskell2010
-  if !os(windows)
-    build-depends:
-        unix

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -21,30 +21,6 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- bytestring
-- text
-# These are "distribution" packages
-- hs-opentelemetry-api >= 0.0.3 && < 0.2
-- hs-opentelemetry-propagator-w3c == 0.0.1.*
-- hs-opentelemetry-exporter-otlp == 0.0.1.*
-- hs-opentelemetry-propagator-b3 ==0.0.1.*
-- hs-opentelemetry-propagator-datadog ==0.0.0.*
-
-- async
-- vector
-- stm
-- unagi-chan
-- unordered-containers
-- vector-builder
-- http-types
-- network-bsd
-- unix-compat >= 0.7.1 # for getProcessID
-- transformers
-- random >= 1.2.0
-
-when:
-  condition: '!os(windows)'
-  dependencies: unix # for getEffectiveUserID
 
 library:
   ghc-options: -Wall
@@ -55,6 +31,26 @@ library:
         source-dirs: src/platform/windows
       else:
         source-dirs: src/platform/unix
+        dependencies: unix # for getEffectiveUserID
+  dependencies:
+  - async
+  - bytestring
+  - http-types
+  - network-bsd
+  - random >= 1.2.0
+  - stm
+  - text
+  - unagi-chan
+  - unix-compat >= 0.7.1 # for getProcessID
+  - unordered-containers
+  - vector
+  - vector-builder
+  # These are "distribution" packages
+  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-propagator-w3c == 0.0.1.*
+  - hs-opentelemetry-exporter-otlp == 0.0.1.*
+  - hs-opentelemetry-propagator-b3 ==0.0.1.*
+  - hs-opentelemetry-propagator-datadog ==0.0.0.*
   reexported-modules:
     - OpenTelemetry.Attributes
     - OpenTelemetry.Baggage
@@ -99,7 +95,8 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hspec
-    - hs-opentelemetry-sdk
-    - hs-opentelemetry-api
     - clock
+    - hs-opentelemetry-api
+    - hs-opentelemetry-sdk
+    - hspec
+    - text

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -100,3 +100,4 @@ tests:
     - hs-opentelemetry-sdk
     - hspec
     - text
+    - unordered-containers

--- a/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
+++ b/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
@@ -48,8 +48,4 @@ test-suite exceptions-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , exceptions
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-sdk ==0.0.3.*
-    , text
   default-language: Haskell2010

--- a/utils/exceptions/package.yaml
+++ b/utils/exceptions/package.yaml
@@ -20,13 +20,14 @@ description:         Please see the README on GitHub at <https://github.com/iand
 
 dependencies:
 - base >= 4.7 && < 5
-- hs-opentelemetry-api == 0.1.*
-- hs-opentelemetry-sdk == 0.0.3.*
-- text
-- exceptions
 
 library:
   source-dirs: src
+  dependencies:
+  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-sdk == 0.0.3.*
+  - text
+  - exceptions
 
 tests:
   exceptions-test:

--- a/vendors/honeycomb/hs-opentelemetry-vendor-honeycomb.cabal
+++ b/vendors/honeycomb/hs-opentelemetry-vendor-honeycomb.cabal
@@ -60,17 +60,8 @@ test-suite test
       hspec-discover:hspec-discover
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , honeycomb >=0.1.0.1
     , hs-opentelemetry-api
     , hs-opentelemetry-vendor-honeycomb
     , hspec
-    , hspec-core
-    , hspec-expectations
-    , mtl
-    , text
     , time
-    , transformers
-    , unordered-containers
-    , uri-bytestring
   default-language: Haskell2010

--- a/vendors/honeycomb/package.yaml
+++ b/vendors/honeycomb/package.yaml
@@ -46,19 +46,19 @@ ghc-options:
 
 dependencies:
 - base >= 4.7 && < 5
-- bytestring
-- hs-opentelemetry-api
-- honeycomb >= 0.1.0.1
-- unordered-containers
-- text
-- mtl
-- time
-- transformers
-- uri-bytestring
 
 library:
   source-dirs: src
-
+  dependencies:
+  - bytestring
+  - honeycomb >= 0.1.0.1
+  - hs-opentelemetry-api
+  - mtl
+  - text
+  - time
+  - transformers
+  - unordered-containers
+  - uri-bytestring
 
 tests:
   test:
@@ -76,7 +76,7 @@ tests:
       hspec-discover
 
     dependencies:
-      - hspec
-      - hspec-core
-      - hspec-expectations
+      - hs-opentelemetry-api
       - hs-opentelemetry-vendor-honeycomb
+      - hspec
+      - time


### PR DESCRIPTION
This PR proposes to:
- Remove all orphan Haskell dependencies.
- Leave `base` as the only shared dependency for libraries, executables and tests.
- Remove all the unused or commented Haskell imports.
- Disable `tests` sections in `package.yaml` when tests are not yet implemented.
- Fix some minor Haskell warnings/deprecations.