### PR TITLE
fix: propagate shutdown/forceflush across all signals, fix barrel module exports

### DIFF
--- a/exporters/handle/ChangeLog.md
+++ b/exporters/handle/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `OpenTelemetry.Exporter.Handle` barrel now re-exports all three signals (Span, Metric, LogRecord); deprecated annotation removed
 - New `OpenTelemetry.Exporter.Handle.LogRecord` module (console log exporter with default formatter)
 - New `OpenTelemetry.Exporter.Handle.Metric` module (console metric exporter)
 

--- a/exporters/handle/src/OpenTelemetry/Exporter/Handle.hs
+++ b/exporters/handle/src/OpenTelemetry/Exporter/Handle.hs
@@ -1,7 +1,10 @@
-module OpenTelemetry.Exporter.Handle
-  {-# DEPRECATED "use OpenTelemetry.Exporter.Handle.Span instead" #-} (
+module OpenTelemetry.Exporter.Handle (
   module OpenTelemetry.Exporter.Handle.Span,
+  module OpenTelemetry.Exporter.Handle.Metric,
+  module OpenTelemetry.Exporter.Handle.LogRecord,
 ) where
 
+import OpenTelemetry.Exporter.Handle.LogRecord
+import OpenTelemetry.Exporter.Handle.Metric
 import OpenTelemetry.Exporter.Handle.Span
 

--- a/exporters/in-memory/ChangeLog.md
+++ b/exporters/in-memory/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `OpenTelemetry.Exporter.InMemory` barrel now re-exports all three signals (Span, Metric, LogRecord); deprecated annotation removed
 - New `OpenTelemetry.Exporter.InMemory.LogRecord` module (in-memory log exporter for testing)
 - New `OpenTelemetry.Exporter.InMemory.Metric` module (in-memory metric exporter for tests)
 

--- a/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory.hs
+++ b/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory.hs
@@ -1,7 +1,10 @@
-module OpenTelemetry.Exporter.InMemory
-  {-# DEPRECATED "use OpenTelemetry.Exporter.InMemory.Span instead" #-} (
+module OpenTelemetry.Exporter.InMemory (
   module OpenTelemetry.Exporter.InMemory.Span,
+  module OpenTelemetry.Exporter.InMemory.Metric,
+  module OpenTelemetry.Exporter.InMemory.LogRecord,
 ) where
 
+import OpenTelemetry.Exporter.InMemory.LogRecord
+import OpenTelemetry.Exporter.InMemory.Metric
 import OpenTelemetry.Exporter.InMemory.Span
 

--- a/exporters/otlp/ChangeLog.md
+++ b/exporters/otlp/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Implement `OpenTelemetry.Exporter.OTLP.LogRecord` — full OTLP HTTP/Protobuf log exporter with retry, compression, and severity/AnyValue/tracing-context serialization
+- `OpenTelemetry.Exporter.OTLP` barrel module now re-exports all three signals (Span, Metric, LogRecord)
 - Use `startTimeUnixNano` from data points instead of hardcoded 0
 - Comprehensive protobuf round-trip tests for all metric types
 - OTLP metrics: exemplars on number and histogram data points; exponential histogram messages; aggregation temporality from export model.

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP.hs
@@ -1,8 +1,10 @@
 module OpenTelemetry.Exporter.OTLP (
   module OpenTelemetry.Exporter.OTLP.Span,
   module OpenTelemetry.Exporter.OTLP.Metric,
+  module OpenTelemetry.Exporter.OTLP.LogRecord,
 ) where
 
+import OpenTelemetry.Exporter.OTLP.LogRecord
 import OpenTelemetry.Exporter.OTLP.Metric
 import OpenTelemetry.Exporter.OTLP.Span
 

--- a/sdk/ChangeLog.md
+++ b/sdk/ChangeLog.md
@@ -2,8 +2,14 @@
 
 ## Unreleased
 
-- Batch/simple span processors now call `spanExporterForceFlush` during processor `ForceFlush`
-- IsValid test coverage expanded for TraceId-only and SpanId-only zero cases
+- **Shutdown/ForceFlush propagation audit:**
+  - Batch span processor now calls `spanExporterShutdown` during processor shutdown (was missing)
+  - Batch log processor now calls `logRecordExporterShutdown` during processor shutdown
+  - `MeterProvider` shutdown now does a final collect + export + `metricExporterShutdown` when an exporter is configured
+  - `MeterProvider` forceFlush now does collect + export + `metricExporterForceFlush` when an exporter is configured
+  - `SdkMeterProviderOptions` gains `metricExporter :: Maybe MetricExporter` field
+  - Periodic metric reader stop now calls `metricExporterShutdown` after final export
+  - `forceFlushTracerProvider` exported from `OpenTelemetry.Trace` (SDK)
 - Track `startTimeUnixNano` across all data points (was hardcoded to 0)
 - `ForceFlush` on `MeterProvider` now triggers a metric collect
 - `View` supports name and description overrides

--- a/sdk/src/OpenTelemetry/MeterProvider.hs
+++ b/sdk/src/OpenTelemetry/MeterProvider.hs
@@ -51,6 +51,7 @@ import OpenTelemetry.Exporter.Metric (
   HistogramDataPoint (..),
   MetricExemplar (..),
   MetricExport (..),
+  MetricExporter (..),
   ResourceMetricsExport (..),
   ScopeMetricsExport (..),
   SumDataPoint (..),
@@ -102,6 +103,7 @@ data SdkMeterProviderOptions = SdkMeterProviderOptions
   , aggregationTemporality :: !AggregationTemporality
   , views :: ![View]
   , exemplarOptions :: !SdkMeterExemplarOptions
+  , metricExporter :: !(Maybe MetricExporter)
   }
 
 
@@ -112,6 +114,7 @@ defaultSdkMeterProviderOptions =
     , aggregationTemporality = AggregationCumulative
     , views = []
     , exemplarOptions = defaultSdkMeterExemplarOptions
+    , metricExporter = Nothing
     }
 
 
@@ -1217,6 +1220,7 @@ createMeterProvider res opts = do
           , sdkMeterExemplarOptions = exOpts
           , sdkMeterStartTimeNanos = startT
           }
