### PR TITLE
feat(exporters): OTLP, handle, and in-memory log exporters

### DIFF
--- a/exporters/handle/ChangeLog.md
+++ b/exporters/handle/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New `OpenTelemetry.Exporter.Handle.LogRecord` module (console log exporter with default formatter)
 - New `OpenTelemetry.Exporter.Handle.Metric` module (console metric exporter)
 
 ## 0.0.1.3

--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -26,10 +26,10 @@ source-repository head
 library
   exposed-modules:
       OpenTelemetry.Exporter.Handle
+      OpenTelemetry.Exporter.Handle.LogRecord
       OpenTelemetry.Exporter.Handle.Metric
       OpenTelemetry.Exporter.Handle.Span
   other-modules:
-      OpenTelemetry.Exporter.Handle.LogRecord
       Paths_hs_opentelemetry_exporter_handle
   hs-source-dirs:
       src
@@ -37,4 +37,5 @@ library
       base >=4.7 && <5
     , hs-opentelemetry-api ==0.3.*
     , text
+    , vector
   default-language: Haskell2010

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -26,11 +26,13 @@ library:
   source-dirs: src
   exposed-modules:
   - OpenTelemetry.Exporter.Handle
+  - OpenTelemetry.Exporter.Handle.LogRecord
   - OpenTelemetry.Exporter.Handle.Metric
   - OpenTelemetry.Exporter.Handle.Span
   dependencies:
   - hs-opentelemetry-api ^>= 0.3
   - text
+  - vector
 
 # Test suite not yet implemented
 _tests:

--- a/exporters/handle/src/OpenTelemetry/Exporter/Handle/LogRecord.hs
+++ b/exporters/handle/src/OpenTelemetry/Exporter/Handle/LogRecord.hs
@@ -1,2 +1,94 @@
-module OpenTelemetry.Exporter.Handle.LogRecord () where
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
+module OpenTelemetry.Exporter.Handle.LogRecord (
+  makeHandleLogRecordExporter,
+  stdoutLogRecordExporter,
+  stderrLogRecordExporter,
+  defaultLogRecordFormatter,
+) where
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LB
+import Data.Text.Lazy.Builder.Int (decimal)
+import Data.Text.Lazy.Builder.RealFloat (realFloat)
+import qualified Data.Vector as V
+import OpenTelemetry.Internal.Common.Types (ExportResult (..), InstrumentationLibrary (..))
+import OpenTelemetry.Internal.Logs.Types
+import OpenTelemetry.LogAttributes (AnyValue (..), LogAttributes (..))
+import System.IO (Handle, hFlush, stderr, stdout)
+
+
+builderText :: LB.Builder -> T.Text
+builderText = LT.toStrict . LB.toLazyText
+
+
+textIntegral :: (Integral n) => n -> T.Text
+textIntegral = builderText . decimal
+
+
+textDouble :: Double -> T.Text
+textDouble = builderText . realFloat
+
+
+makeHandleLogRecordExporter :: Handle -> (ReadableLogRecord -> IO T.Text) -> IO LogRecordExporter
+makeHandleLogRecordExporter h formatter =
+  mkLogRecordExporter
+    LogRecordExporterArguments
+      { logRecordExporterArgumentsExport = \lrs -> do
+          V.mapM_ (\lr -> formatter lr >>= T.hPutStrLn h >> hFlush h) lrs
+          pure Success
+      , logRecordExporterArgumentsForceFlush = hFlush h
+      , logRecordExporterArgumentsShutdown = hFlush h
+      }
+
+
+stdoutLogRecordExporter :: IO LogRecordExporter
+stdoutLogRecordExporter = makeHandleLogRecordExporter stdout defaultLogRecordFormatter
+
+
+stderrLogRecordExporter :: IO LogRecordExporter
+stderrLogRecordExporter = makeHandleLogRecordExporter stderr defaultLogRecordFormatter
+
+
+defaultLogRecordFormatter :: ReadableLogRecord -> IO T.Text
+defaultLogRecordFormatter lr = do
+  ImmutableLogRecord {..} <- readLogRecord lr
+  let scope_ = readLogRecordInstrumentationScope lr
+  let sevText = case logRecordSeverityText of
+        Just s -> s
+        Nothing -> "UNSET"
+  let bodyText = case logRecordBody of
+        TextValue t -> t
+        IntValue i -> textIntegral i
+        DoubleValue d -> textDouble d
+        BoolValue b -> if b then "true" else "false"
+        NullValue -> ""
+        _ -> T.pack (show logRecordBody)
+  let traceInfo = case logRecordTracingDetails of
+        Just (tid, sid, _flags) -> " trace=" <> T.pack (show tid) <> " span=" <> T.pack (show sid)
+        Nothing -> ""
+  let LogAttributes {attributesCount = attrCount, attributesDropped = droppedCount} = logRecordAttributes
+  let attrInfo =
+        if attrCount > 0
+          then " attrs=" <> textIntegral attrCount <> if droppedCount > 0 then " dropped=" <> textIntegral droppedCount else ""
+          else ""
+  let eventInfo = case logRecordEventName of
+        Just en -> " event=" <> en
+        Nothing -> ""
+  pure $
+    T.concat
+      [ T.pack (show logRecordObservedTimestamp)
+      , " "
+      , sevText
+      , " ["
+      , libraryName scope_
+      , "]"
+      , eventInfo
+      , " "
+      , bodyText
+      , traceInfo
+      , attrInfo
+      ]

