### PR TITLE
Update nixpkgs in the flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1749213349,
-        "narHash": "sha256-UAaWOyQhdp7nXzsbmLVC67fo+QetzoTm9hsPf9X3yr4=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a4ff0e3c64846abea89662bfbacf037ef4b34207",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,10 +1,9 @@
 builds:
   - include:
-    - "packages.x86_64-linux.hs-opentelemetry-suite-ghc90"
-    - "packages.x86_64-linux.hs-opentelemetry-suite-ghc92"
     - "packages.x86_64-linux.hs-opentelemetry-suite-ghc94"
     - "packages.x86_64-linux.hs-opentelemetry-suite-ghc96"
     - "packages.x86_64-linux.hs-opentelemetry-suite-ghc98"
+    - "packages.x86_64-linux.hs-opentelemetry-suite-ghc910"
     - "checks.x86_64-linux.*"
     exclude:
     - "devShells.*"

--- a/nix/matrix.nix
+++ b/nix/matrix.nix
@@ -7,9 +7,6 @@
   ];
 
   supportedGHCVersions = [
-    "ghc810"
-    "ghc90"
-    "ghc92"
     "ghc94"
     "ghc96"
     "ghc98"


### PR DESCRIPTION
The dev shell wasn't working for MacOS due to a failing Julia(??? why ???) dependency. Updating to the latest in nixpkg technology seems to solve it for us.