### PR TITLE
Make it compatible with the latest `text` and `persistent` releases

### DIFF
--- a/api/src/OpenTelemetry/Propagator.hs
+++ b/api/src/OpenTelemetry/Propagator.hs
@@ -31,7 +31,7 @@ module OpenTelemetry.Propagator where
 
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.Text
+import Data.Text (Text)
 
 
 {- |

--- a/api/src/OpenTelemetry/Resource/Service.hs
+++ b/api/src/OpenTelemetry/Resource/Service.hs
@@ -16,7 +16,7 @@
 -}
 module OpenTelemetry.Resource.Service where
 
-import Data.Text
+import Data.Text (Text)
 import OpenTelemetry.Resource
 
 

--- a/api/src/OpenTelemetry/Trace/Sampler.hs
+++ b/api/src/OpenTelemetry/Trace/Sampler.hs
@@ -36,7 +36,7 @@ import Data.Binary.Get
 import Data.Bits
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
-import Data.Text
+import qualified Data.Text as T
 import Data.Word (Word64)
 import OpenTelemetry.Attributes (toAttribute)
 import OpenTelemetry.Context
@@ -100,7 +100,7 @@ traceIdRatioBased fraction =
     traceIdUpperBound = floor (fraction * fromIntegral ((1 :: Word64) `shiftL` 63)) :: Word64
     sampler =
       Sampler
-        { getDescription = "TraceIdRatioBased{" <> pack (show fraction) <> "}"
+        { getDescription = "TraceIdRatioBased{" <> T.pack (show fraction) <> "}"
         , shouldSample = \ctxt tid _ _ -> do
             mspanCtxt <- sequence (getSpanContext <$> lookupSpan ctxt)
             let x = runGet getWord64be (L.fromStrict $ B.take 8 $ traceIdBytes tid) `shiftR` 1

--- a/instrumentation/persistent/src/OpenTelemetry/Instrumentation/Persistent.hs
+++ b/instrumentation/persistent/src/OpenTelemetry/Instrumentation/Persistent.hs
@@ -20,7 +20,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vault.Strict as Vault
-import Database.Persist.Sql
+import Database.Persist.Sql (IsolationLevel (..), SqlReadBackend, SqlWriteBackend, Statement (..))
 import Database.Persist.SqlBackend (MkSqlBackendArgs (connRDBMS), emptySqlBackendHooks, getConnVault, getRDBMS, modifyConnVault, setConnHooks)
 import Database.Persist.SqlBackend.Internal
 import OpenTelemetry.Attributes (Attributes)


### PR DESCRIPTION
This PR allows to build `hs-opentelemetry` with the latest versions of `text` [1] and `persistent` [2].

[1] https://github.com/haskell/text/pull/608
[2] https://github.com/yesodweb/persistent/pull/1569