--- a/exporters/in-memory/ChangeLog.md
+++ b/exporters/in-memory/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New `OpenTelemetry.Exporter.InMemory.LogRecord` module (in-memory log exporter for testing)
 - New `OpenTelemetry.Exporter.InMemory.Metric` module (in-memory metric exporter for tests)
 
 ## 0.0.1.5

--- a/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
+++ b/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
@@ -26,10 +26,10 @@ source-repository head
 library
   exposed-modules:
       OpenTelemetry.Exporter.InMemory
+      OpenTelemetry.Exporter.InMemory.LogRecord
       OpenTelemetry.Exporter.InMemory.Metric
       OpenTelemetry.Exporter.InMemory.Span
   other-modules:
-      OpenTelemetry.Exporter.InMemory.LogRecord
       Paths_hs_opentelemetry_exporter_in_memory
   hs-source-dirs:
       src
@@ -39,4 +39,5 @@ library
     , base >=4.7 && <5
     , hs-opentelemetry-api ==0.3.*
     , unagi-chan
+    , vector
   default-language: Haskell2010

--- a/exporters/in-memory/package.yaml
+++ b/exporters/in-memory/package.yaml
@@ -27,12 +27,14 @@ library:
   source-dirs: src
   exposed-modules:
   - OpenTelemetry.Exporter.InMemory
+  - OpenTelemetry.Exporter.InMemory.LogRecord
   - OpenTelemetry.Exporter.InMemory.Metric
   - OpenTelemetry.Exporter.InMemory.Span
   dependencies:
   - hs-opentelemetry-api ^>= 0.3
   - async
   - unagi-chan
+  - vector
 
 # Test suite not yet implemented
 _tests:

--- a/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory/LogRecord.hs
+++ b/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory/LogRecord.hs
@@ -1,2 +1,30 @@
-module OpenTelemetry.Exporter.InMemory.LogRecord () where
+module OpenTelemetry.Exporter.InMemory.LogRecord (
+  inMemoryLogRecordExporter,
+  getExportedLogRecords,
+) where
 
+import Control.Monad.IO.Class
+import Data.IORef
+import qualified Data.Vector as V
+import OpenTelemetry.Internal.Common.Types (ExportResult (..))
+import OpenTelemetry.Internal.Logs.Types
+
+
+inMemoryLogRecordExporter :: (MonadIO m) => m (LogRecordExporter, IORef [ReadableLogRecord])
+inMemoryLogRecordExporter = liftIO $ do
+  ref <- newIORef []
+  exporter <-
+    mkLogRecordExporter
+      LogRecordExporterArguments
+        { logRecordExporterArgumentsExport = \lrs -> do
+            let newRecords = V.toList lrs
+            atomicModifyIORef ref (\existing -> (newRecords ++ existing, ()))
+            pure Success
+        , logRecordExporterArgumentsForceFlush = pure ()
+        , logRecordExporterArgumentsShutdown = pure ()
+        }
+  pure (exporter, ref)
+
+
+getExportedLogRecords :: (MonadIO m) => IORef [ReadableLogRecord] -> m [ReadableLogRecord]
+getExportedLogRecords = liftIO . readIORef