+      mExporter = metricExporter opts
       provider =
         MeterProvider
           { meterProviderGetMeter = \scope -> do
@@ -1224,11 +1228,21 @@ createMeterProvider res opts = do
               if shut then pure (noopMeter scope) else pure (mkMeter env scope)
           , meterProviderShutdown = do
               writeIORef sd True
+              batches <- collectResourceMetrics env
+              result <- case mExporter of
+                Just ex -> do
+                  _ <- metricExporterExport ex batches
+                  metricExporterShutdown ex
+                Nothing -> pure ShutdownSuccess
               writeIORef st emptyStorageState
               writeIORef cbs Seq.empty
-              pure ShutdownSuccess
+              pure result
           , meterProviderForceFlush = do
-              _ <- collectResourceMetrics env
-              pure FlushSuccess
+              batches <- collectResourceMetrics env
+              case mExporter of
+                Just ex -> do
+                  _ <- metricExporterExport ex batches
+                  metricExporterForceFlush ex
+                Nothing -> pure FlushSuccess
           }
   pure (provider, env)

--- a/sdk/src/OpenTelemetry/MetricReader.hs
+++ b/sdk/src/OpenTelemetry/MetricReader.hs
@@ -81,6 +81,7 @@ forkPeriodicMetricReader env ex opts = do
         cancel a
         _ <- waitCatch a
         _ <- exportMetricsOnce env ex
+        _ <- metricExporterShutdown ex
         pure ()
   pure $
     PeriodicMetricReaderHandle

--- a/sdk/src/OpenTelemetry/Processor/Batch/LogRecord.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch/LogRecord.hs
@@ -15,9 +15,10 @@ import Control.Monad.IO.Class
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
-import OpenTelemetry.Internal.Common.Types (ShutdownResult (..))
+import OpenTelemetry.Internal.Common.Types (ExportResult (..), ShutdownResult (..))
 import OpenTelemetry.Internal.Logs.Types
 import System.IO (hPutStrLn, stderr)
+import System.Timeout (timeout)
 import VectorBuilder.Builder as Builder
 import VectorBuilder.Vector as Builder
 
@@ -56,7 +57,7 @@ emptyBuffer bounds exportBounds = BoundedBuffer bounds exportBounds 0 mempty
 
 pushBuffer :: ReadableLogRecord -> BoundedBuffer -> Maybe BoundedBuffer
 pushBuffer lr buf
-  | bufCount buf + 1 >= bufBounds buf = Nothing
+  | bufCount buf >= bufBounds buf = Nothing
   | otherwise =
       Just $!
         buf
@@ -87,16 +88,34 @@ batchLogRecordProcessor BatchLogRecordProcessorConfig {..} = liftIO $ do
   flushRequestSignal <- newEmptyTMVarIO
   flushDoneSignal <- newEmptyTMVarIO
 
