### PR TITLE
Prepare release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,0 @@
-# Changelog for opentelemetry-haskell
-
-## Unreleased changes

--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for hs-opentelemetry-api
 
-## Unreleased changes
+## 0.2.0.0
 
 - `callerAttributes` and `ownCodeAttributes` now work properly if the call stack has been frozen. Hence most
   span-construction functions should now get correct source code attributes in this situation also (#137.

--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -8,7 +8,7 @@
 - Fixed precedence order of resource merge (#156).
 - Added the ability to add links to spans after creation (#152).
 - Correctly compute attribute length limits (#151).
-- Add helper for reading boolean environment variables correctly.
+- Add helper for reading boolean environment variables correctly (#11).
 - Initial scaffolding for logging support. Renamed `Processor` to `SpanProcessor`.
 - Export `FlushResult` (#960
 - Use `HashMap Text Attribute` instead of `[(Text, Attribute)]` as attributes

--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -3,11 +3,16 @@
 ## Unreleased changes
 
 - `callerAttributes` and `ownCodeAttributes` now work properly if the call stack has been frozen. Hence most
-  span-construction functions should now get correct source code attributes in this situation also.
-
-## 0.1.0.0
-
+  span-construction functions should now get correct source code attributes in this situation also (#137.
+- Added `detectInstrumentationLibrary` for producing `InstrumentationLibrary`s with TH (#2).
+- Fixed precedence order of resource merge (#156).
+- Added the ability to add links to spans after creation (#152).
+- Correctly compute attribute length limits (#151).
+- Add helper for reading boolean environment variables correctly.
+- Initial scaffolding for logging support. Renamed `Processor` to `SpanProcessor`.
+- Export `FlushResult` (#960
 - Use `HashMap Text Attribute` instead of `[(Text, Attribute)]` as attributes
+- Improved conformance with semantic conventions.
 
 ## 0.0.3.6
 

--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-api
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           OpenTelemetry API for use by libraries for direct instrumentation or wrapper packages.
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/api#readme>
 category:           OpenTelemetry, Telemetry, Monitoring, Observability, Metrics

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../package-common.yaml"
 
 name:                hs-opentelemetry-api
-version:             0.1.0.0
+version:             0.2.0.0
 
 <<: *preface
 

--- a/exporters/handle/ChangeLog.md
+++ b/exporters/handle/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for hs-opentelemetry-exporter-handle
 
-## Unreleased changes
+## 0.0.1.2
+
+- Support newer dependencies
 
 ## 0.0.1.1
 

--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-handle
-version:        0.0.1.1
+version:        0.0.1.2
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues

--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -34,6 +34,6 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , text
   default-language: Haskell2010

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -1,5 +1,5 @@
 name:                hs-opentelemetry-exporter-handle
-version:             0.0.1.1
+version:             0.0.1.2
 github:              "iand675/hs-opentelemetry"
 license:             BSD3
 author:              "Ian Duncan"

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -25,7 +25,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2 
   - text
 
 # Test suite not yet implemented

--- a/exporters/in-memory/ChangeLog.md
+++ b/exporters/in-memory/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for hs-opentelemetry-exporter-in-memory
 
+## 0.0.1.2 
+
+- Support newer dependencies
+
 ## 0.0.1.1
 
 - Support hs-opentelemetry-api-0.0.2.0

--- a/exporters/in-memory/ChangeLog.md
+++ b/exporters/in-memory/ChangeLog.md
@@ -11,4 +11,3 @@
 ## 0.0.1.0
 
 - Initial release
-## Unreleased changes

--- a/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
+++ b/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-in-memory
-version:        0.0.1.3
+version:        0.0.1.4
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/in-memory#readme>
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues

--- a/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
+++ b/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
@@ -36,6 +36,6 @@ library
   build-depends:
       async
     , base >=4.7 && <5
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , unagi-chan
   default-language: Haskell2010

--- a/exporters/in-memory/package.yaml
+++ b/exporters/in-memory/package.yaml
@@ -26,7 +26,7 @@ library:
   ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2
   - async
   - unagi-chan
 

--- a/exporters/in-memory/package.yaml
+++ b/exporters/in-memory/package.yaml
@@ -1,5 +1,5 @@
 name:                hs-opentelemetry-exporter-in-memory
-version:             0.0.1.3
+version:             0.0.1.4
 github:              "iand675/hs-opentelemetry"
 license:             BSD3
 author:              "Ian Duncan"

--- a/exporters/otlp/ChangeLog.md
+++ b/exporters/otlp/ChangeLog.md
@@ -1,12 +1,11 @@
 # Changelog for hs-opentelemetry-exporter-otlp
 
-## 0.0.2.0
+## Unreleased
 
 - Export dropped span, link, event, and attribute counts
-- Upgrade to account for interfaces changed in hs-opentelemetry-api-0.0.2.0
 - Add gzip compression support
+- Swallow errors from sending data to localhost
 
 ## 0.0.1.0
 
 - Initial release
-## Unreleased changes

--- a/exporters/otlp/ChangeLog.md
+++ b/exporters/otlp/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for hs-opentelemetry-exporter-otlp
 
-## Unreleased
+## 0.1.0.0
 
 - Export dropped span, link, event, and attribute counts
 - Add gzip compression support

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-otlp
-version:        0.0.1.5
+version:        0.1.0.0
 synopsis:       OpenTelemetry exporter supporting the standard OTLP protocol
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/otlp#readme>
 category:       OpenTelemetry, Telemetry, Monitoring, Observability, Metrics

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -39,7 +39,7 @@ library
       base >=4.7 && <5
     , bytestring
     , case-insensitive
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , hs-opentelemetry-otlp ==0.0.1.*
     , http-client
     , http-conduit

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -40,7 +40,7 @@ library
     , bytestring
     , case-insensitive
     , hs-opentelemetry-api ==0.2.*
-    , hs-opentelemetry-otlp ==0.0.1.*
+    , hs-opentelemetry-otlp ==0.1.*
     , http-client
     , http-conduit
     , http-types

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -28,7 +28,7 @@ library:
   dependencies:
   - bytestring
   - case-insensitive
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2 
   - hs-opentelemetry-otlp == 0.0.1.*
   - http-client
   - http-conduit

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -1,5 +1,5 @@
 name:                hs-opentelemetry-exporter-otlp
-version:             0.0.1.5
+version:             0.1.0.0
 github:              "iand675/hs-opentelemetry"
 license:             BSD3
 author:              "Ian Duncan"

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -29,7 +29,7 @@ library:
   - bytestring
   - case-insensitive
   - hs-opentelemetry-api ^>= 0.2 
-  - hs-opentelemetry-otlp == 0.0.1.*
+  - hs-opentelemetry-otlp ^>= 0.1
   - http-client
   - http-conduit
   - http-types

--- a/instrumentation/cloudflare/ChangeLog.md
+++ b/instrumentation/cloudflare/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for cloudflare
 
-## Unreleased changes
+## 0.2.0.1
+
+- Support newer dependencies
 
 ## 0.2.0.0
 

--- a/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
+++ b/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-cloudflare
-version:            0.2.0.0
+version:            0.2.0.1
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/cloudflare#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
+++ b/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , case-insensitive
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , hs-opentelemetry-instrumentation-wai
     , text
     , unordered-containers

--- a/instrumentation/cloudflare/package.yaml
+++ b/instrumentation/cloudflare/package.yaml
@@ -25,7 +25,7 @@ library:
   source-dirs: src
   dependencies:
   - case-insensitive
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
   - hs-opentelemetry-instrumentation-wai
   - text
   - unordered-containers

--- a/instrumentation/cloudflare/package.yaml
+++ b/instrumentation/cloudflare/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-cloudflare
-version:             0.2.0.0
+version:             0.2.0.1
 
 <<: *preface
 

--- a/instrumentation/conduit/ChangeLog.md
+++ b/instrumentation/conduit/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for hs-opentelemetry-instrumentation-conduit
 
-## Unreleased changes
+## 0.1.0.1
+
+- Support newer dependencies
 
 ## 0.1.0.0
 

--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-conduit
-version:            0.1.0.0
+version:            0.1.0.1
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/conduit#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -34,6 +34,6 @@ library
   build-depends:
       base >=4.7 && <5
     , conduit
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , text
   default-language: Haskell2010

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-conduit
-version:             0.1.0.0
+version:             0.1.0.1
 
 <<: *preface
 

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -27,7 +27,7 @@ library:
   dependencies:
   - conduit
   - text
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
 
 # Test suite not yet implemented
 _tests:

--- a/instrumentation/hspec/ChangeLog.md
+++ b/instrumentation/hspec/ChangeLog.md
@@ -1,7 +1,9 @@
 # Changelog for hs-opentelemetry-instrumentation-hspec
 
+## 0.0.1.2
+
+- Support newer dependencies
+
 ## 0.0.1.0
 
 - Initial release
-
-## Unreleased changes

--- a/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
+++ b/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
@@ -32,7 +32,7 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , hspec-core >=2.9.4
     , mtl
     , text

--- a/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
+++ b/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-hspec
-version:            0.0.1.1
+version:            0.0.1.2
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/hspec#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/instrumentation/hspec/package.yaml
+++ b/instrumentation/hspec/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-hspec
-version:             0.0.1.1
+version:             0.0.1.2
 
 <<: *preface
 

--- a/instrumentation/hspec/package.yaml
+++ b/instrumentation/hspec/package.yaml
@@ -25,7 +25,7 @@ library:
   # ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2
   - hspec-core >= 2.9.4
   - text
   - mtl

--- a/instrumentation/http-client/ChangeLog.md
+++ b/instrumentation/http-client/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for hs-opentelemetry-instrumentation-http-client
 
-## Unreleased changes
+## 0.1.0.1
+
+- Support newer dependencies
 
 ## 0.1.0.0
 

--- a/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
+++ b/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
@@ -39,7 +39,7 @@ library
     , bytestring
     , case-insensitive
     , conduit
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , hs-opentelemetry-instrumentation-conduit >=0.0.1 && <0.2
     , http-client
     , http-conduit

--- a/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
+++ b/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-http-client
-version:            0.1.0.0
+version:            0.1.0.1
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/http-client#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/instrumentation/http-client/package.yaml
+++ b/instrumentation/http-client/package.yaml
@@ -29,7 +29,7 @@ library:
   - bytestring
   - case-insensitive
   - conduit
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
   - hs-opentelemetry-instrumentation-conduit >= 0.0.1 && < 0.2
   - http-client
   - http-conduit

--- a/instrumentation/http-client/package.yaml
+++ b/instrumentation/http-client/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-http-client
-version:             0.1.0.0
+version:             0.1.0.1
 
 <<: *preface
 

--- a/instrumentation/persistent/ChangeLog.md
+++ b/instrumentation/persistent/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for hs-opentelemetry-persistent
 
-## Unreleased changes
+## 0.1.0.1
+
+- Support newer dependencies
 
 ## 0.1.0.0
 

--- a/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
+++ b/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , clock
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , mtl
     , persistent >=2.13.3
     , resourcet

--- a/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
+++ b/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-persistent
-version:            0.1.0.0
+version:            0.1.0.1
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/persistent#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/instrumentation/persistent/package.yaml
+++ b/instrumentation/persistent/package.yaml
@@ -25,7 +25,7 @@ library:
   # ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
   - persistent >= 2.13.3
   - text
   - vault

--- a/instrumentation/persistent/package.yaml
+++ b/instrumentation/persistent/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-persistent
-version:             0.1.0.0
+version:             0.1.0.1
 
 <<: *preface
 

--- a/instrumentation/postgresql-simple/ChangeLog.md
+++ b/instrumentation/postgresql-simple/ChangeLog.md
@@ -1,5 +1,5 @@
 # Changelog for hs-opentelemetry-instrumentation-postgresql-simple
 
-## Unreleased changes
+## 0.2.0.0
 
 - Significantly reworked implementation

--- a/instrumentation/postgresql-simple/ChangeLog.md
+++ b/instrumentation/postgresql-simple/ChangeLog.md
@@ -2,6 +2,4 @@
 
 ## Unreleased changes
 
-### Breaking changes
-
-- Use `HashMap Text Attribute` instead of `[(Text, Attribute)]` as attributes
+- Significantly reworked implementation

--- a/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
+++ b/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , iproute
     , postgresql-libpq
     , postgresql-simple

--- a/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
+++ b/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-postgresql-simple
-version:            0.1.0.0
+version:            0.2.0.0
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/postgresql-simple#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/instrumentation/postgresql-simple/package.yaml
+++ b/instrumentation/postgresql-simple/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
   - iproute
   - postgresql-simple
   - postgresql-libpq

--- a/instrumentation/postgresql-simple/package.yaml
+++ b/instrumentation/postgresql-simple/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-postgresql-simple
-version:             0.1.0.0
+version:             0.2.0.0
 
 <<: *preface
 

--- a/instrumentation/tasty/Changelog.md
+++ b/instrumentation/tasty/Changelog.md
@@ -1,5 +1,5 @@
 # Changelog for hs-opentelemetry-instrumentation-tasty
 
-## Unreleased changes
+## 0.1.0.0
 
 - Initial release

--- a/instrumentation/tasty/Changelog.md
+++ b/instrumentation/tasty/Changelog.md
@@ -1,0 +1,5 @@
+# Changelog for hs-opentelemetry-instrumentation-tasty
+
+## Unreleased changes
+
+- Initial release

--- a/instrumentation/tasty/hs-opentelemetry-instrumentation-tasty.cabal
+++ b/instrumentation/tasty/hs-opentelemetry-instrumentation-tasty.cabal
@@ -23,7 +23,7 @@ library
   default-language: Haskell2010
   build-depends:
     base >=4.7 && <5
-    , hs-opentelemetry-api >=0.1 && <0.2
+    , hs-opentelemetry-api ^>=0.2
     , tagged ^>= 0.8
     , tasty ^>= 1.5
     , text

--- a/instrumentation/wai/ChangeLog.md
+++ b/instrumentation/wai/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Bracket WAIT middleware spans with detachChontext (#116).
+
 ## 0.1.0.0
 
 ### Breaking changes

--- a/instrumentation/wai/ChangeLog.md
+++ b/instrumentation/wai/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for hs-opentelemetry-instrumentation-wai
 
-## Unreleased changes
+## 0.1.1
 
 - Bracket WAIT middleware spans with detachChontext (#116).
 

--- a/instrumentation/wai/ChangeLog.md
+++ b/instrumentation/wai/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.1.1
 
-- Bracket WAIT middleware spans with detachChontext (#116).
+- Bracket WAI middleware spans with detachChontext (#116).
 
 ## 0.1.0.0
 

--- a/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
+++ b/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
@@ -35,7 +35,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , http-types
     , iproute
     , network

--- a/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
+++ b/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-wai
-version:            0.1.0.0
+version:            0.1.1.0
 synopsis:           WAI instrumentation middleware for OpenTelemetry
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/wai#readme>
 category:           OpenTelemetry, Web

--- a/instrumentation/wai/package.yaml
+++ b/instrumentation/wai/package.yaml
@@ -27,7 +27,7 @@ library:
   dependencies:
   - http-types
   - wai
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
   - vault
   - text
   - network

--- a/instrumentation/wai/package.yaml
+++ b/instrumentation/wai/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-wai
-version:             0.1.0.0
+version:             0.1.1.0
 
 <<: *preface
 

--- a/instrumentation/yesod/ChangeLog.md
+++ b/instrumentation/yesod/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for hs-opentelemetry-instrumentation-yesod
 
-## Unreleased changes
+## 0.1.1.0
 
 - Set exception details when using WAI and Yesod instrumentation together (#121).
 

--- a/instrumentation/yesod/ChangeLog.md
+++ b/instrumentation/yesod/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Set exception details when using WAI and Yesod instrumentation together (#121).
+
 ## 0.1.0.0
 
 ### Breaking changes

--- a/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
+++ b/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
@@ -35,7 +35,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.1.*
+    , hs-opentelemetry-api ==0.2.*
     , hs-opentelemetry-instrumentation-wai >=0.0.1 && <0.2
     , microlens
     , template-haskell

--- a/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
+++ b/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-yesod
-version:            0.1.0.0
+version:            0.1.1.0
 synopsis:           Yesod middleware for providing OpenTelemetry instrumentation
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/yesod#readme>
 category:           OpenTelemetry, Web

--- a/instrumentation/yesod/package.yaml
+++ b/instrumentation/yesod/package.yaml
@@ -25,7 +25,7 @@ library:
   ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api == 0.1.*
+  - hs-opentelemetry-api ^>= 0.2
   - hs-opentelemetry-instrumentation-wai >= 0.0.1 && < 0.2
   - microlens
   - template-haskell

--- a/instrumentation/yesod/package.yaml
+++ b/instrumentation/yesod/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-instrumentation-yesod
-version:             0.1.0.0
+version:             0.1.1.0
 
 <<: *preface
 

--- a/otlp/ChangeLog.md
+++ b/otlp/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for otlp
 
-## Unreleased changes
+## 0.1.0.0
 
 Support OTLP specification v1.0.0
 

--- a/otlp/hs-opentelemetry-otlp.cabal
+++ b/otlp/hs-opentelemetry-otlp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-otlp
-version:        0.0.1.0
+version:        0.1.0.0
 synopsis:       OpenTelemetry protocol buffer modules generated for the OTLP protocol by the proto-lens package
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry#readme>
 category:       OpenTelemetry

--- a/otlp/package.yaml
+++ b/otlp/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../package-common.yaml"
 
 name:                hs-opentelemetry-otlp
-version:             0.0.1.0
+version:             0.1.0.0
 
 <<: *preface
 

--- a/propagators/b3/ChangeLog.md
+++ b/propagators/b3/ChangeLog.md
@@ -1,3 +1,5 @@
 # Changelog for hs-opentelemetry-propagator-b3
 
-## Unreleased changes
+## 0.0.1.2
+
+- Support newer dependencies

--- a/propagators/b3/hs-opentelemetry-propagator-b3.cabal
+++ b/propagators/b3/hs-opentelemetry-propagator-b3.cabal
@@ -38,7 +38,7 @@ library
       attoparsec
     , base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , http-types
     , text
   default-language: Haskell2010

--- a/propagators/b3/hs-opentelemetry-propagator-b3.cabal
+++ b/propagators/b3/hs-opentelemetry-propagator-b3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-propagator-b3
-version:            0.0.1.1
+version:            0.0.1.2
 synopsis:           Trace propagation via HTTP headers following the b3 tracestate spec.
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/propagators/b3#readme>
 category:           OpenTelemetry, Tracing, Web

--- a/propagators/b3/package.yaml
+++ b/propagators/b3/package.yaml
@@ -1,5 +1,5 @@
 name:                hs-opentelemetry-propagator-b3
-version:             0.0.1.1
+version:             0.0.1.2
 github:              "iand675/hs-opentelemetry"
 license:             BSD3
 author:              "Ian Duncan"

--- a/propagators/b3/package.yaml
+++ b/propagators/b3/package.yaml
@@ -28,7 +28,7 @@ library:
   dependencies:
   - attoparsec
   - bytestring
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2
   - http-types
   - text
 

--- a/propagators/datadog/Changelog.md
+++ b/propagators/datadog/Changelog.md
@@ -1,0 +1,5 @@
+# Changelog for hs-opentelemetry-propagator-datadog
+
+## 0.0.1.0
+
+- Initial release

--- a/propagators/datadog/hs-opentelemetry-propagator-datadog.cabal
+++ b/propagators/datadog/hs-opentelemetry-propagator-datadog.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name: hs-opentelemetry-propagator-datadog
-version: 0.0.0.0
+version: 0.0.1.0
 author: Kazuki Okamoto (岡本和樹)
 maintainer: kazuki.okamoto@herp.co.jp
 

--- a/propagators/w3c/ChangeLog.md
+++ b/propagators/w3c/ChangeLog.md
@@ -1,9 +1,13 @@
 # Changelog for hs-opentelemetry-propagator-w3c
 
+## 0.0.1.4
+
+- Support newer dependencies
+
 ## 0.0.1.1
 
 - Update to hs-opentelemetry-api == 0.0.2.*
+
 ## 0.0.1.0
 
 - Initial release
-## Unreleased changes

--- a/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
+++ b/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-propagator-w3c
-version:            0.0.1.3
+version:            0.0.1.4
 synopsis:           Trace propagation via HTTP headers following the w3c tracestate spec.
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/propagators/w3c#readme>
 category:           OpenTelemetry, Tracing, Web

--- a/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
+++ b/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
@@ -38,6 +38,6 @@ library
       attoparsec
     , base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , http-types
   default-language: Haskell2010

--- a/propagators/w3c/package.yaml
+++ b/propagators/w3c/package.yaml
@@ -26,7 +26,7 @@ library:
   source-dirs: src
   dependencies:
   - bytestring
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2
   - http-types
   - attoparsec
 

--- a/propagators/w3c/package.yaml
+++ b/propagators/w3c/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-propagator-w3c
-version:             0.0.1.3
+version:             0.0.1.4
 
 <<: *preface
 

--- a/scripts/upload-all
+++ b/scripts/upload-all
@@ -6,17 +6,16 @@ stack upload \
   sdk \
   exporters/in-memory \
   exporters/otlp \
+  exporters/handle \
   propagators/w3c \
+  instrumentation/cloudflare \
   instrumentation/conduit \
+  instrumentation/hspec \
+  instrumentation/http-client \
+  instrumentation/persistent \
+  instrumentation/postgresql-simple \
+  instrumentation/tasty \
   instrumentation/wai \
   instrumentation/yesod \
-  instrumentation/http-client \
-  instrumentation/postgresql-simple
-  # Pending upstream merges
-  # instrumentation/persistent
-  # Pending dev
-  # propagators/b3
-  # propagators/jaeger
-  # exporters/handle
-  # exporters/jaeger
-  # exporters/zipkin
+  utils/exceptions \
+  vendors/honeycomb

--- a/sdk/ChangeLog.md
+++ b/sdk/ChangeLog.md
@@ -3,9 +3,10 @@
 ## 0.1.0.0
 
 - Support new versions of dependencies.
-- Build on Windows (#114).
+- Windows: Replace POSIX-only functionality with a stub, so the package could be built at all (#114).
 - Support `OTEL_SDK_DISABLED` (#148).
 - Add Datadog as a known propagator (#117).
+- Documentation improvements
 
 ## 0.0.3.6
 
@@ -37,8 +38,3 @@
 ## 0.0.1.0
 
 - Initial release
-
-## Unreleased changes
-
-- Documentation improvements
-- Windows: Replace POSIX-only functionality with a stub, so the package could be built at all

--- a/sdk/ChangeLog.md
+++ b/sdk/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for hs-opentelemetry-sdk
 
-## Unreleased
+## 0.1.0.0
 
 - Support new versions of dependencies.
 - Build on Windows (#114).

--- a/sdk/ChangeLog.md
+++ b/sdk/ChangeLog.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- Support `OTEL_SDK_DISABLED`
+- Support new versions of dependencies.
+- Build on Windows (#114).
+- Support `OTEL_SDK_DISABLED` (#148).
+- Add Datadog as a known propagator (#117).
 
 ## 0.0.3.6
 

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.22
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-sdk
-version:            0.0.3.6
+version:            0.1.0.0
 synopsis:           OpenTelemetry SDK for use in applications.
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/sdk#readme>
 category:           OpenTelemetry, Telemetry, Monitoring, Observability, Metrics
@@ -81,7 +81,7 @@ library
       async
     , base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api >=0.0.3 && <0.2
+    , hs-opentelemetry-api ==0.2.*
     , hs-opentelemetry-exporter-otlp ==0.0.1.*
     , hs-opentelemetry-propagator-b3 ==0.0.1.*
     , hs-opentelemetry-propagator-datadog ==0.0.0.*

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -82,10 +82,10 @@ library
     , base >=4.7 && <5
     , bytestring
     , hs-opentelemetry-api ==0.2.*
-    , hs-opentelemetry-exporter-otlp ==0.0.1.*
-    , hs-opentelemetry-propagator-b3 ==0.0.1.*
-    , hs-opentelemetry-propagator-datadog ==0.0.0.*
-    , hs-opentelemetry-propagator-w3c ==0.0.1.*
+    , hs-opentelemetry-exporter-otlp ==0.1.*
+    , hs-opentelemetry-propagator-b3 >=0.0.1 && <0.1
+    , hs-opentelemetry-propagator-datadog >=0.0.0 && <0.1
+    , hs-opentelemetry-propagator-w3c >=0.0.1 && <0.1
     , http-types
     , network-bsd
     , random >=1.2.0

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -47,10 +47,10 @@ library:
   - vector-builder
   # These are "distribution" packages
   - hs-opentelemetry-api ^>= 0.2
-  - hs-opentelemetry-propagator-w3c == 0.0.1.*
-  - hs-opentelemetry-exporter-otlp == 0.0.1.*
-  - hs-opentelemetry-propagator-b3 ==0.0.1.*
-  - hs-opentelemetry-propagator-datadog ==0.0.0.*
+  - hs-opentelemetry-propagator-w3c ^>= 0.0.1
+  - hs-opentelemetry-exporter-otlp ^>= 0.1
+  - hs-opentelemetry-propagator-b3 ^>=0.0.1
+  - hs-opentelemetry-propagator-datadog ^>=0.0.0
   reexported-modules:
     - OpenTelemetry.Attributes
     - OpenTelemetry.Baggage

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../package-common.yaml"
 
 name:                hs-opentelemetry-sdk
-version:             0.0.3.6
+version:             0.1.0.0
 
 <<: *preface
 
@@ -46,7 +46,7 @@ library:
   - vector
   - vector-builder
   # These are "distribution" packages
-  - hs-opentelemetry-api >= 0.0.3 && < 0.2
+  - hs-opentelemetry-api ^>= 0.2
   - hs-opentelemetry-propagator-w3c == 0.0.1.*
   - hs-opentelemetry-exporter-otlp == 0.0.1.*
   - hs-opentelemetry-propagator-b3 ==0.0.1.*

--- a/utils/exceptions/ChangeLog.md
+++ b/utils/exceptions/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog for exceptions
 
-## Unreleased changes
+## 0.2.0.1
+
+- Support newer dependencies
 
 ## 0.2.0.0
 

--- a/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
+++ b/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-utils-exceptions
-version:            0.2.0.0
+version:            0.2.0.1
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/utils/exceptions#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues

--- a/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
+++ b/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
@@ -33,8 +33,8 @@ library
   build-depends:
       base >=4.7 && <5
     , exceptions
-    , hs-opentelemetry-api ==0.1.*
-    , hs-opentelemetry-sdk ==0.0.3.*
+    , hs-opentelemetry-api ==0.2.*
+    , hs-opentelemetry-sdk ==0.1.*
     , text
   default-language: Haskell2010
 

--- a/utils/exceptions/package.yaml
+++ b/utils/exceptions/package.yaml
@@ -24,8 +24,8 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api == 0.1.*
-  - hs-opentelemetry-sdk == 0.0.3.*
+  - hs-opentelemetry-api ^>= 0.2
+  - hs-opentelemetry-sdk ^>= 0.1
   - text
   - exceptions
 

--- a/utils/exceptions/package.yaml
+++ b/utils/exceptions/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-utils-exceptions
-version:             0.2.0.0
+version:             0.2.0.1
 
 <<: *preface
 

--- a/vendors/honeycomb/ChangeLog.md
+++ b/vendors/honeycomb/ChangeLog.md
@@ -1,6 +1,9 @@
 # Changelog for hs-opentelemetry-vendor-honeycomb
 
+## 0.0.1.2
+
+- Support newer dependencies
+
 ## 0.0.1.0
 
 Initial release
-## Unreleased changes

--- a/vendors/honeycomb/hs-opentelemetry-vendor-honeycomb.cabal
+++ b/vendors/honeycomb/hs-opentelemetry-vendor-honeycomb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-vendor-honeycomb
-version:            0.0.1.1
+version:            0.0.1.2
 synopsis:           Optional OpenTelemetry integration for Honeycomb
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry#readme>
 category:           OpenTelemetry

--- a/vendors/honeycomb/package.yaml
+++ b/vendors/honeycomb/package.yaml
@@ -1,7 +1,7 @@
 _common/lib: !include "../../package-common.yaml"
 
 name:                hs-opentelemetry-vendor-honeycomb
-version:             0.0.1.1
+version:             0.0.1.2
 
 <<: *preface
 


### PR DESCRIPTION
I've made some effort at reconstructing changelogs. They're not perfect, but at least there's mostly something there.

I bumped version numbers as seemed appropriate.
- I gave the API a major version bump as quite a bit has happened there
- I bumped the SDK to a major version, I think it is stable enough that we can call it at least `0.1`
- My intention is to release a new versions of everything to ensure we have published versions of everything that can use the latest dependencies.
- I've ignored the placeholder packages

Step towards #154.

Tagging  @ocharles @kakkun61 @pbrisbin @velveteer @iand675 