### PR TITLE
trace/exporter-forceflush: add ForceFlush to SpanExporter (MUST per spec)

### DIFF
--- a/api/src/OpenTelemetry/Exporter.hs
+++ b/api/src/OpenTelemetry/Exporter.hs
@@ -3,7 +3,8 @@
 module OpenTelemetry.Exporter
   {-# DEPRECATED "use OpenTelemetry.Exporter.Span instead" #-} (
   Exporter,
-  SpanExporter (Exporter, exporterExport, exporterShutdown),
+  mkExporter,
+  SpanExporter (..),
   ExportResult (..),
 ) where
 
@@ -20,9 +21,11 @@ import OpenTelemetry.Internal.Trace.Types (ImmutableSpan)
 type Exporter a = SpanExporter
 
 
-pattern Exporter :: (HashMap InstrumentationLibrary (Vector ImmutableSpan) -> IO ExportResult) -> IO () -> Exporter ImmutableSpan
-pattern Exporter {exporterExport, exporterShutdown} =
+{-# DEPRECATED mkExporter "use SpanExporter constructor directly" #-}
+mkExporter :: (HashMap InstrumentationLibrary (Vector ImmutableSpan) -> IO ExportResult) -> IO () -> Exporter ImmutableSpan
+mkExporter export shutdown =
   SpanExporter
-    { spanExporterExport = exporterExport
-    , spanExporterShutdown = exporterShutdown
+    { spanExporterExport = export
+    , spanExporterShutdown = shutdown
+    , spanExporterForceFlush = pure ()
     }

--- a/api/src/OpenTelemetry/Internal/Trace/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/Types.hs
@@ -32,6 +32,7 @@ import OpenTelemetry.Util
 data SpanExporter = SpanExporter
   { spanExporterExport :: HashMap InstrumentationLibrary (Vector ImmutableSpan) -> IO ExportResult
   , spanExporterShutdown :: IO ()
+  , spanExporterForceFlush :: IO ()
   }
 
 

--- a/exporters/handle/src/OpenTelemetry/Exporter/Handle/Span.hs
+++ b/exporters/handle/src/OpenTelemetry/Exporter/Handle/Span.hs
@@ -26,6 +26,7 @@ makeHandleExporter h f =
         mapM_ (mapM_ (\s -> f s >>= L.hPutStrLn h >> hFlush h)) fs
         pure Success
     , spanExporterShutdown = hFlush h
+    , spanExporterForceFlush = hFlush h
     }
 
 

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -289,6 +289,7 @@ httpOtlpExporter conf = do
                 Right ok -> pure ok
             else pure Success
       , spanExporterShutdown = pure ()
+      , spanExporterForceFlush = pure ()
       }
   where
     retryDelay = 100_000 -- 100ms

--- a/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
@@ -30,12 +30,13 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
-import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Vector (Vector)
 import OpenTelemetry.Exporter.Span (SpanExporter)
 import qualified OpenTelemetry.Exporter.Span as SpanExporter
 import OpenTelemetry.Processor.Span
 import OpenTelemetry.Trace.Core
+import System.IO (hPutStrLn, stderr)
 import VectorBuilder.Builder as Builder
 import VectorBuilder.Vector as Builder
 
