### PR TITLE
drop `http-client` MonadUnliftIO constraint

### DIFF
--- a/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient.hs
+++ b/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient.hs
@@ -43,7 +43,7 @@ import OpenTelemetry.Trace.Core (
   defaultSpanArguments,
   inSpan'',
  )
-import UnliftIO (MonadUnliftIO, askRunInIO)
+import UnliftIO (askRunInIO)
 
 
 spanArgs :: SpanArguments
@@ -66,12 +66,12 @@ spanArgs = defaultSpanArguments {kind = Client}
  body.
 -}
 withResponse
-  :: (MonadUnliftIO m, HasCallStack)
+  :: (HasCallStack)
   => HttpClientInstrumentationConfig
   -> Client.Request
   -> Client.Manager
-  -> (Client.Response Client.BodyReader -> m a)
-  -> m a
+  -> (Client.Response Client.BodyReader -> IO a)
+  -> IO a
 withResponse httpConf req man f = do
   tracer <- httpTracerProvider
   inSpan'' tracer "withResponse" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_wrSpan -> do
@@ -91,7 +91,7 @@ withResponse httpConf req man f = do
  for memory efficiency. If you are anticipating a large response body, you
  are encouraged to use 'withResponse' and 'brRead' instead.
 -}
-httpLbs :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> m (Client.Response L.ByteString)
+httpLbs :: (HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> IO (Client.Response L.ByteString)
 httpLbs httpConf req man = do
   tracer <- httpTracerProvider
   inSpan'' tracer "httpLbs" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_ -> do
@@ -105,7 +105,7 @@ httpLbs httpConf req man = do
 {- | A convenient wrapper around 'withResponse' which ignores the response
  body. This is useful, for example, when performing a HEAD request.
 -}
-httpNoBody :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> m (Client.Response ())
+httpNoBody :: (HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> IO (Client.Response ())
 httpNoBody httpConf req man = do
   tracer <- httpTracerProvider
   inSpan'' tracer "httpNoBody" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_ -> do
@@ -144,7 +144,7 @@ httpNoBody httpConf req man = do
  Content-Encoding: and Accept-Encoding: from request and response
  headers to be relayed.
 -}
-responseOpen :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> m (Client.Response Client.BodyReader)
+responseOpen :: (HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> IO (Client.Response Client.BodyReader)
 responseOpen httpConf req man = do
   tracer <- httpTracerProvider
   inSpan'' tracer "responseOpen" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_ -> do


### PR DESCRIPTION
## description

just what it says on the tin: these functions work just fine in `IO`, so we shouldn't need to require that callers have a `MonadUnliftIO` instance (they can go through the `MonadUnliftIO` instance on `IO` instead).