### PR TITLE
fix ignoreGeneratedFiles function

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,8 @@
       supportedSystems
       ;
     ignoreGeneratedFiles = attrs:
-      {
+      attrs
+      // {
         excludes =
           attrs.excludes
           or []
@@ -41,8 +42,7 @@
             "^otlp/src/"
             ".*\\.cabal$"
           ];
-      }
-      // attrs;
+      };
     pre-commit-hooks = {
       # General hooks
       end-of-file-fixer = ignoreGeneratedFiles {


### PR DESCRIPTION
The current implementation always override `excludes` with `attrs.excludes` when `attrs.excludes` exists and so `[ "^otlp/src/" ".*\\.cabal$". ]` is removed.