--- a/exporters/otlp/ChangeLog.md
+++ b/exporters/otlp/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Implement `OpenTelemetry.Exporter.OTLP.LogRecord` — full OTLP HTTP/Protobuf log exporter with retry, compression, and severity/AnyValue/tracing-context serialization
 - Use `startTimeUnixNano` from data points instead of hardcoded 0
 - Comprehensive protobuf round-trip tests for all metric types
 - OTLP metrics: exemplars on number and histogram data points; exponential histogram messages; aggregation temporality from export model.

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
@@ -1,2 +1,365 @@
-module OpenTelemetry.Exporter.OTLP.LogRecord () where
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
+module OpenTelemetry.Exporter.OTLP.LogRecord (
+  otlpLogRecordExporter,
+  immutableLogRecordToProto,
+) where
+
+import Codec.Compression.GZip (compress)
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeAsyncException (..), SomeException (..), fromException, throwIO, try)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Bits (shiftL)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Lazy as L
+import qualified Data.HashMap.Strict as H
+import Data.List (isInfixOf)
+import Data.Maybe (fromMaybe)
+import Data.ProtoLens (defMessage, encodeMessage)
+import qualified Data.ProtoLens as ProtoLens
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import Data.Word (Word64)
+import Lens.Micro ((&), (.~))
+import Network.HTTP.Client
+import qualified Network.HTTP.Client as HTTPClient
+import Network.HTTP.Simple (httpBS)
+import Network.HTTP.Types.Header
+import Network.HTTP.Types.Status
+import qualified OpenTelemetry.Attributes as A
+import OpenTelemetry.Common (Timestamp (..))
+import OpenTelemetry.Exporter.OTLP.Span (CompressionFormat (..), OTLPExporterConfig (..))
+import OpenTelemetry.Internal.Common.Types
+import OpenTelemetry.Internal.Logs.Types
+import OpenTelemetry.Internal.Trace.Id (spanIdBytes, traceIdBytes)
+import OpenTelemetry.LogAttributes (AnyValue (..), LogAttributes (..))
+import OpenTelemetry.Resource (MaterializedResources, emptyMaterializedResources, getMaterializedResourcesAttributes, getMaterializedResourcesSchema)
+import OpenTelemetry.Trace.Core (timestampNanoseconds, traceFlagsValue)
+import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService (ExportLogsServiceRequest)
+import qualified Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService_Fields as LSF
+import Proto.Opentelemetry.Proto.Common.V1.Common (InstrumentationScope, KeyValue)
+import qualified Proto.Opentelemetry.Proto.Common.V1.Common as Common
+import qualified Proto.Opentelemetry.Proto.Common.V1.Common_Fields as CF
+import Proto.Opentelemetry.Proto.Logs.V1.Logs (ResourceLogs, ScopeLogs)
+import qualified Proto.Opentelemetry.Proto.Logs.V1.Logs as PL
+import qualified Proto.Opentelemetry.Proto.Logs.V1.Logs_Fields as LF
+import qualified Proto.Opentelemetry.Proto.Resource.V1.Resource as Res
+import qualified Proto.Opentelemetry.Proto.Resource.V1.Resource_Fields as RF
+import Text.Read (readMaybe)
+
+
+defaultExporterTimeout :: Int
+defaultExporterTimeout = 10_000
+
+
+httpProtobufMimeType :: C.ByteString
+httpProtobufMimeType = "application/x-protobuf"
+
+
+otlpLogRecordExporter :: (MonadIO m) => OTLPExporterConfig -> m LogRecordExporter
+otlpLogRecordExporter conf = liftIO $ do
+  req <- parseRequest (logsEndpointUrl conf)
+  let (encodingHeaders, encoder) = httpLogsCompression conf
+  let baseReq =
+        req
+          { method = "POST"
+          , requestHeaders = encodingHeaders <> httpLogsBaseHeaders conf req
+          , responseTimeout = httpLogsResponseTimeout conf
+          }
+  mkLogRecordExporter
+    LogRecordExporterArguments
+      { logRecordExporterArgumentsExport = \lrs -> do
+          if V.null lrs
+            then pure Success
+            else do
+              result <- try $ exporterExportCall encoder baseReq lrs
+              case result of
+                Left err -> case fromException err of
+                  Just (SomeAsyncException _) -> throwIO err
+                  Nothing -> pure $ Failure $ Just err
+                Right ok -> pure ok
+      , logRecordExporterArgumentsForceFlush = pure ()
+      , logRecordExporterArgumentsShutdown = pure ()
+      }
+  where
+    retryDelay = 100_000
+    maxRetryCount = 5
+    isRetryableStatusCode status_ =
+      status_ == status408 || status_ == status429 || (statusCode status_ >= 500 && statusCode status_ < 600)
+    isRetryableException = \case
+      ResponseTimeout -> True
+      ConnectionTimeout -> True
+      ConnectionFailure _ -> True
+      ConnectionClosed -> True
+      _ -> False
+
+    exporterExportCall encoder baseReq lrs = do
+      rl <- buildResourceLogsFromBatch lrs
+      let exportReq :: ExportLogsServiceRequest
+          exportReq =
+            defMessage
+              & LSF.vec'resourceLogs
+                .~ V.singleton rl
+      let msg = encodeMessage exportReq
+      let req =
+            baseReq
+              { requestBody = RequestBodyLBS $ encoder $ L.fromStrict msg
+              }
+      sendReq req 0
+
+    sendReq req backoffCount = do
+      eResp <- try $ httpBS req
+      let exponentialBackoff =
+            if backoffCount == maxRetryCount
+              then pure $ Failure Nothing
+              else do
+                threadDelay (retryDelay `shiftL` backoffCount)
+                sendReq req (backoffCount + 1)
+      case eResp of
+        Left err@(HttpExceptionRequest req' e)
+          | HTTPClient.host req' == "localhost"
+          , HTTPClient.port req' == 4317 || HTTPClient.port req' == 4318
+          , ConnectionFailure _ <- e ->
+              pure $ Failure Nothing
+          | otherwise ->
+              if isRetryableException e
+                then exponentialBackoff
+                else pure $ Failure $ Just $ SomeException err
+        Left err -> pure $ Failure $ Just $ SomeException err
+        Right resp ->
+          if isRetryableStatusCode (responseStatus resp)
+            then case lookup hRetryAfter $ responseHeaders resp of
+              Nothing -> exponentialBackoff
+              Just retryAfter -> case readMaybe $ C.unpack retryAfter of
+                Nothing -> exponentialBackoff
+                Just seconds -> do
+                  threadDelay (seconds * 1_000_000)
+                  sendReq req (backoffCount + 1)
+            else
+              if statusCode (responseStatus resp) >= 300
+                then pure $ Failure Nothing
+                else pure Success
+
+
+groupByScope
+  :: H.HashMap InstrumentationLibrary [ReadableLogRecord]
+  -> ReadableLogRecord
+  -> IO (H.HashMap InstrumentationLibrary [ReadableLogRecord])
+groupByScope acc lr = do
+  let scope = readLogRecordInstrumentationScope lr
+  pure $ H.insertWith (++) scope [lr] acc
+
+
+buildResourceLogsFromBatch :: V.Vector ReadableLogRecord -> IO ResourceLogs
+buildResourceLogsFromBatch lrs = do
+  grouped <- V.foldM' groupByScope H.empty lrs
+  scopeLogsList <- mapM (uncurry buildScopeLogs) (H.toList grouped)
+  let res = if V.null lrs then emptyMaterializedResources else readLogRecordResource (V.head lrs)
+  pure $
+    defMessage
+      & LF.resource
+        .~ materializedResourceToProto res
+      & LF.vec'scopeLogs
+        .~ V.fromList scopeLogsList
+      & LF.schemaUrl
+        .~ maybe T.empty T.pack (getMaterializedResourcesSchema res)
+
+
+buildScopeLogs :: InstrumentationLibrary -> [ReadableLogRecord] -> IO ScopeLogs
+buildScopeLogs scope lrs = do
+  protoRecords <- mapM readableLogRecordToProtoIO lrs
+  pure $
+    defMessage
+      & LF.scope
+        .~ instrumentationLibraryToProto scope
+      & LF.vec'logRecords
+        .~ V.fromList protoRecords
+      & LF.schemaUrl
+        .~ librarySchemaUrl scope
+
+
+readableLogRecordToProtoIO :: ReadableLogRecord -> IO PL.LogRecord
+readableLogRecordToProtoIO rlr = do
+  ilr <- readLogRecord rlr
+  pure $ immutableLogRecordToProto ilr
+
+
+immutableLogRecordToProto :: ImmutableLogRecord -> PL.LogRecord
+immutableLogRecordToProto ImmutableLogRecord {..} =
+  defMessage
+    & LF.timeUnixNano
+      .~ maybe 0 tsToNanos logRecordTimestamp
+    & LF.observedTimeUnixNano
+      .~ tsToNanos logRecordObservedTimestamp
+    & LF.severityNumber
+      .~ maybe PL.SEVERITY_NUMBER_UNSPECIFIED severityToProto logRecordSeverityNumber
+    & LF.severityText
+      .~ fromMaybe "" logRecordSeverityText
+    & LF.maybe'body
+      .~ Just (anyValueToProto logRecordBody)
+    & LF.vec'attributes
+      .~ logAttributesToProto logRecordAttributes
+    & LF.droppedAttributesCount
+      .~ fromIntegral (attributesDropped logRecordAttributes)
+    & LF.traceId
+      .~ maybe BS.empty (\(tid, _, _) -> traceIdBytes tid) logRecordTracingDetails
+    & LF.spanId
+      .~ maybe BS.empty (\(_, sid, _) -> spanIdBytes sid) logRecordTracingDetails
+    & LF.flags
+      .~ maybe 0 (\(_, _, fl) -> fromIntegral (traceFlagsValue fl)) logRecordTracingDetails
+    & LF.eventName
+      .~ fromMaybe "" logRecordEventName
+
+
+tsToNanos :: Timestamp -> Word64
+tsToNanos = fromIntegral . timestampNanoseconds
+
+
+severityToProto :: SeverityNumber -> PL.SeverityNumber
+severityToProto = \case
+  Trace -> PL.SEVERITY_NUMBER_TRACE
+  Trace2 -> PL.SEVERITY_NUMBER_TRACE2
+  Trace3 -> PL.SEVERITY_NUMBER_TRACE3
+  Trace4 -> PL.SEVERITY_NUMBER_TRACE4
+  Debug -> PL.SEVERITY_NUMBER_DEBUG
+  Debug2 -> PL.SEVERITY_NUMBER_DEBUG2
+  Debug3 -> PL.SEVERITY_NUMBER_DEBUG3
+  Debug4 -> PL.SEVERITY_NUMBER_DEBUG4
+  Info -> PL.SEVERITY_NUMBER_INFO
+  Info2 -> PL.SEVERITY_NUMBER_INFO2
+  Info3 -> PL.SEVERITY_NUMBER_INFO3
+  Info4 -> PL.SEVERITY_NUMBER_INFO4
+  Warn -> PL.SEVERITY_NUMBER_WARN
+  Warn2 -> PL.SEVERITY_NUMBER_WARN2
+  Warn3 -> PL.SEVERITY_NUMBER_WARN3
+  Warn4 -> PL.SEVERITY_NUMBER_WARN4
+  Error -> PL.SEVERITY_NUMBER_ERROR
+  Error2 -> PL.SEVERITY_NUMBER_ERROR2
+  Error3 -> PL.SEVERITY_NUMBER_ERROR3
+  Error4 -> PL.SEVERITY_NUMBER_ERROR4
+  Fatal -> PL.SEVERITY_NUMBER_FATAL
+  Fatal2 -> PL.SEVERITY_NUMBER_FATAL2
+  Fatal3 -> PL.SEVERITY_NUMBER_FATAL3
+  Fatal4 -> PL.SEVERITY_NUMBER_FATAL4
+  Unknown n -> fromMaybe PL.SEVERITY_NUMBER_UNSPECIFIED (ProtoLens.maybeToEnum n)
+
+
+logAttributesToProto :: LogAttributes -> V.Vector KeyValue
+logAttributesToProto LogAttributes {..} =
+  V.fromList $ fmap anyValueToKeyValue $ H.toList attributes
+  where
+    anyValueToKeyValue :: (Text, OpenTelemetry.LogAttributes.AnyValue) -> KeyValue
+    anyValueToKeyValue (k, v) =
+      defMessage
+        & CF.key .~ k
+        & CF.value .~ anyValueToProto v
+
+
+anyValueToProto :: OpenTelemetry.LogAttributes.AnyValue -> Common.AnyValue
+anyValueToProto = \case
+  TextValue t -> defMessage & CF.stringValue .~ t
+  BoolValue b -> defMessage & CF.boolValue .~ b
+  DoubleValue d -> defMessage & CF.doubleValue .~ d
+  IntValue i -> defMessage & CF.intValue .~ fromIntegral i
+  ByteStringValue bs -> defMessage & CF.bytesValue .~ bs
+  ArrayValue arr ->
+    defMessage
+      & CF.arrayValue
+        .~ (defMessage & CF.values .~ fmap anyValueToProto arr)
+  HashMapValue hm ->
+    defMessage
+      & CF.kvlistValue
+        .~ (defMessage & CF.values .~ fmap (\(k, v) -> defMessage & CF.key .~ k & CF.value .~ anyValueToProto v) (H.toList hm))
+  NullValue -> defMessage
+
+
+materializedResourceToProto :: MaterializedResources -> Res.Resource
+materializedResourceToProto r =
+  let attrs = getMaterializedResourcesAttributes r
+  in defMessage
+       & RF.vec'attributes
+         .~ attrsToProto attrs
+       & RF.droppedAttributesCount
+         .~ fromIntegral (A.getCount attrs)
+
+
+instrumentationLibraryToProto :: InstrumentationLibrary -> InstrumentationScope
+instrumentationLibraryToProto InstrumentationLibrary {..} =
+  defMessage
+    & CF.name .~ libraryName
+    & CF.version .~ libraryVersion
+    & CF.vec'attributes .~ attrsToProto libraryAttributes
+    & CF.droppedAttributesCount .~ fromIntegral (A.getCount libraryAttributes)
+
+
+attrsToProto :: A.Attributes -> V.Vector KeyValue
+attrsToProto =
+  V.fromList
+    . fmap attrToKeyValue
+    . H.toList
+    . A.getAttributeMap
+  where
+    primToAnyValue = \case
+      A.TextAttribute t -> defMessage & CF.stringValue .~ t
+      A.BoolAttribute b -> defMessage & CF.boolValue .~ b
+      A.DoubleAttribute d -> defMessage & CF.doubleValue .~ d
+      A.IntAttribute i -> defMessage & CF.intValue .~ i
+    attrToKeyValue :: (Text, A.Attribute) -> KeyValue
+    attrToKeyValue (k, v) =
+      defMessage
+        & CF.key .~ k
+        & CF.value
+          .~ ( case v of
+                 A.AttributeValue a -> primToAnyValue a
+                 A.AttributeArray a ->
+                   defMessage
+                     & CF.arrayValue
+                       .~ (defMessage & CF.values .~ fmap primToAnyValue a)
+             )
+
+
+type Encoder = L.ByteString -> L.ByteString
+
+
+httpLogsCompression :: OTLPExporterConfig -> ([(HeaderName, C.ByteString)], Encoder)
+httpLogsCompression conf =
+  case otlpCompression conf of
+    Just GZip -> ([(hContentEncoding, "gzip")], compress)
+    _ -> ([], id)
+
+
+httpLogsResponseTimeout :: OTLPExporterConfig -> ResponseTimeout
+httpLogsResponseTimeout conf = case otlpTimeout conf of
+  Just timeoutMilli
+    | timeoutMilli == 0 -> responseTimeoutNone
+    | timeoutMilli >= 1 -> responseTimeoutMicro (timeoutMilli * 1_000)
+  _ -> responseTimeoutMicro (defaultExporterTimeout * 1_000)
+
+
+httpLogsBaseHeaders :: OTLPExporterConfig -> Request -> RequestHeaders
+httpLogsBaseHeaders conf req =
+  concat
+    [ [(hContentType, httpProtobufMimeType)]
+    , [(hAcceptEncoding, httpProtobufMimeType)]
+    , fromMaybe [] (otlpHeaders conf)
+    , requestHeaders req
+    ]
+
+
+logsEndpointUrl :: OTLPExporterConfig -> String
+logsEndpointUrl conf =
+  case otlpEndpoint conf of
+    Nothing -> "http://localhost:4318/v1/logs"
+    Just e ->
+      if "/v1/" `isInfixOf` e
+        then e
+        else trimTrailingSlash e <> "/v1/logs"
+
+
+trimTrailingSlash :: String -> String
+trimTrailingSlash = reverse . dropWhile (== '/') . reverse


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #247.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)