-  let publish batchToExport =
-        mask_ $
-          logRecordExporterExport batchLogExporter batchToExport
+  let timeoutMicros = millisToMicros batchLogExportTimeoutMillis
+
+  let publish batchToExport = do
+        mResult <-
+          timeout timeoutMicros $
+            mask_ $
+              logRecordExporterExport batchLogExporter batchToExport
+        pure $ case mResult of
+          Nothing -> Failure Nothing
+          Just r -> r
+
+  let publishBounded batchToExport
+        | V.null batchToExport = pure Success
+        | V.length batchToExport <= batchLogMaxExportBatchSize =
+            publish batchToExport
+        | otherwise = do
+            let (chunk, rest) = V.splitAt batchLogMaxExportBatchSize batchToExport
+            res <- publish chunk
+            case res of
+              Failure _ -> pure res
+              Success -> publishBounded rest
 
   let flushQueueImmediately ret = do
         batchToExport <- atomicModifyIORef' batch buildExportBatch
         if V.null batchToExport
           then pure ret
           else do
-            ret' <- publish batchToExport
+            ret' <- publishBounded batchToExport
             flushQueueImmediately ret'
 
   -- Shutdown and FlushRequested are tried before work signals so they
@@ -116,7 +135,7 @@ batchLogRecordProcessor BatchLogRecordProcessorConfig {..} = liftIO $ do
   let workerAction = do
         req <- waiting
         batchToExport <- atomicModifyIORef' batch buildExportBatch
-        res <- publish batchToExport
+        res <- publishBounded batchToExport
         case req of
           Shutdown -> flushQueueImmediately res
           FlushRequested -> do
@@ -168,9 +187,6 @@ batchLogRecordProcessor BatchLogRecordProcessorConfig {..} = liftIO $ do
     millisToMicros = (* 1000)
 
 
--- TODO: otel-12 introduces OpenTelemetry.Internal.Logging (otelLogWarning)
--- which respects OTEL_LOG_LEVEL and the global error handler.
--- Replace hPutStrLn stderr with otelLogWarning once available.
 warnOnDrop :: IORef Int -> IORef Bool -> Int -> String -> IO ()
 warnOnDrop droppedRef warnedRef capacity processorName = do
   n <- atomicModifyIORef' droppedRef (\c -> let c' = c + 1 in (c', c'))

--- a/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
@@ -32,11 +32,13 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Vector (Vector)
+import qualified Data.Vector as V
 import OpenTelemetry.Exporter.Span (SpanExporter)
 import qualified OpenTelemetry.Exporter.Span as SpanExporter
 import OpenTelemetry.Processor.Span
 import OpenTelemetry.Trace.Core
 import System.IO (hPutStrLn, stderr)
+import System.Timeout (timeout)
 import VectorBuilder.Builder as Builder
 import VectorBuilder.Vector as Builder
 
@@ -178,7 +180,7 @@ boundedMap bounds exportBounds = BoundedMap bounds exportBounds 0 mempty
 
 push :: ImmutableSpan -> BoundedMap ImmutableSpan -> Maybe (BoundedMap ImmutableSpan)
 push s m =
-  if itemCount m + 1 >= itemBounds m
+  if itemCount m >= itemBounds m
     then Nothing
     else
       Just $!
@@ -200,7 +202,7 @@ buildExport m =
   )
 
 
-data ProcessorMessage = ScheduledFlush | MaxExportFlush | Shutdown
+data ProcessorMessage = ScheduledFlush | MaxExportFlush | FlushRequested | Shutdown
 
 
 -- note: [Unmasking Asyncs]
@@ -241,46 +243,76 @@ batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
   warnedRef <- newIORef False
   workSignal <- newEmptyTMVarIO
   shutdownSignal <- newEmptyTMVarIO
-  let publish batchToProcess = mask_ $ do
-        -- we mask async exceptions in this, so that a buggy exporter that
-        -- catches async exceptions won't swallow them. since we use
-        -- an interruptible mask, blocking calls can still be killed, like
-        -- `threadDelay` or `putMVar` or most file I/O operations.
-        --
-        -- if we've received a shutdown, then we should be expecting
-        -- a `cancel` anytime now.
-        SpanExporter.spanExporterExport exporter batchToProcess
+  flushRequestSignal <- newEmptyTMVarIO
+  flushDoneSignal <- newEmptyTMVarIO
+  let timeoutMicros = millisToMicros exportTimeoutMillis
+
+  let publish batchToProcess = do
+        mResult <-
+          timeout timeoutMicros $
+            mask_ $
+              SpanExporter.spanExporterExport exporter batchToProcess
+        pure $ case mResult of
+          Nothing -> Failure Nothing
+          Just r -> r
+
+  -- Split a batch map into a chunk of at most n items and a remainder.
+  let splitBatch n m = go n (HashMap.toList m) [] []
+        where
+          go _ [] chunkAcc restAcc = (HashMap.fromList chunkAcc, HashMap.fromList restAcc)
+          go 0 remaining chunkAcc restAcc = (HashMap.fromList chunkAcc, HashMap.fromList (restAcc ++ remaining))
+          go remaining ((lib, vec) : rest) chunkAcc restAcc
+            | V.length vec <= remaining =
+                go (remaining - V.length vec) rest ((lib, vec) : chunkAcc) restAcc
+            | otherwise =
+                let (front, back) = V.splitAt remaining vec
+                in go 0 rest ((lib, front) : chunkAcc) ((lib, back) : restAcc)
+
+  let publishBounded batchMap
+        | HashMap.null batchMap = pure Success
+        | sum (V.length <$> HashMap.elems batchMap) <= maxExportBatchSize =
+            publish batchMap
+        | otherwise = do
+            let (chunk, rest) = splitBatch maxExportBatchSize batchMap
+            res <- publish chunk
+            case res of
+              Failure _ -> pure res
+              Success -> publishBounded rest
 
   let flushQueueImmediately ret = do
         batchToProcess <- atomicModifyIORef' batch buildExport
         if null batchToProcess
