### PR TITLE
'addAttributes' should prefer new values on key collision

### DIFF
--- a/api/src/OpenTelemetry/Attributes.hs
+++ b/api/src/OpenTelemetry/Attributes.hs
@@ -121,7 +121,7 @@ addAttributes AttributeLimits {..} Attributes {..} attrs = case attributeCountLi
       then Attributes attributeMap attributesCount (attributesDropped + H.size attrs)
       else Attributes newAttrs newCount attributesDropped
   where
-    newAttrs = H.union attributeMap $ H.map (maybe id limitLengths attributeLengthLimit . toAttribute) attrs
+    newAttrs = H.union (H.map (maybe id limitLengths attributeLengthLimit . toAttribute) attrs) attributeMap
     newCount = H.size newAttrs
 {-# INLINE addAttributes #-}
 

--- a/api/src/OpenTelemetry/LogAttributes.hs
+++ b/api/src/OpenTelemetry/LogAttributes.hs
@@ -61,7 +61,7 @@ addAttributes AttributeLimits {..} LogAttributes {..} attrs = case attributeCoun
       then LogAttributes attributes attributesCount (attributesDropped + H.size attrs)
       else LogAttributes newAttrs newCount attributesDropped
   where
-    newAttrs = H.union attributes $ H.map toValue attrs
+    newAttrs = H.union (H.map toValue attrs) attributes
     newCount = H.size newAttrs
 {-# INLINE addAttributes #-}
 

--- a/api/test/OpenTelemetry/AttributesSpec.hs
+++ b/api/test/OpenTelemetry/AttributesSpec.hs
@@ -2,6 +2,7 @@
 
 module OpenTelemetry.AttributesSpec where
 
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified OpenTelemetry.Attributes as A
 import qualified Test.Hspec as Hspec
@@ -17,6 +18,15 @@ spec = Hspec.describe "Attributes" $ do
             addAttr newValue (addAttr prevValue attrs) `Hspec.shouldBe` addAttr newValue attrs
 
     overwritesPrevious Example ("new value" :: T.Text) "prev value" A.emptyAttributes
+
+  Hspec.describe "addAttributes" $ do
+    Hspec.it "Overwrites previous values new values when keys collide" $ do
+      let initialAttrs = addAttributeDefault "language" ("english" :: T.Text) A.emptyAttributes
+          newAttrMap = HM.fromList [("language" :: T.Text, "morporkian" :: A.Attribute), ("currency", "AM$")]
+          updatedAttrs = A.addAttributes A.defaultAttributeLimits initialAttrs newAttrMap
+      A.getAttributeMap updatedAttrs
+        `Hspec.shouldBe` newAttrMap
+
   Hspec.describe "unsafeMergeAttributesIgnoringLimits" $ do
     Hspec.it "Is left-biased when keys conflict" $ do
       let left = addAttributeDefault Example (1 :: Int) A.emptyAttributes


### PR DESCRIPTION
## description

`addAttribute` replaced values on collision, `addAttributes` should do the same thing.