### PR TITLE
trace/tracestate-lookup: add TraceState.lookup (MUST per spec)

### DIFF
--- a/api/src/OpenTelemetry/Trace/TraceState.hs
+++ b/api/src/OpenTelemetry/Trace/TraceState.hs
@@ -24,13 +24,16 @@ module OpenTelemetry.Trace.TraceState (
   Value (..),
   empty,
   fromList,
+  lookup,
   insert,
   update,
   delete,
   toList,
 ) where
 
+import Data.List (find)
 import Data.Text (Text)
+import Prelude hiding (lookup)
 
 
 newtype Key = Key Text
@@ -59,6 +62,14 @@ empty = TraceState []
 -}
 fromList :: [(Key, Value)] -> TraceState
 fromList = TraceState
+
+
+{- | Get the value associated with a given key.
+
+ O(n)
+-}
+lookup :: Key -> TraceState -> Maybe Value
+lookup k (TraceState ts) = snd <$> find (\(k', _) -> k' == k) ts
 
 
 {- | Add a key-value pair to a 'TraceState'


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #243.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)