### PR TITLE
Add tracerIsEnabled to Tracer

### DIFF
--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `tracerIsEnabled` function to check if a Tracer is enabled (helps avoid expensive operations when tracing is disabled)
+
 ## 0.3.0.0
 
 - Export `fromList` from `OpenTelemetry.Trace.TraceState` for creating TraceState from key-value pairs

--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -120,6 +120,7 @@ test-suite hs-opentelemetry-api-test
       OpenTelemetry.SemanticsConfigSpec
       OpenTelemetry.Trace.SamplerSpec
       OpenTelemetry.Trace.TraceFlagsSpec
+      OpenTelemetry.Trace.TracerSpec
       Paths_hs_opentelemetry_api
   hs-source-dirs:
       test

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -60,6 +60,7 @@ module OpenTelemetry.Trace.Core (
   -- * @Tracer@ operations
   Tracer,
   tracerName,
+  tracerIsEnabled,
   HasTracer (..),
   makeTracer,
   getTracer,
@@ -878,6 +879,21 @@ getImmutableSpanTracer = spanTracer
 
 getTracerTracerProvider :: Tracer -> TracerProvider
 getTracerTracerProvider = tracerProvider
+
+
+{- | Check if the 'Tracer' is enabled.
+
+ This function helps users avoid performing computationally expensive operations
+ when creating 'Span's if the tracer is not enabled.
+
+ A 'Tracer' is considered enabled if it has at least one configured processor.
+ If the 'TracerProvider' has no processors, all spans will be dropped, so the
+ tracer is disabled.
+
+ @since 0.3.1.0
+-}
+tracerIsEnabled :: Tracer -> Bool
+tracerIsEnabled t = not $ V.null $ tracerProviderProcessors $ tracerProvider t
 
 
 {- | Smart constructor for 'SpanArguments' providing reasonable values for most 'Span's created

--- a/api/test/OpenTelemetry/Trace/TracerSpec.hs
+++ b/api/test/OpenTelemetry/Trace/TracerSpec.hs
@@ -1,0 +1,50 @@
+module OpenTelemetry.Trace.TracerSpec where
+
+import qualified OpenTelemetry.Attributes as A
+import OpenTelemetry.Processor.Span (SpanProcessor (..))
+import OpenTelemetry.Trace.Core
+import OpenTelemetry.Trace.Sampler
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "Tracer" $ do
+  describe "tracerIsEnabled" $ do
+    it "returns False when TracerProvider has no processors" $ do
+      tp <- createTracerProvider [] emptyTracerProviderOptions
+      let instrLib = InstrumentationLibrary "test" "1.0.0" "" A.emptyAttributes
+          tracer = makeTracer tp instrLib tracerOptions
+      tracerIsEnabled tracer `shouldBe` False
+
+    it "returns True when TracerProvider has at least one processor" $ do
+      let dummyProcessor =
+            SpanProcessor
+              { spanProcessorOnStart = \_ _ -> pure ()
+              , spanProcessorOnEnd = \_ -> pure ()
+              , spanProcessorShutdown = error "not implemented in test"
+              , spanProcessorForceFlush = pure ()
+              }
+      tp <- createTracerProvider [dummyProcessor] emptyTracerProviderOptions
+      let instrLib = InstrumentationLibrary "test" "1.0.0" "" A.emptyAttributes
+          tracer = makeTracer tp instrLib tracerOptions
+      tracerIsEnabled tracer `shouldBe` True
+
+    it "returns True when TracerProvider has multiple processors" $ do
+      let dummyProcessor1 =
+            SpanProcessor
+              { spanProcessorOnStart = \_ _ -> pure ()
+              , spanProcessorOnEnd = \_ -> pure ()
+              , spanProcessorShutdown = error "not implemented in test"
+              , spanProcessorForceFlush = pure ()
+              }
+          dummyProcessor2 =
+            SpanProcessor
+              { spanProcessorOnStart = \_ _ -> pure ()
+              , spanProcessorOnEnd = \_ -> pure ()
+              , spanProcessorShutdown = error "not implemented in test"
+              , spanProcessorForceFlush = pure ()
+              }
+      tp <- createTracerProvider [dummyProcessor1, dummyProcessor2] emptyTracerProviderOptions
+      let instrLib = InstrumentationLibrary "test" "1.0.0" "" A.emptyAttributes
+          tracer = makeTracer tp instrLib tracerOptions
+      tracerIsEnabled tracer `shouldBe` True

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -21,6 +21,7 @@ import qualified OpenTelemetry.SemanticsConfigSpec as SemanticsConfigSpec
 import OpenTelemetry.Trace.Core
 import qualified OpenTelemetry.Trace.SamplerSpec as Sampler
 import qualified OpenTelemetry.Trace.TraceFlagsSpec as TraceFlags
+import qualified OpenTelemetry.Trace.TracerSpec as Tracer
 import OpenTelemetry.Util
 import Test.Hspec
 import qualified VectorBuilder.Vector as Builder
@@ -62,5 +63,6 @@ main = hspec $ do
   InstrumentationLibrary.spec
   Sampler.spec
   TraceFlags.spec
+  Tracer.spec
   SemanticsConfigSpec.spec
   CoreSpec.spec


### PR DESCRIPTION
This function helps users avoid performing computationally expensive operations
when creating Spans if the Tracer is not enabled.

A Tracer is considered enabled if it has at least one configured processor.
If the TracerProvider has no processors, all spans will be dropped, so the
tracer is functionally useless.