### PR TITLE
Fix resource merge

### DIFF
--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -110,8 +110,10 @@ test-suite hs-opentelemetry-api-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      OpenTelemetry.AttributesSpec
       OpenTelemetry.BaggageSpec
       OpenTelemetry.Logs.CoreSpec
+      OpenTelemetry.ResourceSpec
       OpenTelemetry.SemanticsConfigSpec
       OpenTelemetry.Trace.SamplerSpec
       OpenTelemetry.Trace.TraceFlagsSpec

--- a/api/src/OpenTelemetry/Attributes.hs
+++ b/api/src/OpenTelemetry/Attributes.hs
@@ -260,8 +260,13 @@ instance (ToPrimitiveAttribute a) => ToAttribute [a] where
   toAttribute = AttributeArray . map toPrimitiveAttribute
 
 
+-- | Left-biased merge.
 unsafeMergeAttributesIgnoringLimits :: Attributes -> Attributes -> Attributes
-unsafeMergeAttributesIgnoringLimits (Attributes l lc ld) (Attributes r rc rd) = Attributes (l <> r) (lc + rc) (ld + rd)
+unsafeMergeAttributesIgnoringLimits left right = Attributes hm c d
+  where
+    hm = attributes left <> attributes right
+    c = H.size hm
+    d = attributesDropped left + attributesDropped right
 
 
 unsafeAttributesFromListIgnoringLimits :: [(Text, Attribute)] -> Attributes

--- a/api/test/OpenTelemetry/AttributesSpec.hs
+++ b/api/test/OpenTelemetry/AttributesSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module OpenTelemetry.AttributesSpec where
+
+import qualified Data.Text as T
+import qualified OpenTelemetry.Attributes as A
+import qualified Test.Hspec as Hspec
+
+
+spec :: Hspec.Spec
+spec = Hspec.describe "Attributes" $ do
+  Hspec.describe "addAttribute" $ do
+    let overwritesPrevious :: (A.ToAttribute a) => T.Text -> a -> a -> A.Attributes -> Hspec.Spec
+        overwritesPrevious attrKey newValue prevValue attrs = do
+          let addAttr = addAttributeDefault attrKey
+          Hspec.it "Overwrites previous value with new value at this key." $
+            addAttr newValue (addAttr prevValue attrs) `Hspec.shouldBe` addAttr newValue attrs
+
+    overwritesPrevious Example ("new value" :: T.Text) "prev value" A.emptyAttributes
+  Hspec.describe "unsafeMergeAttributesIgnoringLimits" $ do
+    Hspec.it "Is left-biased when keys conflict" $ do
+      let left = addAttributeDefault Example (1 :: Int) A.emptyAttributes
+          right = addAttributeDefault Example (2 :: Int) A.emptyAttributes
+      A.unsafeMergeAttributesIgnoringLimits left right `Hspec.shouldBe` left
+
+
+pattern Example :: T.Text
+pattern Example = "example"
+
+
+addAttributeDefault :: (A.ToAttribute a) => T.Text -> a -> A.Attributes -> A.Attributes
+addAttributeDefault attrKey value attrs = A.addAttribute A.defaultAttributeLimits attrs attrKey value

--- a/api/test/OpenTelemetry/ResourceSpec.hs
+++ b/api/test/OpenTelemetry/ResourceSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module OpenTelemetry.ResourceSpec where
+
+import qualified Data.Text as T
+import qualified OpenTelemetry.Resource as R
+import qualified Test.Hspec as Hspec
+
+
+spec :: Hspec.Spec
+spec = Hspec.describe "Resource" $ do
+  Hspec.describe "mergeResources" $ do
+    Hspec.it "Is left-biased when attribute keys conflict" $ do
+      let right = mkExampleResource "Old Right" 3
+          left = mkExampleResource "New Left" 7
+      R.materializeResources (R.mergeResources left right) `Hspec.shouldBe` R.materializeResources left
+
+  Hspec.describe "Semigroup.<>" $ do
+    Hspec.it "Is left-biased when attribute keys conflict" $ do
+      let right = mkExampleResource "Old Right" 3
+          left = mkExampleResource "New Left" 7
+      R.materializeResources (left <> right) `Hspec.shouldBe` R.materializeResources left
+
+
+mkExampleResource :: T.Text -> Int -> R.Resource 'Nothing
+mkExampleResource name count =
+  R.mkResource [ExampleName R..= name, ExampleCount R..= count]
+
+
+pattern ExampleName :: T.Text
+pattern ExampleName = "example.name"
+
+
+pattern ExampleCount :: T.Text
+pattern ExampleCount = "example.count"

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -11,9 +11,11 @@ import qualified Data.Vector as V
 import OpenTelemetry.Attributes (lookupAttribute)
 -- Specs
 
+import qualified OpenTelemetry.AttributesSpec as Attributes
 import qualified OpenTelemetry.BaggageSpec as Baggage
 import OpenTelemetry.Context
 import qualified OpenTelemetry.Logs.CoreSpec as CoreSpec
+import qualified OpenTelemetry.ResourceSpec as Resource
 import qualified OpenTelemetry.SemanticsConfigSpec as SemanticsConfigSpec
 import OpenTelemetry.Trace.Core
 import qualified OpenTelemetry.Trace.SamplerSpec as Sampler
@@ -53,7 +55,9 @@ main = hspec $ do
   -- describe "inSpan" $ do
   --   it "records exceptions" $ do
   --     exceptionTest
+  Attributes.spec
   Baggage.spec
+  Resource.spec
   Sampler.spec
   TraceFlags.spec
   SemanticsConfigSpec.spec

--- a/sdk/test/Spec.hs
+++ b/sdk/test/Spec.hs
@@ -11,6 +11,8 @@ main :: IO ()
 main = do
   -- For the attribute length limit test
   setEnv "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT" "50"
+  -- For the resource attributes initialization test
+  setEnv "OTEL_RESOURCE_ATTRIBUTES" "host.name=env_host_name,example.name=env_example_name,example.count=42"
   initializeGlobalTracerProvider
   hspec $ do
     BaggageSpec.spec


### PR DESCRIPTION
Fixes #111

- Re-order the Resource merge in `getTracerProviderInitializationOptions'` so that built-in resource attributes are _lowest_ priority rather than _highest_.
  - Enables overriding built-in resources with OTEL_RESOURCE_ATTRIBUTES environment variable.
  - Enables overriding OTEL_RESOURCE_ATTRIBUTES and built-ins with the user resource provided as an argument to `getTracerProviderInitializationOptions'`.
- Add unit tests and documentation to establish the left-biased nature of `Attributes` and `Resource`: when two attribute keys conflict, the value of the leftmost element is used.
- Fix bug in `unsafeMergeAttributesIgnoringLimits` where attribute count can get out of sync with actual size of the HashMap. Instead of adding the sizes of the inputs, simply take the size of the resulting HashMap. This is the approach used in the neighboring function `unsafeAttributesFromListIgnoringLimits`. Taking the size is $O(n)$ for HashMap, so may want to use Data.Map instead.