### PR TITLE
[instrumentation/postgresql-simple] fix error thrown if no rows supplied

### DIFF
--- a/instrumentation/postgresql-simple/src/OpenTelemetry/Instrumentation/PostgresqlSimple.hs
+++ b/instrumentation/postgresql-simple/src/OpenTelemetry/Instrumentation/PostgresqlSimple.hs
@@ -261,6 +261,7 @@ returning = returningWith Simple.fromRow
 
 -- | A version of 'returning' taking parser as argument
 returningWith :: (HasCallStack, MonadIO m, ToRow q) => Simple.RowParser r -> Connection -> Query -> [q] -> m [r]
+returningWith _parser _conn _q [] = pure []
 returningWith parser conn q qs = liftIO $ do
   statement <- formatMany conn q qs
   pgsSpan conn statement $ Simple.returningWith parser conn q qs
@@ -282,6 +283,7 @@ execute_ conn q = liftIO $ do
 
 -- | Instrumented version of 'Simple.executeMany'
 executeMany :: (HasCallStack, MonadIO m, ToRow q) => Connection -> Query -> [q] -> m Int64
+executeMany _conn _q [] = pure 0
 executeMany conn q qs = liftIO $ do
   statement <- formatMany conn q qs
   pgsSpan conn statement $ Simple.executeMany conn q qs


### PR DESCRIPTION
Hey :wave: 

- [`formatMany` throws an exception](https://github.com/haskellari/postgresql-simple/blob/f8693c38c6de4751121114e1970ec6694e6aec7e/src/Database/PostgreSQL/Simple.hs#L175) if no rows are supplied.
- `executeMany` and `returningWith` shortcut, without actually querying the DB, in this case.

This PR fixes the instrumented functions to do the same.
