### PR TITLE
logs/eventname-enabled: add EventName field and Logger.Enabled API

### DIFF
--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fix `isValid` to require BOTH TraceId AND SpanId non-zero (was incorrectly valid if either was non-zero)
+- Add `TraceState.lookup` for getting a value by key (MUST per spec)
+- Add `spanExporterForceFlush` field to `SpanExporter` (MUST per spec); built-in simple/batch processors now call it
+- Add `logRecordEventName` field to `ImmutableLogRecord` and `eventName` to `LogRecordArguments`
+- Add `loggerIsEnabled` function to check if a Logger has registered processors (SHOULD per spec)
 - Add `startTimeUnixNano` field to `SumDataPoint`, `HistogramDataPoint`, `ExponentialHistogramDataPoint`, `GaugeDataPoint`
 - View `name` and `description` override fields on `View`
 - Metrics: `AggregationTemporality`, `MetricExemplar`, `ExponentialHistogramDataPoint`, exemplar fields on data points, `MetricExportExponentialHistogram`, `filterAttributesByKeys`.

--- a/api/src/OpenTelemetry/Internal/Logs/Core.hs
+++ b/api/src/OpenTelemetry/Internal/Logs/Core.hs
@@ -11,6 +11,7 @@ module OpenTelemetry.Internal.Logs.Core (
   shutdownLoggerProvider,
   forceFlushLoggerProvider,
   makeLogger,
+  loggerIsEnabled,
   emitLogRecord,
   addAttribute,
   addAttributes,
@@ -157,6 +158,20 @@ makeLogger
 makeLogger loggerLoggerProvider loggerInstrumentationScope = Logger {..}
 
 
+{- | Whether this logger\'s provider will process emitted records (@True@ when at least
+ one processor is registered).
+
+ Per the OpenTelemetry Logs API, @Logger@ @Enabled@ is defined at the specification
+ surface to default to enabling emission unless the SDK or configuration disables
+ collection — so a standalone API no-op logger can still conceptually count as \"enabled.\"
+ Here we report practicality for Haskell apps: @False@ when the provider has no processors
+ (including the default global no-op \'LoggerProvider\'), until the SDK attaches exporters.
+-}
+loggerIsEnabled :: Logger -> Bool
+loggerIsEnabled Logger {loggerLoggerProvider = LoggerProvider {loggerProviderProcessors}} =
+  not (V.null loggerProviderProcessors)
+
+
 createImmutableLogRecord
   :: (MonadIO m)
   => LA.AttributeLimits
@@ -189,6 +204,7 @@ createImmutableLogRecord attributeLimits LogRecordArguments {..} = do
       , logRecordSeverityText = severityText <|> (toShortName =<< severityNumber)
       , logRecordBody = body
       , logRecordAttributes
+      , logRecordEventName = eventName
       }
 
 

--- a/api/src/OpenTelemetry/Internal/Logs/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Logs/Types.hs
@@ -351,6 +351,8 @@ data ImmutableLogRecord = ImmutableLogRecord
   Can contain information about the request context (other than Trace Context Fields). The log attribute model MUST support any type, a superset of standard Attribute, to preserve the semantics of structured attributes
   emitted by the applications. This field is optional.
   -}
+  , logRecordEventName :: Maybe Text
+  -- ^ Optional event name. When set, this identifies the log record as an event following the event semantic conventions.
   }
 
 
@@ -366,6 +368,7 @@ data LogRecordArguments = LogRecordArguments
   , severityNumber :: Maybe SeverityNumber
   , body :: AnyValue
   , attributes :: HashMap Text AnyValue
+  , eventName :: Maybe Text
   }
 
 
@@ -379,6 +382,7 @@ emptyLogRecordArguments =
     , severityNumber = Nothing
     , body = NullValue
     , attributes = H.empty
+    , eventName = Nothing
     }
 
 

