### PR TITLE
Export `toImmutableSpan`

### DIFF
--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for hs-opentelemetry-api
 
+## 0.2.1.0
+
+- defined and exported `toImmutableSpan` and `FrozenOrDropped` from `OpenTelemetry.Trace.Core`
+
 ## 0.2.0.0
 
 - `callerAttributes` and `ownCodeAttributes` now work properly if the call stack has been frozen. Hence most

--- a/api/src/OpenTelemetry/Internal/Trace/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/Types.hs
@@ -306,6 +306,14 @@ instance Show Span where
   showsPrec d (Dropped ctx) = showParen (d > 10) $ showString "Dropped " . showsPrec 11 ctx
 
 
+-- | Extracts the values from a @Span@ if it is still mutable. Returns @Nothing@ if the @Span@ is frozen or dropped.
+toImmutableSpan :: Span -> IO (Maybe ImmutableSpan)
+toImmutableSpan s = case s of
+  Span ioref -> Just <$> readIORef ioref
+  FrozenSpan ctx -> pure Nothing
+  Dropped ctx -> pure Nothing
+
+
 {- | TraceFlags with the @sampled@ flag not set. This means that it is up to the
  sampling configuration to decide whether or not to sample the trace.
 -}

--- a/api/src/OpenTelemetry/Internal/Trace/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/Types.hs
@@ -309,7 +309,7 @@ instance Show Span where
 data FrozenOrDropped = SpanFrozen | SpanDropped deriving (Show, Eq)
 
 
--- | Extracts the values from a @Span@ if it is still mutable. Returns @Nothing@ if the @Span@ is frozen or dropped.
+-- | Extracts the values from a @Span@ if it is still mutable. Returns a @Left@ with @FrozenOrDropped@ if the @Span@ is frozen or dropped.
 toImmutableSpan :: MonadIO m => Span -> m (Either FrozenOrDropped ImmutableSpan)
 toImmutableSpan s = case s of
   Span ioref -> Right <$> liftIO (readIORef ioref)

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -72,6 +72,7 @@ module OpenTelemetry.Trace.Core (
 
   -- * Span operations
   Span,
+  toImmutableSpan,
   ImmutableSpan (..),
   SpanContext (..),
   -- | W3c Trace flags

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -73,7 +73,7 @@ module OpenTelemetry.Trace.Core (
   -- * Span operations
   Span,
   toImmutableSpan,
-  FrozenOrDropped,
+  FrozenOrDropped (..),
   ImmutableSpan (..),
   SpanContext (..),
   -- | W3c Trace flags

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -73,6 +73,7 @@ module OpenTelemetry.Trace.Core (
   -- * Span operations
   Span,
   toImmutableSpan,
+  FrozenOrDropped,
   ImmutableSpan (..),
   SpanContext (..),
   -- | W3c Trace flags
@@ -689,10 +690,12 @@ spanIsRemote (Dropped _) = pure False
  to semantic versioning .
 -}
 unsafeReadSpan :: (MonadIO m) => Span -> m ImmutableSpan
-unsafeReadSpan = \case
-  Span ref -> liftIO $ readIORef ref
-  FrozenSpan _s -> error "This span is from another process"
-  Dropped _s -> error "This span was dropped"
+unsafeReadSpan s =
+  toImmutableSpan s >>= \case
+    Right span -> pure span
+    Left frozenOrDropped -> case frozenOrDropped of
+      SpanFrozen -> error "This span is from another process"
+      SpanDropped -> error "This span was dropped"
 
 
 wrapSpanContext :: SpanContext -> Span


### PR DESCRIPTION
At the moment, the thread-local storage retains a span, but the `Span` exposed there cannot be traversed upward. This only becomes available in the `Processor`s.

We have a use case that would benefit from being able to traverse up the `Span` with `alterSpansUpward` before the span is concluded and sent to the `Processor`.

The use case is for a span to indicate that not only itself, but also all child spans, should not propagate span information over an async boundary (in an application that uses this library). We want to use a span attribute for this (it's useful as an attribute both for this control behavior and as an indicator in our telemetry viewer).