### PR TITLE
feat(sdk): batch and simple LogRecordProcessor

### DIFF
--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -99,7 +99,6 @@ library
     , random >=1.2.0
     , stm
     , text
-    , unagi-chan
     , unix-compat >=0.7.1
     , unordered-containers
     , vector
@@ -122,6 +121,7 @@ test-suite hs-opentelemetry-sdk-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      OpenTelemetry.MeterProviderSpec
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -61,7 +61,6 @@ library:
   - random >= 1.2.0
   - stm
   - text
-  - unagi-chan
   - unix-compat >= 0.7.1 # for getProcessID
   - unordered-containers
   - vector

--- a/sdk/src/OpenTelemetry/Processor/Batch/LogRecord.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch/LogRecord.hs
@@ -1,2 +1,185 @@
-module OpenTelemetry.Processor.Batch.LogRecord () where
+{-# LANGUAGE RecordWildCards #-}
 
+module OpenTelemetry.Processor.Batch.LogRecord (
+  BatchLogRecordProcessorConfig (..),
+  defaultBatchLogRecordProcessorConfig,
+  batchLogRecordProcessor,
+) where
+
+import Control.Concurrent (rtsSupportsBoundThreads)
+import Control.Concurrent.Async
+import Control.Concurrent.STM
+import Control.Exception
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import OpenTelemetry.Internal.Common.Types (ShutdownResult (..))
+import OpenTelemetry.Internal.Logs.Types
+import System.IO (hPutStrLn, stderr)
+import VectorBuilder.Builder as Builder
+import VectorBuilder.Vector as Builder
+
+
+data BatchLogRecordProcessorConfig = BatchLogRecordProcessorConfig
+  { batchLogExporter :: !LogRecordExporter
+  , batchLogMaxQueueSize :: !Int
+  , batchLogScheduledDelayMillis :: !Int
+  , batchLogExportTimeoutMillis :: !Int
+  , batchLogMaxExportBatchSize :: !Int
+  }
+
+
+defaultBatchLogRecordProcessorConfig :: LogRecordExporter -> BatchLogRecordProcessorConfig
+defaultBatchLogRecordProcessorConfig e =
+  BatchLogRecordProcessorConfig
+    { batchLogExporter = e
+    , batchLogMaxQueueSize = 2048
+    , batchLogScheduledDelayMillis = 1000
+    , batchLogExportTimeoutMillis = 30000
+    , batchLogMaxExportBatchSize = 512
+    }
+
+
+data BoundedBuffer = BoundedBuffer
+  { bufBounds :: !Int
+  , bufExportBounds :: !Int
+  , bufCount :: !Int
+  , bufItems :: !(Builder.Builder ReadableLogRecord)
+  }
+
+
+emptyBuffer :: Int -> Int -> BoundedBuffer
+emptyBuffer bounds exportBounds = BoundedBuffer bounds exportBounds 0 mempty
+
+
+pushBuffer :: ReadableLogRecord -> BoundedBuffer -> Maybe BoundedBuffer
+pushBuffer lr buf
+  | bufCount buf + 1 >= bufBounds buf = Nothing
+  | otherwise =
+      Just $!
+        buf
+          { bufCount = bufCount buf + 1
+          , bufItems = bufItems buf <> Builder.singleton lr
+          }
+
+
+buildExportBatch :: BoundedBuffer -> (BoundedBuffer, Vector ReadableLogRecord)
+buildExportBatch buf =
+  ( buf {bufCount = 0, bufItems = mempty}
+  , Builder.build (bufItems buf)
+  )
+
+
+data ProcessorMessage = ScheduledFlush | MaxExportFlush | FlushRequested | Shutdown
+
+
+batchLogRecordProcessor :: (MonadIO m) => BatchLogRecordProcessorConfig -> m LogRecordProcessor
+batchLogRecordProcessor BatchLogRecordProcessorConfig {..} = liftIO $ do
+  unless rtsSupportsBoundThreads $
+    throwIO (userError "The threaded runtime is required for the batch log record processor")
+  batch <- newIORef $ emptyBuffer batchLogMaxQueueSize batchLogMaxExportBatchSize
+  droppedRef <- newIORef (0 :: Int)
+  warnedRef <- newIORef False
+  workSignal <- newEmptyTMVarIO
+  shutdownSignal <- newEmptyTMVarIO
+  flushRequestSignal <- newEmptyTMVarIO
+  flushDoneSignal <- newEmptyTMVarIO
+
+  let publish batchToExport =
+        mask_ $
+          logRecordExporterExport batchLogExporter batchToExport
+
+  let flushQueueImmediately ret = do
+        batchToExport <- atomicModifyIORef' batch buildExportBatch
+        if V.null batchToExport
+          then pure ret
+          else do
+            ret' <- publish batchToExport
+            flushQueueImmediately ret'
+
+  -- Shutdown and FlushRequested are tried before work signals so they
+  -- cannot be starved under sustained high throughput.
+  let waiting = do
+        delay <- registerDelay (millisToMicros batchLogScheduledDelayMillis)
+        atomically $
+          msum
+            [ Shutdown <$ takeTMVar shutdownSignal
+            , FlushRequested <$ takeTMVar flushRequestSignal
+            , MaxExportFlush <$ takeTMVar workSignal
+            , ScheduledFlush <$ do
+                continue <- readTVar delay
+                check continue
+            ]
+
+  let workerAction = do
+        req <- waiting
+        batchToExport <- atomicModifyIORef' batch buildExportBatch
+        res <- publish batchToExport
+        case req of
+          Shutdown -> flushQueueImmediately res
+          FlushRequested -> do
+            _ <- flushQueueImmediately res
+            atomically $ putTMVar flushDoneSignal ()
+            workerAction
+          _ -> workerAction
+
+  worker <- asyncWithUnmask $ \unmask -> unmask workerAction
+
+  pure
+    LogRecordProcessor
+      { logRecordProcessorOnEmit = \lr _ctxt -> do
+          let readable = mkReadableLogRecord lr
+          (dropped, exportNeeded) <- atomicModifyIORef' batch $ \buf ->
+            case pushBuffer readable buf of
+              Nothing -> (buf, (True, True))
+              Just b' ->
+                if bufCount b' >= bufExportBounds b'
+                  then (b', (False, True))
+                  else (b', (False, False))
+          when dropped $ warnOnDrop droppedRef warnedRef batchLogMaxQueueSize "BatchLogRecordProcessor"
+          when exportNeeded $ void $ atomically $ tryPutTMVar workSignal ()
+      , logRecordProcessorForceFlush = do
+          atomically $ putTMVar flushRequestSignal ()
+          atomically $ takeTMVar flushDoneSignal
+          logRecordExporterForceFlush batchLogExporter
+      , logRecordProcessorShutdown =
+          asyncWithUnmask $ \unmask -> unmask $ do
+            mask $ \_restore -> do
+              void $ atomically $ putTMVar shutdownSignal ()
+              delay <- registerDelay (millisToMicros batchLogExportTimeoutMillis)
+              shutdownResult <-
+                atomically $
+                  msum
+                    [ Just <$> waitCatchSTM worker
+                    , Nothing <$ do
+                        shouldStop <- readTVar delay
+                        check shouldStop
+                    ]
+              cancel worker
+              logRecordExporterShutdown batchLogExporter
+              pure $ case shutdownResult of
+                Nothing -> ShutdownTimeout
+                Just (Left _) -> ShutdownFailure
+                Just (Right _) -> ShutdownSuccess
+      }
+  where
+    millisToMicros = (* 1000)
+
+
+-- TODO: otel-12 introduces OpenTelemetry.Internal.Logging (otelLogWarning)
+-- which respects OTEL_LOG_LEVEL and the global error handler.
+-- Replace hPutStrLn stderr with otelLogWarning once available.
+warnOnDrop :: IORef Int -> IORef Bool -> Int -> String -> IO ()
+warnOnDrop droppedRef warnedRef capacity processorName = do
+  n <- atomicModifyIORef' droppedRef (\c -> let c' = c + 1 in (c', c'))
+  alreadyWarned <- atomicModifyIORef' warnedRef (\w -> (True, w))
+  unless alreadyWarned $
+    hPutStrLn stderr $
+      "OpenTelemetry [WARN] "
+        <> processorName
+        <> ": queue full (capacity "
+        <> show capacity
+        <> "), dropping log record. Total dropped so far: "
+        <> show n

--- a/sdk/src/OpenTelemetry/Processor/Simple/LogRecord.hs
+++ b/sdk/src/OpenTelemetry/Processor/Simple/LogRecord.hs
@@ -1,2 +1,101 @@
-module OpenTelemetry.Processor.Simple.LogRecord () where
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
+module OpenTelemetry.Processor.Simple.LogRecord (
+  SimpleLogRecordProcessorConfig (..),
+  simpleLogRecordProcessor,
+) where
+
+import Control.Concurrent.Async
+import Control.Concurrent.STM
+import Control.Monad
+import Data.IORef
+import qualified Data.Vector as V
+import OpenTelemetry.Internal.Common.Types (ShutdownResult (..))
+import OpenTelemetry.Internal.Logs.Types
+import System.IO (hPutStrLn, stderr)
+
+
+data SimpleLogRecordProcessorConfig = SimpleLogRecordProcessorConfig
+  { simpleLogRecordExporter :: LogRecordExporter
+  , simpleLogRecordExportTimeoutMicros :: !Int
+  -- ^ Timeout for individual export calls in microseconds. Default: 30s.
+  }
+
+
+defaultSimpleQueueBound :: Int
+defaultSimpleQueueBound = 2048
+
+
+simpleLogRecordProcessor :: SimpleLogRecordProcessorConfig -> IO LogRecordProcessor
+simpleLogRecordProcessor SimpleLogRecordProcessorConfig {..} = do
+  queue <- newTBQueueIO (fromIntegral defaultSimpleQueueBound)
+  droppedRef <- newIORef (0 :: Int)
+  warnedRef <- newIORef False
+  shutdownVar <- newTVarIO False
+  flushReq <- newEmptyTMVarIO
+  flushDone <- newEmptyTMVarIO
+
+  let exportOne rw = do
+        let readable = mkReadableLogRecord rw
+        mask_ (logRecordExporterExport simpleLogRecordExporter (V.singleton readable))
+
+  let drainQueue = do
+        mRw <- atomically $ tryReadTBQueue queue
+        case mRw of
+          Nothing -> pure ()
+          Just rw -> do
+            _ <- exportOne rw
+            drainQueue
+
+  let workerLoop = do
+        cmd <-
+          atomically $
+            msum
+              [ Nothing <$ (readTVar shutdownVar >>= check)
+              , Just Nothing <$ takeTMVar flushReq
+              , Just . Just <$> readTBQueue queue
+              ]
+        case cmd of
+          Nothing -> do
+            drainQueue
+            void $ atomically $ tryPutTMVar flushDone ()
+          Just Nothing -> do
+            drainQueue
+            atomically $ putTMVar flushDone ()
+            workerLoop
+          Just (Just rw) -> do
+            _ <- exportOne rw
+            workerLoop
+
+  exportWorker <- async workerLoop
+
+  pure
+    LogRecordProcessor
+      { logRecordProcessorOnEmit = \lr _ctxt -> do
+          written <- atomically $ tryWriteTBQueue queue lr
+          unless written $ do
+            n <- atomicModifyIORef' droppedRef (\c -> let c' = c + 1 in (c', c'))
+            alreadyWarned <- atomicModifyIORef' warnedRef (\w -> (True, w))
+            -- TODO: otel-12 introduces OpenTelemetry.Internal.Logging (otelLogWarning)
+            -- which respects OTEL_LOG_LEVEL and the global error handler.
+            -- Replace hPutStrLn stderr with otelLogWarning once available.
+            unless alreadyWarned $
+              hPutStrLn stderr $
+                "OpenTelemetry [WARN] SimpleLogRecordProcessor: queue full (capacity "
+                  <> show defaultSimpleQueueBound
+                  <> "), dropping log record. Total dropped so far: "
+                  <> show n
+      , logRecordProcessorShutdown = do
+          atomically $ writeTVar shutdownVar True
+          async $ do
+            wait exportWorker
+            logRecordExporterShutdown simpleLogRecordExporter
+            pure ShutdownSuccess
+      , logRecordProcessorForceFlush = do
+          isShut <- readTVarIO shutdownVar
+          unless isShut $ do
+            atomically $ putTMVar flushReq ()
+            atomically $ takeTMVar flushDone
+          logRecordExporterForceFlush simpleLogRecordExporter
+      }


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #246.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)