### PR TITLE
Make BoundedMap.itemMap strict

### DIFF
--- a/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
@@ -166,7 +166,7 @@ data BoundedMap a = BoundedMap
   { itemBounds :: !Int
   , itemMaxExportBounds :: !Int
   , itemCount :: !Int
-  , itemMap :: HashMap InstrumentationLibrary (Builder.Builder a)
+  , itemMap :: !(HashMap InstrumentationLibrary (Builder.Builder a))
   }
 
 


### PR DESCRIPTION
I noticed that BoundedMap.itemMap was accumulating chains of thunks while looking at a heap with ghc-debug.

This isn't necessarily a problem. BoundedMap will eventually get forced. So, this cannot lead to a space leak.

However, this is unnecessarily laziness. There is a performance overhead to creating and evaluating thunks. Just making this strict should be a mild improvement for both allocations and runtime.