--- a/api/src/OpenTelemetry/Logs/Core.hs
+++ b/api/src/OpenTelemetry/Logs/Core.hs
@@ -13,6 +13,7 @@ module OpenTelemetry.Logs.Core (
   InstrumentationLibrary (..),
   Logger (..),
   makeLogger,
+  loggerIsEnabled,
 
   -- * @LogRecord@ operations
   ReadableLogRecord,

--- a/sdk/ChangeLog.md
+++ b/sdk/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Batch/simple span processors now call `spanExporterForceFlush` during processor `ForceFlush`
+- IsValid test coverage expanded for TraceId-only and SpanId-only zero cases
 - Track `startTimeUnixNano` across all data points (was hardcoded to 0)
 - `ForceFlush` on `MeterProvider` now triggers a metric collect
 - `View` supports name and description overrides

--- a/spec-compliance.md
+++ b/spec-compliance.md
@@ -32,9 +32,10 @@ formats is required. Implementing more than one format is optional.
 | Mark Span active                                                                                 |          | +  |
 | Safe for concurrent calls                                                                        |          | +  |
 | [SpanContext](specification/trace/api.md#spancontext)                                            |          | +  |
-| IsValid                                                                                          |          | +  |
+| IsValid (both TraceId AND SpanId non-zero)                                                       |          | +  |
 | IsRemote                                                                                         |          | +  |
 | Conforms to the W3C TraceContext spec                                                            |          | (partial)  |
+| [TraceState](specification/trace/api.md#tracestate) get/add/update/delete                        |          | +  |
 | [Span](specification/trace/api.md#span)                                                          |          | +  |
 | Create root span                                                                                 |          | +  |
 | Create with default parent (active span)                                                         |          | +  |
@@ -80,6 +81,8 @@ formats is required. Implementing more than one format is optional.
 | [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          | +  |
 | [SpanLimits](specification/trace/sdk.md#span-limits)                                             | X        | +  |
 | [Built-in `Processor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)     |          | +  |
+| [Tracer.Enabled](specification/trace/api.md#enabled)                                             | X        | +  |
+| [SpanExporter ForceFlush](specification/trace/sdk.md#forceflush-2)                               |          | +  |
 | [Attribute Limits](specification/common/common.md#attribute-limits)                              | X        | +  |
 
 ## Baggage
@@ -123,6 +126,26 @@ formats is required. Implementing more than one format is optional.
 | NaN/Inf measurement handling (silently dropped) | | + |
 
 See `OpenTelemetry.Metrics`, `OpenTelemetry.MeterProvider`, `OpenTelemetry.Metrics.View`, `OpenTelemetry.MetricReader` (SDK), `OpenTelemetry.Exporter.Metric`, `OpenTelemetry.Exporter.OTLP.Metric`, `OpenTelemetry.Exporter.Prometheus`.
+
+## Logs
+
+| Feature                                                                         | Optional | Haskell |
+|---------------------------------------------------------------------------------|----------|---------|
+| [LoggerProvider](specification/logs/api.md#loggerprovider)                      |          | +       |
+| Get a Logger (name, version, schema_url, attributes)                            |          | +       |
+| [Logger.Enabled](specification/logs/api.md#enabled)                             | X        | +       |
+| [Emit LogRecord](specification/logs/api.md#emit-a-logrecord)                    |          | +       |
+| LogRecord: timestamp, observed timestamp, severity, body, attributes            |          | +       |
+| LogRecord: EventName                                                            |          | +       |
+| LogRecord: trace context fields (TraceId, SpanId, TraceFlags)                   |          | +       |
+| Shutdown / ForceFlush (LoggerProvider)                                           |          | +       |
+| [LogRecordProcessor](specification/logs/sdk.md#logrecordprocessor) interface     |          | +       |
+| Built-in Simple processor                                                       |          | - (stub) |
+| Built-in Batch processor                                                        |          | - (stub) |
+| [LogRecordExporter](specification/logs/sdk.md#logrecordexporter) interface       |          | +       |
+| Concrete OTLP log exporter                                                      |          | - (stub) |
+| Concrete handle/console log exporter                                            |          | - (stub) |
+| Concrete in-memory log exporter (testing)                                       |          | - (stub) |
 
 ## Resource
 


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #245.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)