### PR TITLE
Turn off hpack precommit hook for now

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,9 @@
       fourmolu = ignoreGeneratedFiles {
         enable = true;
       };
-      hpack.enable = true;
+      hpack = {
+        enable = false;
+      };
     };
   in
     {
@@ -112,6 +114,7 @@
                 );
               };
 
+              # Use a consistent hpack version across shells.
               pre-commit.hooks = pre-commit-hooks;
             })
           ];

--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -5,7 +5,6 @@
 }: let
   inherit
     (builtins)
-    attrNames
     listToAttrs
     map
     ;


### PR DESCRIPTION
Precommit checks are a bit busted by hpack, because we have a lot of different versions of hpack flying around here. If you use stack, it's whatever is built in there, but then precommit overwrites that. And the version that nix puts in the shell for developers also doesn't (necessarily) match the pre-commit flakes version.

It's not immediately clear how to best solve this, so I'm going to turn it off for now.