@@ -163,8 +164,6 @@ will be incremented.
 --   -- TODO slice and freeze appropriate section
 -- M.slice (gbSectionSize * (r .&. gbSectionMask)
 
--- TODO, counters for dropped spans, exported spans
-
 data BoundedMap a = BoundedMap
   { itemBounds :: !Int
   , itemMaxExportBounds :: !Int
@@ -238,6 +237,8 @@ batchProcessor :: (MonadIO m) => BatchTimeoutConfig -> SpanExporter -> m SpanPro
 batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
   unless rtsSupportsBoundThreads $ error "The hs-opentelemetry batch processor does not work without the -threaded GHC flag!"
   batch <- newIORef $ boundedMap maxQueueSize maxExportBatchSize
+  droppedRef <- newIORef (0 :: Int)
+  warnedRef <- newIORef False
   workSignal <- newEmptyTMVarIO
   shutdownSignal <- newEmptyTMVarIO
   let publish batchToProcess = mask_ $ do
@@ -290,16 +291,18 @@ batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
       { spanProcessorOnStart = \_ _ -> pure ()
       , spanProcessorOnEnd = \s -> do
           span_ <- readIORef s
-          appendFailedOrExportNeeded <- atomicModifyIORef' batch $ \builder ->
+          (dropped, exportNeeded) <- atomicModifyIORef' batch $ \builder ->
             case push span_ builder of
-              Nothing -> (builder, True)
+              Nothing -> (builder, (True, True))
               Just b' ->
                 if itemCount b' >= itemMaxExportBounds b'
-                  then -- If the batch has grown to the maximum export size, prompt the worker to export it.
-                    (b', True)
-                  else (b', False)
-          when appendFailedOrExportNeeded $ void $ atomically $ tryPutTMVar workSignal ()
-      , spanProcessorForceFlush = void $ atomically $ tryPutTMVar workSignal ()
+                  then (b', (False, True))
+                  else (b', (False, False))
+          when dropped $ warnOnDrop droppedRef warnedRef maxQueueSize "BatchSpanProcessor"
+          when exportNeeded $ void $ atomically $ tryPutTMVar workSignal ()
+      , spanProcessorForceFlush = do
+          void $ atomically $ tryPutTMVar workSignal ()
+          SpanExporter.spanExporterForceFlush exporter
       , -- TODO where to call restore, if anywhere?
         spanProcessorShutdown =
           asyncWithUnmask $ \unmask -> unmask $ do
@@ -354,6 +357,7 @@ batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
   where
     millisToMicros = (* 1000)
 
+
 {-
 buffer <- newGreenBlueBuffer _ _
 batchProcessorAction <- async $ forever $ do
@@ -373,3 +377,19 @@ pure $ Processor
 where
   sendDelay = scheduledDelayMilis * 1_000
 -}
+
+-- TODO: otel-12 introduces OpenTelemetry.Internal.Logging (otelLogWarning)
+-- which respects OTEL_LOG_LEVEL and the global error handler.
+-- Replace hPutStrLn stderr with otelLogWarning once available.
+warnOnDrop :: IORef Int -> IORef Bool -> Int -> String -> IO ()
+warnOnDrop droppedRef warnedRef capacity processorName = do
+  n <- atomicModifyIORef' droppedRef (\c -> let c' = c + 1 in (c', c'))
+  alreadyWarned <- atomicModifyIORef' warnedRef (\w -> (True, w))
+  unless alreadyWarned $
+    hPutStrLn stderr $
+      "OpenTelemetry [WARN] "
+        <> processorName
+        <> ": queue full (capacity "
+        <> show capacity
+        <> "), dropping span. Total dropped so far: "
+        <> show n

--- a/sdk/src/OpenTelemetry/Processor/Simple/Span.hs
+++ b/sdk/src/OpenTelemetry/Processor/Simple/Span.hs
@@ -7,58 +7,111 @@ module OpenTelemetry.Processor.Simple.Span (
 ) where
 
 import Control.Concurrent.Async
-import Control.Concurrent.Chan.Unagi
-import Control.Exception
+import Control.Concurrent.STM
 import Control.Monad
 import qualified Data.HashMap.Strict as HashMap
 import Data.IORef
 import qualified OpenTelemetry.Exporter.Span as SpanExporter
 import OpenTelemetry.Processor.Span
 import OpenTelemetry.Trace.Core (ImmutableSpan, spanTracer, tracerName)
+import System.IO (hPutStrLn, stderr)
 
 
-newtype SimpleProcessorConfig = SimpleProcessorConfig
+data SimpleProcessorConfig = SimpleProcessorConfig
   { spanExporter :: SpanExporter.SpanExporter
   -- ^ The exporter where the spans are pushed.
+  , simpleSpanExportTimeoutMicros :: !Int
+  -- ^ Timeout for individual export calls in microseconds. Default: 30s.
   }
+
+
+defaultSimpleQueueBound :: Int
+defaultSimpleQueueBound = 2048
 
 
 {- | This is an implementation of SpanProcessor which passes finished spans
  and passes the export-friendly span data representation to the configured SpanExporter,
  as soon as they are finished.
 
+ Uses a bounded queue internally. Spans that arrive while the queue is full
+ are dropped and counted per @otel.sdk.processor.span.processed@ with
+ @error.type=queue_full@ (OTel SDK semconv).
+
  @since 0.0.1.0
 -}
 simpleProcessor :: SimpleProcessorConfig -> IO SpanProcessor
 simpleProcessor SimpleProcessorConfig {..} = do
-  (inChan :: InChan (IORef ImmutableSpan), outChan :: OutChan (IORef ImmutableSpan)) <- newChan
-  exportWorker <- async $ forever $ do
-    -- TODO, masking vs bracket here, not sure what's the right choice
-    spanRef <- readChanOnException outChan (>>= writeChan inChan)
-    span_ <- readIORef spanRef
-    mask_ (spanExporter `SpanExporter.spanExporterExport` HashMap.singleton (tracerName $ spanTracer span_) (pure span_))
+  queue <- newTBQueueIO (fromIntegral defaultSimpleQueueBound)
+  droppedRef <- newIORef (0 :: Int)
+  warnedRef <- newIORef False
+  shutdownVar <- newTVarIO False
+  flushReq <- newEmptyTMVarIO
+  flushDone <- newEmptyTMVarIO
+
+  let exportOne spanRef = do
+        span_ <- readIORef spanRef
+        mask_ (spanExporter `SpanExporter.spanExporterExport` HashMap.singleton (tracerName $ spanTracer span_) (pure span_))
+
+  let drainQueue = do
+        mRef <- atomically $ tryReadTBQueue queue
+        case mRef of
+          Nothing -> pure ()
+          Just spanRef -> do
+            _ <- exportOne spanRef
+            drainQueue
+
+  -- Cooperative worker: checks shutdown and flush signals via STM rather
+  -- than relying on async exceptions, avoiding the race where cancel
+  -- arrives between readTBQueue and mask_ and drops an in-flight span.
+  let workerLoop = do
+        cmd <-
+          atomically $
+            msum
+              [ Nothing <$ (readTVar shutdownVar >>= check)
+              , Just Nothing <$ takeTMVar flushReq
+              , Just . Just <$> readTBQueue queue
+              ]
+        case cmd of
+          Nothing -> do
+            drainQueue
+            void $ atomically $ tryPutTMVar flushDone ()
+          Just Nothing -> do
+            drainQueue
+            atomically $ putTMVar flushDone ()
+            workerLoop
+          Just (Just spanRef) -> do
+            _ <- exportOne spanRef
+            workerLoop
+
+  exportWorker <- async workerLoop
 
   pure $
     SpanProcessor
       { spanProcessorOnStart = \_ _ -> pure ()
-      , spanProcessorOnEnd = writeChan inChan
-      , spanProcessorShutdown = async $ mask $ \restore -> do
-          cancel exportWorker
-          -- TODO handle timeouts
-          restore $ do
-            -- TODO, not convinced we should shut down processor here
-            shutdownProcessor outChan `finally` SpanExporter.spanExporterShutdown spanExporter
-          pure ShutdownSuccess
-      , spanProcessorForceFlush = pure ()
+      , spanProcessorOnEnd = \s -> do
+          written <- atomically $ tryWriteTBQueue queue s
+          unless written $ do
+            n <- atomicModifyIORef' droppedRef (\c -> let c' = c + 1 in (c', c'))
+            alreadyWarned <- atomicModifyIORef' warnedRef (\w -> (True, w))
+            -- TODO: otel-12 introduces OpenTelemetry.Internal.Logging (otelLogWarning)
+            -- which respects OTEL_LOG_LEVEL and the global error handler.
+            -- Replace hPutStrLn stderr with otelLogWarning once available.
+            unless alreadyWarned $
+              hPutStrLn stderr $
+                "OpenTelemetry [WARN] SimpleSpanProcessor: queue full (capacity "
+                  <> show defaultSimpleQueueBound
+                  <> "), dropping span. Total dropped so far: "
+                  <> show n
+      , spanProcessorShutdown = do
+          atomically $ writeTVar shutdownVar True
+          async $ do
+            wait exportWorker
+            SpanExporter.spanExporterShutdown spanExporter
+            pure ShutdownSuccess
+      , spanProcessorForceFlush = do
+          isShut <- readTVarIO shutdownVar
+          unless isShut $ do
+            atomically $ putTMVar flushReq ()
+            atomically $ takeTMVar flushDone
+          SpanExporter.spanExporterForceFlush spanExporter
       }
-  where
-    shutdownProcessor :: OutChan (IORef ImmutableSpan) -> IO ()
-    shutdownProcessor outChan = do
-      (Element m, _) <- tryReadChan outChan
-      mSpan <- m
-      case mSpan of
-        Nothing -> pure ()
-        Just spanRef -> do
-          span_ <- readIORef spanRef
-          _ <- spanExporter `SpanExporter.spanExporterExport` HashMap.singleton (tracerName $ spanTracer span_) (pure span_)
-          shutdownProcessor outChan


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #244.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)