-          then do
-            pure ret
+          then pure ret
           else do
-            ret' <- publish batchToProcess
+            ret' <- publishBounded batchToProcess
             flushQueueImmediately ret'
 
+  -- Shutdown and FlushRequested are tried before work signals so they
+  -- cannot be starved under sustained high throughput.
   let waiting = do
         delay <- registerDelay (millisToMicros scheduledDelayMillis)
-        atomically $ do
+        atomically $
           msum
-            -- Flush every scheduled delay time, when we've reached the max export size, or when the shutdown signal is received.
-            [ ScheduledFlush <$ do
+            [ Shutdown <$ takeTMVar shutdownSignal
+            , FlushRequested <$ takeTMVar flushRequestSignal
+            , MaxExportFlush <$ takeTMVar workSignal
+            , ScheduledFlush <$ do
                 continue <- readTVar delay
                 check continue
-            , MaxExportFlush <$ takeTMVar workSignal
-            , Shutdown <$ takeTMVar shutdownSignal
             ]
 
   let workerAction = do
         req <- waiting
         batchToProcess <- atomicModifyIORef' batch buildExport
-        res <- publish batchToProcess
+        res <- publishBounded batchToProcess
 
-        -- if we were asked to shutdown, stop waiting and flush it all out
         case req of
           Shutdown ->
             flushQueueImmediately res
+          FlushRequested -> do
+            _ <- flushQueueImmediately res
+            atomically $ putTMVar flushDoneSignal ()
+            workerAction
           _ ->
             workerAction
   -- see note [Unmasking Asyncs]
@@ -301,7 +333,8 @@ batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
           when dropped $ warnOnDrop droppedRef warnedRef maxQueueSize "BatchSpanProcessor"
           when exportNeeded $ void $ atomically $ tryPutTMVar workSignal ()
       , spanProcessorForceFlush = do
-          void $ atomically $ tryPutTMVar workSignal ()
+          atomically $ putTMVar flushRequestSignal ()
+          atomically $ takeTMVar flushDoneSignal
           SpanExporter.spanExporterForceFlush exporter
       , -- TODO where to call restore, if anywhere?
         spanProcessorShutdown =
@@ -342,7 +375,8 @@ batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
 
               -- make sure the worker comes down if we timed out.
               cancel worker
-              -- TODO, not convinced we should shut down processor here
+              -- OTel spec: Processor.Shutdown MUST shut down the exporter
+              SpanExporter.spanExporterShutdown exporter
 
               pure $ case shutdownResult of
                 Nothing ->

--- a/sdk/src/OpenTelemetry/Trace.hs
+++ b/sdk/src/OpenTelemetry/Trace.hs
@@ -94,6 +94,7 @@ module OpenTelemetry.Trace (
   getTracerProviderInitializationOptions,
   getTracerProviderInitializationOptions',
   shutdownTracerProvider,
+  forceFlushTracerProvider,
 
   -- ** Getting / setting the global 'TracerProvider'
   getGlobalTracerProvider,

--- a/spec-compliance.md
+++ b/spec-compliance.md
@@ -214,7 +214,7 @@ Note: Support for environment variables is optional.
 |--------------------------------------------------------------------------------|----------|----|
 | [Exporter interface](specification/trace/sdk.md#span-exporter)                 |          | +  |
 | [Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2) |          | +  |
-| Standard output (logging)                                                      |          | + (metrics only) |
+| Standard output (logging)                                                      |          | + (spans, metrics, logs) |
 | In-memory (mock exporter)                                                      |          | +  |
 | [OTLP](specification/protocol/otlp.md)                                         |          | +  |
 | OTLP/gRPC Exporter                                                             | *        |    |


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #249.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)