### PR TITLE
Add missing packages into localPackages

### DIFF
--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -33,6 +33,13 @@ in rec {
     hs-opentelemetry-instrumentation-postgresql-simple = ../instrumentation/postgresql-simple;
     hs-opentelemetry-instrumentation-yesod = ../instrumentation/yesod;
     hs-opentelemetry-instrumentation-wai = ../instrumentation/wai;
+    hs-opentelemetry-instrumentation-tasty = ../instrumentation/tasty;
+    hs-opentelemetry-utils-exceptions = ../utils/exceptions;
+    hs-opentelemetry-vendor-honeycomb = ../vendors/honeycomb;
+
+    hspec-example = ../examples/hspec;
+    hw-kafka-client-example = ../examples/hw-kafka-client-example;
+    yesod-minimal = ../examples/yesod-minimal;
   };
 
   localPackageCabalDerivations = hfinal: let


### PR DESCRIPTION
The `localPackages` were missing some packages, so the CI wasn't running for them. This PR aims to resolve this issue.