### PR TITLE
trace/isValid-fix: require both TraceId AND SpanId non-zero

### DIFF
--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -674,11 +674,12 @@ recordException s attrs ts e = liftIO $ do
       }
 
 
--- | Returns @True@ if the @SpanContext@ has a non-zero @TraceID@ and a non-zero @SpanID@
+{- | Returns @True@ if the @SpanContext@ has a non-zero @TraceID@ and a non-zero @SpanID@.
+Spec: "true if the SpanContext has a non-zero TraceID and a non-zero SpanID".
+-}
 isValid :: SpanContext -> Bool
 isValid sc =
-  not
-    (isEmptyTraceId (traceId sc) && isEmptySpanId (spanId sc))
+  not (isEmptyTraceId (traceId sc)) && not (isEmptySpanId (spanId sc))
 
 
 {- |

--- a/sdk/test/OpenTelemetry/TraceSpec.hs
+++ b/sdk/test/OpenTelemetry/TraceSpec.hs
@@ -133,6 +133,9 @@ spec = describe "Trace" $ do
               }
       validSpan `shouldSatisfy` isValid
       (validSpan {spanId = badSpan, traceId = badTrace}) `shouldSatisfy` (not . isValid)
+      -- Spec: BOTH TraceId AND SpanId must be non-zero
+      (validSpan {spanId = badSpan}) `shouldSatisfy` (not . isValid)
+      (validSpan {traceId = badTrace}) `shouldSatisfy` (not . isValid)
     specify "IsRemote" pending
     specify "Conforms to the W3C TraceContext spec" pending
   describe "Span" $ do


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #242.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)