### PR TITLE
feat(propagators): update w3c/b3/datadog, add jaeger and xray propagators

### DIFF
--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -1,11 +1,3 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
-import Control.Exception
-import Data.IORef
-import Data.Maybe (isJust)
-import qualified Data.Vector as V
-import OpenTelemetry.Attributes (lookupAttribute)
 import qualified OpenTelemetry.AttributesSpec as Attributes
 import qualified OpenTelemetry.BaggageSpec as Baggage
 import OpenTelemetry.Context
@@ -24,7 +16,6 @@ import qualified OpenTelemetry.PropagatorSpec as PropagatorSpec
 import qualified OpenTelemetry.RegistrySpec as Registry
 import qualified OpenTelemetry.ResourceSpec as Resource
 import qualified OpenTelemetry.SemanticsConfigSpec as SemanticsConfigSpec
-import OpenTelemetry.Trace.Core
 import qualified OpenTelemetry.Trace.ExceptionHandlerSpec as ExceptionHandler
 import qualified OpenTelemetry.Trace.IdCodecSpec as IdCodec
 import qualified OpenTelemetry.Trace.MonadSpec as TraceMonad
@@ -32,41 +23,11 @@ import qualified OpenTelemetry.Trace.SamplerSpec as Sampler
 import qualified OpenTelemetry.Trace.TraceFlagsSpec as TraceFlags
 import qualified OpenTelemetry.Trace.TracerSpec as Tracer
 import qualified OpenTelemetry.Trace.UtilsSpec as Utils
-import OpenTelemetry.Util
 import Test.Hspec
-
-
-newtype TestException = TestException String
-  deriving (Show)
-
-
-instance Exception TestException
-
-
-exceptionTest :: IO ()
-exceptionTest = do
-  tp <- getGlobalTracerProvider
-  let t = OpenTelemetry.Trace.Core.makeTracer tp "test" tracerOptions
-  spanToCheck <- newIORef undefined
-  handle (\(TestException _) -> pure ()) $ do
-    inSpan' t "test" defaultSpanArguments $ \span -> do
-      writeIORef spanToCheck span
-      throw $ TestException "wow"
-  spanState <- unsafeReadSpan =<< readIORef spanToCheck
-  hot <- readIORef (spanHot spanState)
-  let ev = V.head $ appendOnlyBoundedCollectionValues $ hotEvents hot
-  eventName ev `shouldBe` "exception"
-  eventAttributes ev `shouldSatisfy` \attrs ->
-    isJust (lookupAttribute attrs "exception.type")
-      && isJust (lookupAttribute attrs "exception.message")
-      && isJust (lookupAttribute attrs "exception.stacktrace")
 
 
 main :: IO ()
 main = hspec $ do
-  -- describe "inSpan" $ do
-  --   it "records exceptions" $ do
-  --     exceptionTest
   Attributes.spec
   Baggage.spec
   ContextSpec.spec

--- a/cabal.project
+++ b/cabal.project
@@ -13,6 +13,8 @@ packages:
   , propagators/datadog
   , propagators/w3c
   , propagators/b3
+  , propagators/jaeger
+  , propagators/xray
   , instrumentation/conduit
   , instrumentation/hspec
   , instrumentation/postgresql-simple

--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -13,15 +13,10 @@ in rec {
   inherit pkgs;
 
   skipPackages = [
-    "hs-opentelemetry-sdk"
     "hs-opentelemetry-exporter-handle"
     "hs-opentelemetry-exporter-in-memory"
     "hs-opentelemetry-exporter-otlp"
-    "hs-opentelemetry-propagator-b3"
-    "hs-opentelemetry-propagator-datadog"
-    "hs-opentelemetry-propagator-w3c"
-    "hs-opentelemetry-propagator-jaeger"
-    "hs-opentelemetry-propagator-xray"
+    "hs-opentelemetry-sdk"
     "hs-opentelemetry-instrumentation-cloudflare"
     "hs-opentelemetry-instrumentation-conduit"
     "hs-opentelemetry-instrumentation-ghc-metrics"

--- a/propagators/b3/hs-opentelemetry-propagator-b3.cabal
+++ b/propagators/b3/hs-opentelemetry-propagator-b3.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -38,7 +38,23 @@ library
       attoparsec
     , base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api ==0.3.*
-    , http-types
+    , hs-opentelemetry-api ==0.4.*
+    , text
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-propagator-b3-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_propagator_b3
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-propagator-b3 >=0.0.1 && <0.1
+    , hspec
     , text
   default-language: Haskell2010

--- a/propagators/b3/package.yaml
+++ b/propagators/b3/package.yaml
@@ -28,12 +28,10 @@ library:
   dependencies:
   - attoparsec
   - bytestring
-  - hs-opentelemetry-api ^>= 0.3
-  - http-types
+  - hs-opentelemetry-api ^>= 0.4
   - text
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-propagator-b3-test:
     main:                Spec.hs
     source-dirs:         test
@@ -42,4 +40,8 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-propagator-b3
+    - hs-opentelemetry-propagator-b3 >= 0.0.1 && < 0.1
+    - hs-opentelemetry-api == 0.4.*
+    - hspec
+    - bytestring
+    - text

--- a/propagators/b3/src/OpenTelemetry/Propagator/B3.hs
+++ b/propagators/b3/src/OpenTelemetry/Propagator/B3.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 
 {- | B3 Propagation Requirements:
  https://github.com/openzipkin/b3-propagation
@@ -16,15 +14,18 @@ module OpenTelemetry.Propagator.B3 (
 --------------------------------------------------------------------------------
 
 import Control.Applicative ((<|>))
-import Data.ByteString (ByteString)
 import Data.List (intersperse)
 import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Text.Encoding as Text
-import Network.HTTP.Types (HeaderName, RequestHeaders)
 import OpenTelemetry.Common (TraceFlags (..))
-import OpenTelemetry.Context (Context)
 import qualified OpenTelemetry.Context as Context
-import OpenTelemetry.Propagator (Propagator (..))
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  TextMap,
+  TextMapPropagator,
+  textMapInsert,
+  textMapLookup,
+ )
 import OpenTelemetry.Propagator.B3.Internal
 import qualified OpenTelemetry.Trace.Core as Core
 import qualified OpenTelemetry.Trace.TraceState as TS
@@ -33,7 +34,7 @@ import Prelude
 
 --------------------------------------------------------------------------------
 
-b3TraceContextPropagator :: Propagator Context RequestHeaders RequestHeaders
+b3TraceContextPropagator :: TextMapPropagator
 b3TraceContextPropagator =
   Propagator
     { propagatorFields = ["B3 Trace Context"]
@@ -45,17 +46,18 @@ b3TraceContextPropagator =
         case Context.lookupSpan c of
           Nothing -> pure hs
           Just span' -> do
-            Core.SpanContext {traceId, spanId, traceState = TS.TraceState traceState} <- Core.getSpanContext span'
+            Core.SpanContext {traceId, spanId, traceState = TS.TraceState traceState, traceFlags} <- Core.getSpanContext span'
             let traceIdValue = encodeTraceId traceId
                 spanIdValue = encodeSpanId spanId
-                samplingStateValue = lookup (TS.Key "sampling-state") traceState >>= samplingStateFromValue >>= printSamplingStateSingle
+                samplingStateValue =
+                  printSamplingStateSingle $ injectSamplingState traceState traceFlags
                 value = mconcat $ intersperse "-" $ [traceIdValue, spanIdValue] <> catMaybes [Text.encodeUtf8 <$> samplingStateValue]
 
-            pure $ (b3Header, value) : hs
+            pure $ textMapInsert b3Header (Text.decodeUtf8 value) hs
     }
 
 
-b3MultiTraceContextPropagator :: Propagator Context RequestHeaders RequestHeaders
+b3MultiTraceContextPropagator :: TextMapPropagator
 b3MultiTraceContextPropagator =
   Propagator
     { propagatorFields = ["B3 Multi Trace Context"]
@@ -67,17 +69,31 @@ b3MultiTraceContextPropagator =
         case Context.lookupSpan c of
           Nothing -> pure hs
           Just span' -> do
-            Core.SpanContext {traceId, spanId, traceState = TS.TraceState traceState} <- Core.getSpanContext span'
+            Core.SpanContext {traceId, spanId, traceState = TS.TraceState traceState, traceFlags} <- Core.getSpanContext span'
             let traceIdValue = encodeTraceId traceId
                 spanIdValue = encodeSpanId spanId
-                samplingStateValue = lookup (TS.Key "sampling-state") traceState >>= samplingStateFromValue >>= printSamplingStateMulti
-
-            pure $
-              (xb3TraceIdHeader, traceIdValue)
-                : (xb3SpanIdHeader, spanIdValue)
-                : hs
-                ++ catMaybes [fmap Text.encodeUtf8 <$> samplingStateValue]
+                samplingStateMay =
+                  printSamplingStateMulti $ injectSamplingState traceState traceFlags
+                hs' =
+                  textMapInsert xb3SpanIdHeader (Text.decodeUtf8 spanIdValue) $
+                    textMapInsert xb3TraceIdHeader (Text.decodeUtf8 traceIdValue) hs
+            pure $ case samplingStateMay of
+              Nothing -> hs'
+              Just (k, v) -> textMapInsert k v hs'
     }
+
+
+--------------------------------------------------------------------------------
+
+{- | B3 sampling for injection: prefer explicit @sampling-state@ in trace state,
+otherwise derive from 'TraceFlags' (so local spans inject without a prior extract).
+-}
+injectSamplingState :: [(TS.Key, TS.Value)] -> TraceFlags -> SamplingState
+injectSamplingState traceState traceFlags =
+  case lookup (TS.Key "sampling-state") traceState >>= samplingStateFromValue of
+    Just s -> s
+    Nothing ->
+      if Core.isSampled traceFlags then Accept else Deny
 
 
 --------------------------------------------------------------------------------
@@ -86,13 +102,13 @@ b3MultiTraceContextPropagator =
  multi header extraction:
  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#configuration
 -}
-b3Extractor :: [(HeaderName, ByteString)] -> Maybe Core.SpanContext
+b3Extractor :: TextMap -> Maybe Core.SpanContext
 b3Extractor hs = b3SingleExtractor hs <|> b3MultiExtractor hs
 
 
-b3SingleExtractor :: [(HeaderName, ByteString)] -> Maybe Core.SpanContext
+b3SingleExtractor :: TextMap -> Maybe Core.SpanContext
 b3SingleExtractor hs = do
-  B3SingleHeader {..} <- decodeB3SingleHeader =<< Prelude.lookup b3Header hs
+  B3SingleHeader {..} <- decodeB3SingleHeader =<< (Text.encodeUtf8 <$> textMapLookup b3Header hs)
 
   let traceFlags = if samplingState == Accept || samplingState == Debug then TraceFlags 1 else TraceFlags 0
 
@@ -106,15 +122,15 @@ b3SingleExtractor hs = do
       }
 
 
-b3MultiExtractor :: [(HeaderName, ByteString)] -> Maybe Core.SpanContext
+b3MultiExtractor :: TextMap -> Maybe Core.SpanContext
 b3MultiExtractor hs = do
-  traceId <- decodeXb3TraceIdHeader =<< Prelude.lookup xb3TraceIdHeader hs
-  spanId <- decodeXb3SpanIdHeader =<< Prelude.lookup xb3SpanIdHeader hs
+  traceId <- decodeXb3TraceIdHeader =<< (Text.encodeUtf8 <$> textMapLookup xb3TraceIdHeader hs)
+  spanId <- decodeXb3SpanIdHeader =<< (Text.encodeUtf8 <$> textMapLookup xb3SpanIdHeader hs)
 
-  let sampled = decodeXb3SampledHeader =<< Prelude.lookup xb3SampledHeader hs
-      debug = decodeXb3FlagsHeader =<< Prelude.lookup xb3FlagsHeader hs
+  let sampled = decodeXb3SampledHeader =<< (Text.encodeUtf8 <$> textMapLookup xb3SampledHeader hs)
+      debug = decodeXb3FlagsHeader =<< (Text.encodeUtf8 <$> textMapLookup xb3FlagsHeader hs)
       -- NOTE: Debug implies Accept (https://github.com/openzipkin/b3-propagation#debug-flag)
-      samplingState = fromMaybe Defer $ sampled <|> debug
+      samplingState = fromMaybe Defer $ debug <|> sampled
   let traceFlags = if samplingState == Accept || samplingState == Debug then TraceFlags 1 else TraceFlags 0
 
   pure $

--- a/propagators/b3/src/OpenTelemetry/Propagator/B3/Internal.hs
+++ b/propagators/b3/src/OpenTelemetry/Propagator/B3/Internal.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE Strict #-}
 
 {- | Conversion of the hs-opentelemetry internal representation of the trace ID and the span ID and the B3 header representation of them each other.
@@ -44,21 +44,28 @@ module OpenTelemetry.Propagator.B3.Internal (
   xb3SpanIdHeader,
   xb3SampledHeader,
   xb3FlagsHeader,
+  xb3ParentSpanIdHeader,
 ) where
 
 --------------------------------------------------------------------------------
 
-import Control.Applicative ((<|>))
-import Control.Monad (void)
-import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.Char as C
-import Data.Functor (($>))
 import Data.Text (Text)
-import Network.HTTP.Types (HeaderName)
-import OpenTelemetry.Trace.Id (Base (..), SpanId, TraceId, baseEncodedToSpanId, baseEncodedToTraceId, spanIdBaseEncodedBuilder, traceIdBaseEncodedBuilder)
+import Data.Word (Word8)
+import OpenTelemetry.Trace.Id (
+  Base (..),
+  SpanId,
+  TraceId,
+  baseEncodedToSpanId,
+  baseEncodedToTraceId,
+  bytesToTraceId,
+  spanIdBaseEncodedBuilder,
+  spanIdBytes,
+  traceIdBaseEncodedBuilder,
+ )
 import OpenTelemetry.Trace.TraceState (Value (..))
 
 
@@ -81,85 +88,51 @@ encodeSpanId = BL.toStrict . BB.toLazyByteString . spanIdBaseEncodedBuilder Base
 --------------------------------------------------------------------------------
 
 decodeXb3TraceIdHeader :: ByteString -> Maybe TraceId
-decodeXb3TraceIdHeader tp = case Atto.parseOnly parserTraceId tp of
-  Left _ -> Nothing
-  Right traceId -> Just traceId
+decodeXb3TraceIdHeader bs = either (const Nothing) Just (decodeTraceIdFromHex bs)
 
 
 decodeXb3SpanIdHeader :: ByteString -> Maybe SpanId
-decodeXb3SpanIdHeader tp = case Atto.parseOnly parserSpanId tp of
-  Left _ -> Nothing
-  Right spanId -> Just spanId
+decodeXb3SpanIdHeader bs = either (const Nothing) Just (baseEncodedToSpanId Base16 bs)
 
 
 decodeXb3SampledHeader :: ByteString -> Maybe SamplingState
-decodeXb3SampledHeader tp = case Atto.parseOnly parserXb3Sampled tp of
-  Left _ -> Nothing
-  Right sampled -> Just sampled
+decodeXb3SampledHeader "1" = Just Accept
+decodeXb3SampledHeader "0" = Just Deny
+decodeXb3SampledHeader _ = Nothing
 
 
 decodeXb3FlagsHeader :: ByteString -> Maybe SamplingState
-decodeXb3FlagsHeader tp = case Atto.parseOnly parserXb3Flags tp of
-  Left _ -> Nothing
-  Right flags -> Just flags
+decodeXb3FlagsHeader "1" = Just Debug
+decodeXb3FlagsHeader _ = Nothing
 
 
 decodeB3SingleHeader :: ByteString -> Maybe B3SingleHeader
-decodeB3SingleHeader tp = case Atto.parseOnly parserB3Single tp of
-  Left _ -> Nothing
-  Right b3 -> Just b3
+decodeB3SingleHeader = parseB3Single
 
 
 decodeB3SampleHeader :: ByteString -> Maybe SamplingState
-decodeB3SampleHeader tp = case Atto.parseOnly parserSamplingState tp of
-  Left _ -> Nothing
-  Right b3 -> Just b3
+decodeB3SampleHeader "1" = Just Accept
+decodeB3SampleHeader "0" = Just Deny
+decodeB3SampleHeader "d" = Just Debug
+decodeB3SampleHeader _ = Nothing
 
 
 --------------------------------------------------------------------------------
 
-parserTraceId :: Atto.Parser TraceId
-parserTraceId = do
-  traceIdBs <- Atto.takeWhile C.isHexDigit
-  case baseEncodedToTraceId Base16 traceIdBs of
-    Left err -> fail err
-    Right traceId -> pure traceId
-
-
-parserSpanId :: Atto.Parser SpanId
-parserSpanId = do
-  parentIdBs <- Atto.takeWhile C.isHexDigit
-  case baseEncodedToSpanId Base16 parentIdBs of
-    Left err -> fail err
-    Right ok -> pure ok
+{- | Decode a B3 @X-B3-TraceId@ value: 32 hex chars (128-bit) or 16 hex chars
+ (64-bit, zero-padded to 128-bit per B3).
+-}
+decodeTraceIdFromHex :: ByteString -> Either String TraceId
+decodeTraceIdFromHex hexBs
+  | BS.length hexBs == 32 = baseEncodedToTraceId Base16 hexBs
+  | BS.length hexBs == 16 = do
+      sid <- baseEncodedToSpanId Base16 hexBs
+      bytesToTraceId (BS.replicate 8 0 <> spanIdBytes sid)
+  | otherwise = Left "B3 trace id: expected 16 or 32 hex characters"
 
 
 data SamplingState = Accept | Deny | Debug | Defer
   deriving (Eq)
-
-
--- | Parser for the @x-b3-sampled@ header value.
-parserXb3Sampled :: Atto.Parser SamplingState
-parserXb3Sampled = accept <|> deny
-  where
-    accept = "1" $> Accept
-    deny = "0" $> Deny
-
-
-parserXb3Flags :: Atto.Parser SamplingState
-parserXb3Flags = "1" $> Debug
-
-
-{- | Note that this parser is only correct for the B3 single header
- format. In B3 Multi you can only pass a @0@ or @1@ for the sample
- state for 'Accept' and 'Deny' respectively.
--}
-parserSamplingState :: Atto.Parser SamplingState
-parserSamplingState = accept <|> deny <|> debug
-  where
-    accept = "1" $> Accept
-    deny = "0" $> Deny
-    debug = "d" $> Debug
 
 
 {- | Encode a 'SamplingState' as the Sampling State component of the
@@ -173,7 +146,7 @@ printSamplingStateSingle = \case
   Defer -> Nothing
 
 
-printSamplingStateMulti :: SamplingState -> Maybe (HeaderName, Text)
+printSamplingStateMulti :: SamplingState -> Maybe (Text, Text)
 printSamplingStateMulti = \case
   Accept -> Just (xb3SampledHeader, "1")
   Deny -> Just (xb3SampledHeader, "0")
@@ -208,32 +181,89 @@ data B3SingleHeader = B3SingleHeader
   }
 
 
-parserB3Single :: Atto.Parser B3SingleHeader
-parserB3Single = do
-  traceId <- parserTraceId
-  spanId <- void "-" *> parserSpanId
-  samplingState <- Atto.option Defer (void "-" *> parserSamplingState)
-  parentSpanId <- Atto.option Nothing (void "-" *> fmap Just parserSpanId)
-  pure B3SingleHeader {..}
+{- | Hand-rolled parser for @{traceId}-{spanId}[-{samplingState}[-{parentSpanId}]]@.
+Scans for dash positions instead of using attoparsec.
+-}
+parseB3Single :: ByteString -> Maybe B3SingleHeader
+parseB3Single bs = do
+  let !len = BS.length bs
+  -- Find the first dash — trace ID is 16 or 32 hex chars
+  !dashIdx <- findDash bs 0
+  !tid <- either (const Nothing) Just (decodeTraceIdFromHex (BS.take dashIdx bs))
+  -- Span ID: next 16 hex chars after the dash
+  let !spanStart = dashIdx + 1
+      !spanEnd = spanStart + 16
+  if spanEnd > len
+    then Nothing
+    else do
+      !sid <- either (const Nothing) Just (baseEncodedToSpanId Base16 (BS.take 16 (BS.drop spanStart bs)))
+      -- Optional sampling state and parent span ID
+      if spanEnd == len
+        then Just $! B3SingleHeader tid sid Defer Nothing
+        else do
+          guardByte bs spanEnd 0x2d -- '-'
+          let !sampStart = spanEnd + 1
+          if sampStart >= len
+            then Nothing
+            else do
+              let (!ss, !afterSamp) = parseSamplingAt bs sampStart
+              if afterSamp >= len
+                then Just $! B3SingleHeader tid sid ss Nothing
+                else do
+                  guardByte bs afterSamp 0x2d -- '-'
+                  let !parentStart = afterSamp + 1
+                      !parentEnd = parentStart + 16
+                  if parentEnd > len
+                    then Nothing
+                    else do
+                      !psid <- either (const Nothing) Just (baseEncodedToSpanId Base16 (BS.take 16 (BS.drop parentStart bs)))
+                      Just $! B3SingleHeader tid sid ss (Just psid)
+
+
+findDash :: ByteString -> Int -> Maybe Int
+findDash bs i
+  | i >= BS.length bs = Nothing
+  | BS.index bs i == 0x2d = Just i
+  | otherwise = findDash bs (i + 1)
+
+
+guardByte :: ByteString -> Int -> Word8 -> Maybe ()
+guardByte bs i expected
+  | i < BS.length bs && BS.index bs i == expected = Just ()
+  | otherwise = Nothing
+
+
+parseSamplingAt :: ByteString -> Int -> (SamplingState, Int)
+parseSamplingAt bs i
+  | i >= BS.length bs = (Defer, i)
+  | otherwise = case BS.index bs i of
+      0x31 -> (Accept, i + 1) -- '1'
+      0x30 -> (Deny, i + 1) -- '0'
+      0x64 -> (Debug, i + 1) -- 'd'
+      _ -> (Defer, i)
 
 
 --------------------------------------------------------------------------------
 
-b3Header :: HeaderName
+b3Header :: Text
 b3Header = "b3"
 
 
-xb3TraceIdHeader :: HeaderName
-xb3TraceIdHeader = "X-B3-TraceId"
+xb3TraceIdHeader :: Text
+xb3TraceIdHeader = "x-b3-traceid"
 
 
-xb3SpanIdHeader :: HeaderName
-xb3SpanIdHeader = "X-B3-SpanId"
+xb3SpanIdHeader :: Text
+xb3SpanIdHeader = "x-b3-spanid"
 
 
-xb3SampledHeader :: HeaderName
-xb3SampledHeader = "X-B3-Sampled"
+xb3SampledHeader :: Text
+xb3SampledHeader = "x-b3-sampled"
 
 
-xb3FlagsHeader :: HeaderName
-xb3FlagsHeader = "X-B3-Flags"
+xb3FlagsHeader :: Text
+xb3FlagsHeader = "x-b3-flags"
+
+
+xb3ParentSpanIdHeader :: Text
+xb3ParentSpanIdHeader = "x-b3-parentspanid"

--- a/propagators/b3/test/Spec.hs
+++ b/propagators/b3/test/Spec.hs
@@ -1,3 +1,245 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Data.Maybe (isJust, isNothing)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import OpenTelemetry.Common (TraceFlags (..))
+import OpenTelemetry.Context (Context, empty, insertSpan, lookupSpan)
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  emptyTextMap,
+  textMapFromList,
+  textMapLookup,
+ )
+import OpenTelemetry.Propagator.B3 (b3MultiTraceContextPropagator, b3TraceContextPropagator)
+import qualified OpenTelemetry.Propagator.B3.Internal as B3I
+import OpenTelemetry.Trace.Core (SpanContext (..), getSpanContext, isSampled, wrapSpanContext)
+import OpenTelemetry.Trace.Id (Base (..), SpanId, TraceId, baseEncodedToSpanId, baseEncodedToTraceId)
+import qualified OpenTelemetry.Trace.TraceState as TS
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec spec
+
+
+spec :: Spec
+spec =
+  -- B3 single-header and multi-header propagation
+  -- https://github.com/openzipkin/b3-propagation
+  describe "OpenTelemetry.Propagator.B3" $ do
+    describe "extraction" $ do
+      -- B3 single header: TraceId-SpanId-1 (sampled)
+      -- https://github.com/openzipkin/b3-propagation#single-header
+      it "extracts SpanContext from the single b3 header (sampled)" $ do
+        let headers =
+              textMapFromList
+                [
+                  ( "b3"
+                  , "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1"
+                  )
+                ]
+        ctx' <- extractor b3TraceContextPropagator headers empty
+        assertExpectedRemoteSampled ctx'
+
+      -- B3 multiple headers: X-B3-TraceId, X-B3-SpanId, X-B3-Sampled
+      -- https://github.com/openzipkin/b3-propagation#multiple-headers
+      it "extracts the same SpanContext from multi-header B3 (sampled)" $ do
+        let headers =
+              textMapFromList
+                [ ("x-b3-traceid", "80f198ee56343ba864fe8b2a57d3eff7")
+                , ("x-b3-spanid", "e457b5a2e4d86bd1")
+                , ("x-b3-sampled", "1")
+                ]
+        ctx' <- extractor b3MultiTraceContextPropagator headers empty
+        assertExpectedRemoteSampled ctx'
+
+      it "leaves the context unchanged when headers are missing" $ do
+        ctx1 <- extractor b3TraceContextPropagator emptyTextMap empty
+        ctx2 <- extractor b3MultiTraceContextPropagator emptyTextMap empty
+        lookupSpan ctx1 `shouldSatisfy` isNothing
+        lookupSpan ctx2 `shouldSatisfy` isNothing
+
+      -- Single header: trailing -0 means unsampled
+      -- https://github.com/openzipkin/b3-propagation#single-header
+      it "extracts SpanContext with sampled bit unset when b3 ends in -0" $ do
+        let headers =
+              textMapFromList
+                [
+                  ( "b3"
+                  , "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-0"
+                  )
+                ]
+        ctx' <- extractor b3TraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span -> do
+            sc <- getSpanContext span
+            traceId sc `shouldBe` expectedTraceId
+            spanId sc `shouldBe` expectedSpanId
+            isRemote sc `shouldBe` True
+            isSampled (traceFlags sc) `shouldBe` False
+
+      -- X-B3-Flags: 1 (debug) forces trace on; overrides X-B3-Sampled: 0
+      -- https://github.com/openzipkin/b3-propagation#debug-flag
+      it "debug flag takes precedence over X-B3-Sampled: 0 in multi-header" $ do
+        let headers =
+              textMapFromList
+                [ ("x-b3-traceid", "80f198ee56343ba864fe8b2a57d3eff7")
+                , ("x-b3-spanid", "e457b5a2e4d86bd1")
+                , ("x-b3-sampled", "0")
+                , ("x-b3-flags", "1")
+                ]
+        ctx' <- extractor b3MultiTraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span -> do
+            sc <- getSpanContext span
+            traceId sc `shouldBe` expectedTraceId
+            spanId sc `shouldBe` expectedSpanId
+            isRemote sc `shouldBe` True
+            isSampled (traceFlags sc) `shouldBe` True
+
+      it "X-B3-Sampled: 0 alone means unsampled in multi-header" $ do
+        let headers =
+              textMapFromList
+                [ ("x-b3-traceid", "80f198ee56343ba864fe8b2a57d3eff7")
+                , ("x-b3-spanid", "e457b5a2e4d86bd1")
+                , ("x-b3-sampled", "0")
+                ]
+        ctx' <- extractor b3MultiTraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span -> do
+            sc <- getSpanContext span
+            isSampled (traceFlags sc) `shouldBe` False
+
+    describe "injection" $ do
+      -- Single header format TraceId-SpanId-SamplingState
+      -- https://github.com/openzipkin/b3-propagation#single-header
+      it "injects the b3 single header with traceId-spanId-sampling" $ do
+        let ctx = insertSpan (wrapSpanContext sampleSpanContext) empty
+        hs <- injector b3TraceContextPropagator ctx emptyTextMap
+        case textMapLookup B3I.b3Header hs of
+          Nothing -> expectationFailure "expected b3 header"
+          Just v -> case T.splitOn "-" v of
+            [tid, sid, samp] -> do
+              tid `shouldBe` traceIdHex
+              sid `shouldBe` spanIdHex
+              samp `shouldBe` "1"
+            _ ->
+              expectationFailure $
+                "expected traceId-spanId-sampling in b3 header, got: " ++ show v
+
+      -- https://github.com/openzipkin/b3-propagation#multiple-headers
+      it "injects X-B3-TraceId, X-B3-SpanId, and X-B3-Sampled for multi-header propagation" $ do
+        let ctx = insertSpan (wrapSpanContext sampleSpanContext) empty
+        hs <- injector b3MultiTraceContextPropagator ctx emptyTextMap
+        textMapLookup B3I.xb3TraceIdHeader hs `shouldBe` Just traceIdHex
+        textMapLookup B3I.xb3SpanIdHeader hs `shouldBe` Just spanIdHex
+        textMapLookup B3I.xb3SampledHeader hs `shouldBe` Just "1"
+
+    describe "B3 Internal" $ do
+      -- 128-bit or 64-bit (padded) trace id hex
+      -- https://github.com/openzipkin/b3-propagation#trace-identifiers
+      it "decodeXb3TraceIdHeader parses 128-bit trace ID" $ do
+        B3I.decodeXb3TraceIdHeader "80f198ee56343ba864fe8b2a57d3eff7" `shouldSatisfy` isJust
+
+      it "decodeXb3TraceIdHeader parses 64-bit trace ID (zero-padded)" $ do
+        B3I.decodeXb3TraceIdHeader "e457b5a2e4d86bd1" `shouldSatisfy` isJust
+
+      it "decodeXb3TraceIdHeader rejects invalid hex" $ do
+        B3I.decodeXb3TraceIdHeader "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" `shouldBe` Nothing
+
+      it "decodeXb3TraceIdHeader rejects empty" $ do
+        B3I.decodeXb3TraceIdHeader "" `shouldBe` Nothing
+
+      it "decodeXb3SpanIdHeader parses valid span ID" $ do
+        B3I.decodeXb3SpanIdHeader "e457b5a2e4d86bd1" `shouldSatisfy` isJust
+
+      it "decodeXb3SpanIdHeader rejects too-short hex" $ do
+        B3I.decodeXb3SpanIdHeader "e457" `shouldBe` Nothing
+
+      -- Single header with optional parent span id segment
+      -- https://github.com/openzipkin/b3-propagation#single-header
+      it "decodeB3SingleHeader parses full header with parent" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1-05e3ac9a4f6e3b90"
+        case B3I.decodeB3SingleHeader hdr of
+          Nothing -> expectationFailure "expected parse"
+          Just b3 -> do
+            B3I.parentSpanId b3 `shouldSatisfy` isJust
+            B3I.spanId b3 `shouldBe` expectedSpanId
+            B3I.traceId b3 `shouldBe` expectedTraceId
+
+      -- Sampling state "d" (debug)
+      -- https://github.com/openzipkin/b3-propagation#sampling-state
+      it "decodeB3SingleHeader parses header with sampling=d (debug)" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d"
+        case B3I.decodeB3SingleHeader hdr of
+          Nothing -> expectationFailure "expected parse"
+          Just b3 -> (B3I.samplingState b3 == B3I.Debug) `shouldBe` True
+
+      it "decodeB3SingleHeader parses header without sampling" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1"
+        case B3I.decodeB3SingleHeader hdr of
+          Nothing -> expectationFailure "expected parse"
+          Just b3 -> (B3I.samplingState b3 == B3I.Defer) `shouldBe` True
+
+      it "decodeXb3SampledHeader parses 1 as Accept" $ do
+        (B3I.decodeXb3SampledHeader "1" == Just B3I.Accept) `shouldBe` True
+
+      it "decodeXb3SampledHeader parses 0 as Deny" $ do
+        (B3I.decodeXb3SampledHeader "0" == Just B3I.Deny) `shouldBe` True
+
+      it "decodeXb3FlagsHeader parses 1 as Debug" $ do
+        (B3I.decodeXb3FlagsHeader "1" == Just B3I.Debug) `shouldBe` True
+
+      it "decodeXb3FlagsHeader rejects 0" $ do
+        isNothing (B3I.decodeXb3FlagsHeader "0") `shouldBe` True
+
+
+traceIdHex :: T.Text
+traceIdHex = "80f198ee56343ba864fe8b2a57d3eff7"
+
+
+spanIdHex :: T.Text
+spanIdHex = "e457b5a2e4d86bd1"
+
+
+expectedTraceId :: TraceId
+expectedTraceId =
+  case baseEncodedToTraceId Base16 (TE.encodeUtf8 traceIdHex) of
+    Right t -> t
+    Left e -> error ("expectedTraceId: " ++ e)
+
+
+expectedSpanId :: SpanId
+expectedSpanId =
+  case baseEncodedToSpanId Base16 (TE.encodeUtf8 spanIdHex) of
+    Right s -> s
+    Left e -> error ("expectedSpanId: " ++ e)
+
+
+sampleSpanContext :: SpanContext
+sampleSpanContext =
+  SpanContext
+    { traceId = expectedTraceId
+    , spanId = expectedSpanId
+    , isRemote = False
+    , traceFlags = TraceFlags 1
+    , traceState = TS.empty
+    }
+
+
+assertExpectedRemoteSampled :: Context -> IO ()
+assertExpectedRemoteSampled ctx' =
+  case lookupSpan ctx' of
+    Nothing -> expectationFailure "expected span in context"
+    Just span -> do
+      sc <- getSpanContext span
+      traceId sc `shouldBe` expectedTraceId
+      spanId sc `shouldBe` expectedSpanId
+      isRemote sc `shouldBe` True
+      isSampled (traceFlags sc) `shouldBe` True

--- a/propagators/datadog/benchmark/header-codec/main.hs
+++ b/propagators/datadog/benchmark/header-codec/main.hs
@@ -3,10 +3,17 @@
 
 import Control.DeepSeq (NFData)
 import qualified Criterion.Main as C
+import qualified Data.ByteString as B
 import qualified Data.ByteString.Short as SB
+import OpenTelemetry.Internal.Trace.Id (TraceId (..), bytesToTraceId)
 import OpenTelemetry.Propagator.Datadog.Internal
-import OpenTelemetry.Trace.Id (TraceId)
 import qualified String
+
+
+mkTid :: [Word] -> TraceId
+mkTid bs = case bytesToTraceId (B.pack (map fromIntegral bs)) of
+  Right t -> t
+  Left _ -> error "bad trace id"
 
 
 main :: IO ()
@@ -18,9 +25,11 @@ main =
         , C.bench "old" $ C.nf String.newTraceIdFromHeader "1"
         ]
     , C.bgroup "newHeaderFromTraceId" $
-        let value = SB.pack [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 10, 11, 12, 13, 14, 15]
-        in [ C.bench "new" $ C.nf newHeaderFromTraceId value
-           , C.bench "old" $ C.nf String.newHeaderFromTraceId value
+        let bytes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 10, 11, 12, 13, 14, 15]
+            newValue = mkTid bytes
+            oldValue = SB.pack (map fromIntegral bytes)
+        in [ C.bench "new" $ C.nf newHeaderFromTraceId newValue
+           , C.bench "old" $ C.nf String.newHeaderFromTraceId oldValue
            ]
     ]
 

--- a/propagators/datadog/hs-opentelemetry-propagator-datadog.cabal
+++ b/propagators/datadog/hs-opentelemetry-propagator-datadog.cabal
@@ -6,11 +6,16 @@ author: Kazuki Okamoto (岡本和樹)
 maintainer: kazuki.okamoto@herp.co.jp
 license: BSD-3-Clause
 license-file: LICENSE
-category: Telemetry
-homepage: https://github.com/iand675/hs-opentelemetry
+copyright: 2024 Ian Duncan, Mercury Technologies
+category: OpenTelemetry, Telemetry, Tracing, Datadog
+homepage: https://github.com/iand675/hs-opentelemetry#readme
 bug-reports: https://github.com/iand675/hs-opentelemetry/issues
 synopsis: Datadog Propagator for OpenTelemetry
 description: This package provides a Datadog style propagator for hs-opentelemetry suite.
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
 
 common common
   build-depends: base >= 4 && < 5
@@ -25,8 +30,7 @@ library
   exposed-modules: OpenTelemetry.Propagator.Datadog
                    OpenTelemetry.Propagator.Datadog.Internal
   build-depends: bytestring,
-                 hs-opentelemetry-api ^>= 0.3,
-                 http-types,
+                 hs-opentelemetry-api ^>= 0.4,
                  primitive,
                  text
   ghc-options: -Wcompat
@@ -69,13 +73,14 @@ test-suite spec
                  OpenTelemetry.Propagator.Datadog.InternalSpec
                  Raw
                  String
-  build-depends: hs-opentelemetry-propagator-datadog,
-                 hs-opentelemetry-api,
+  build-depends: hs-opentelemetry-propagator-datadog >= 0.0.0 && < 0.1,
+                 hs-opentelemetry-api == 0.4.*,
                  bytestring,
                  hspec,
                  pretty-hex,
                  primitive,
-                 QuickCheck
+                 QuickCheck,
+                 text
   ghc-options: -threaded
                -rtsopts
                -with-rtsopts=-N

--- a/propagators/datadog/src/OpenTelemetry/Propagator/Datadog.hs
+++ b/propagators/datadog/src/OpenTelemetry/Propagator/Datadog.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -8,29 +9,32 @@ module OpenTelemetry.Propagator.Datadog (
   convertOpenTelemetryTraceIdToDatadogTraceId,
 ) where
 
-import qualified Data.ByteString.Char8 as BC
+import Data.Bits (shiftL, (.|.))
 import qualified Data.ByteString.Short as SB
 import qualified Data.ByteString.Short.Internal as SBI
-import Data.Primitive (ByteArray (ByteArray))
-import Data.String (IsString)
+import Data.Primitive.ByteArray (ByteArray (ByteArray))
+import qualified Data.Primitive.ByteArray as BA
+import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Word (Word64)
-import Network.HTTP.Types (RequestHeaders)
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Read as TR
+import Data.Word (Word64, Word8)
 import OpenTelemetry.Common (TraceFlags (TraceFlags))
 import OpenTelemetry.Context (
-  Context,
   insertSpan,
   lookupSpan,
  )
 import OpenTelemetry.Internal.Trace.Id (
   SpanId,
   TraceId,
-  bytesToSpanId,
-  bytesToTraceId,
  )
-import OpenTelemetry.Propagator (Propagator (Propagator, extractor, injector, propagatorFields))
+import OpenTelemetry.Propagator (
+  Propagator (Propagator, extractor, injector, propagatorFields),
+  TextMapPropagator,
+  textMapInsert,
+  textMapLookup,
+ )
 import OpenTelemetry.Propagator.Datadog.Internal (
-  indexByteArrayNbo,
   newHeaderFromSpanId,
   newHeaderFromTraceId,
   newSpanIdFromHeader,
@@ -39,71 +43,96 @@ import OpenTelemetry.Propagator.Datadog.Internal (
 import OpenTelemetry.Trace.Core (
   SpanContext (SpanContext, isRemote, spanId, traceFlags, traceId, traceState),
   getSpanContext,
+  isSampled,
   wrapSpanContext,
  )
 import OpenTelemetry.Trace.Id (spanIdBytes, traceIdBytes)
-import OpenTelemetry.Trace.TraceState (TraceState (TraceState))
+import OpenTelemetry.Trace.TraceState (TraceState (TraceState), Value (Value))
 import qualified OpenTelemetry.Trace.TraceState as TS
 
 
 -- Reference: bi-directional conversion of IDs of Open Telemetry and ones of Datadog
 -- - English: https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/
 -- - Japanese: https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/opentelemetry/
-datadogTraceContextPropagator :: Propagator Context RequestHeaders RequestHeaders
+datadogTraceContextPropagator :: TextMapPropagator
 datadogTraceContextPropagator =
   Propagator
     { propagatorFields = ["datadog trace context"]
-    , extractor = \hs c -> do
+    , extractor = \tm c -> do
         let spanContext' = do
-              tidBs <- lookup traceIdKey hs
-              sidBs <- lookup parentIdKey hs
-              traceId <- eitherToMaybe $ bytesToTraceId $ SB.fromShort $ newTraceIdFromHeader tidBs
-              parentId <- eitherToMaybe $ bytesToSpanId $ SB.fromShort $ newSpanIdFromHeader sidBs
-              samplingPriority <- T.pack . BC.unpack <$> lookup samplingPriorityKey hs
+              tidText <- textMapLookup traceIdKey tm
+              sidText <- textMapLookup parentIdKey tm
+              let tidBs = Text.encodeUtf8 tidText
+                  sidBs = Text.encodeUtf8 sidText
+                  traceId = newTraceIdFromHeader tidBs
+                  parentId = newSpanIdFromHeader sidBs
+                  mPri = textMapLookup samplingPriorityKey tm
+                  (prioFlags, tsEntries) =
+                    case mPri of
+                      Nothing -> (TraceFlags 1, [])
+                      Just txt ->
+                        ( if datadogSamplingPriorityIndicatesSampled txt
+                            then TraceFlags 1
+                            else TraceFlags 0
+                        , [(TS.Key samplingPriorityKey, TS.Value txt)]
+                        )
               pure $
                 SpanContext
                   { traceId
                   , spanId = parentId
                   , isRemote = True
-                  , -- when 0, not sampled
-                    -- refer: OpenTelemetry.Internal.Trace.Types.isSampled
-                    traceFlags = TraceFlags 1
-                  , traceState = TraceState [(TS.Key samplingPriorityKey, TS.Value samplingPriority)]
+                  , traceFlags = prioFlags
+                  , traceState = TraceState tsEntries
                   }
         case spanContext' of
           Nothing -> pure c
           Just spanContext -> pure $ insertSpan (wrapSpanContext spanContext) c
-    , injector = \c hs ->
+    , injector = \c tm ->
         case lookupSpan c of
-          Nothing -> pure hs
+          Nothing -> pure tm
           Just span' -> do
-            SpanContext {traceId, spanId, traceState = TraceState traceState} <- getSpanContext span'
-            let traceIdValue = newHeaderFromTraceId $ shortFromTraceId traceId
-                parentIdValue = newHeaderFromSpanId $ shortFromSpanId spanId
+            SpanContext {traceId, spanId, traceState = TraceState traceState, traceFlags} <- getSpanContext span'
+            let traceIdValue = newHeaderFromTraceId traceId
+                parentIdValue = newHeaderFromSpanId spanId
             samplingPriority <-
               case lookup (TS.Key samplingPriorityKey) traceState of
-                Nothing -> pure "1" -- when an origin of the trace
-                Just (TS.Value p) -> pure $ BC.pack $ T.unpack p
+                Nothing ->
+                  pure $
+                    if isSampled traceFlags then "1" else "0"
+                Just (Value p) -> pure p
             pure $
-              (traceIdKey, traceIdValue)
-                : (parentIdKey, parentIdValue)
-                : (samplingPriorityKey, samplingPriority)
-                : hs
+              textMapInsert samplingPriorityKey samplingPriority $
+                textMapInsert parentIdKey (Text.decodeUtf8 parentIdValue) $
+                  textMapInsert traceIdKey (Text.decodeUtf8 traceIdValue) tm
     }
   where
-    traceIdKey, parentIdKey, samplingPriorityKey :: (IsString s) => s
+    traceIdKey, parentIdKey, samplingPriorityKey :: Text
     traceIdKey = "x-datadog-trace-id"
     parentIdKey = "x-datadog-parent-id"
     samplingPriorityKey = "x-datadog-sampling-priority"
 
-    eitherToMaybe :: Either e a -> Maybe a
-    eitherToMaybe = either (const Nothing) Just
+    -- Parsed sampling decisions for Datadog @x-datadog-sampling-priority@.
+    -- Non-numeric values are treated as sampled (upstream senders disagree;
+    -- see propagator tests).
+    datadogSamplingPriorityIndicatesSampled :: Text -> Bool
+    datadogSamplingPriorityIndicatesSampled txt =
+      case TR.signed TR.decimal (T.strip txt) of
+        Right (n, rest)
+          | T.null rest ->
+              n > (0 :: Integer)
+        _ -> True
 
-    shortFromTraceId :: TraceId -> SB.ShortByteString
-    shortFromTraceId = SB.toShort . traceIdBytes
 
-    shortFromSpanId :: SpanId -> SB.ShortByteString
-    shortFromSpanId = SB.toShort . spanIdBytes
+-- | Read eight bytes at @8 * offset@ as a big-endian 'Word64'.
+indexByteArrayNbo :: BA.ByteArray -> Int -> Word64
+indexByteArrayNbo ba !off = go 0 0
+  where
+    !base = 8 * off
+    go :: Int -> Word64 -> Word64
+    go 8 !acc = acc
+    go n !acc =
+      let !b = fromIntegral (BA.indexByteArray ba (base + n) :: Word8) :: Word64
+      in go (n + 1) ((acc `shiftL` 8) .|. b)
 
 
 convertOpenTelemetrySpanIdToDatadogSpanId :: SpanId -> Word64

--- a/propagators/datadog/src/OpenTelemetry/Propagator/Datadog/Internal.hs
+++ b/propagators/datadog/src/OpenTelemetry/Propagator/Datadog/Internal.hs
@@ -1,143 +1,103 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Strict #-}
 
-{- | Conversion of the hs-opentelemetry internal representation of the trace ID and the span ID and the Datadog header representation of them each other.
+{- | Conversion between OTel trace/span IDs (Word64-based) and Datadog
+header format (decimal ASCII of a 64-bit integer, big-endian byte order).
 
+@
 +----------+-----------------+----------------+
 |          | Trace ID        | Span ID        |
 +----------+-----------------+----------------+
-| Internal | 128-bit integer | 64-bit integer |
+| Internal | 2 x Word64 (LE)| 1 x Word64 (LE)|
 +----------+-----------------+----------------+
 | Datadog  | ASCII text of   | ASCII text of  |
 | Header   | 64-bit integer  | 64-bit integer |
 +----------+-----------------+----------------+
+@
 -}
 module OpenTelemetry.Propagator.Datadog.Internal (
   newTraceIdFromHeader,
   newSpanIdFromHeader,
   newHeaderFromTraceId,
   newHeaderFromSpanId,
-  indexByteArrayNbo,
 ) where
 
-import Data.Bits (Bits (shift))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Internal as BI
-import qualified Data.ByteString.Lazy as BL
-import Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as SB
-import qualified Data.ByteString.Short.Internal as SBI
-import qualified Data.Char as C
-import Data.Primitive.ByteArray (ByteArray (ByteArray), indexByteArray)
 import Data.Primitive.Ptr (writeOffPtr)
-import Data.Word (Word64, Word8)
+import Data.Word (Word64, Word8, byteSwap64)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Storable (peekElemOff)
+import OpenTelemetry.Internal.Trace.Id (SpanId (..), TraceId (..))
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
 
-newTraceIdFromHeader
-  :: ByteString
-  -- ^ ASCII text of 64-bit integer
-  -> ShortByteString
-  -- ^ 128-bit integer
+{- | Parse a decimal ASCII header value into a 'TraceId'.
+Datadog uses the low 64 bits of the 128-bit trace ID, in big-endian.
+The high 64 bits are set to zero.
+-}
+newTraceIdFromHeader :: ByteString -> TraceId
 newTraceIdFromHeader bs =
-  let w64 = readWord64BS bs
-      builder = BB.word64BE 0 <> BB.word64BE w64
-  in SB.toShort $ BL.toStrict $ BB.toLazyByteString builder
+  let !w64 = readWord64BS bs
+  in TraceId 0 (byteSwap64 w64)
 
 
-newSpanIdFromHeader
-  :: ByteString
-  -- ^ ASCII text of 64-bit integer
-  -> ShortByteString
-  -- ^ 64-bit integer
-newSpanIdFromHeader bs =
-  let w64 = readWord64BS bs
-      builder = BB.word64BE w64
-  in SB.toShort $ BL.toStrict $ BB.toLazyByteString builder
+-- | Parse a decimal ASCII header value into a 'SpanId'.
+newSpanIdFromHeader :: ByteString -> SpanId
+newSpanIdFromHeader bs = SpanId (byteSwap64 (readWord64BS bs))
 
+
+{- | Render the low 64 bits of a 'TraceId' as a decimal ASCII string
+(Datadog header format).
+-}
+newHeaderFromTraceId :: TraceId -> ByteString
+newHeaderFromTraceId (TraceId _hi lo) = showWord64BS (byteSwap64 lo)
+
+
+-- | Render a 'SpanId' as a decimal ASCII string (Datadog header format).
+newHeaderFromSpanId :: SpanId -> ByteString
+newHeaderFromSpanId (SpanId w) = showWord64BS (byteSwap64 w)
+
+
+-- ---------------------------------------------------------------------------
+-- Internal helpers
+-- ---------------------------------------------------------------------------
 
 readWord64BS :: ByteString -> Word64
 readWord64BS (BI.PS fptr _ len) =
-  -- Safe.
   unsafeDupablePerformIO $
-    withForeignPtr fptr readWord64Ptr
-  where
-    readWord64Ptr ptr =
-      readWord64PtrOffset 0 0
-      where
-        readWord64PtrOffset offset acc
-          | offset < len = do
-              b <- peekElemOff ptr offset
-              let n = fromIntegral $ asciiWord8ToWord8 b :: Word64
-              readWord64PtrOffset (offset + 1) $ n + acc * 10
-          | otherwise = pure acc
+    withForeignPtr fptr $ \ptr ->
+      let go !offset !acc
+            | offset < len = do
+                b <- peekElemOff ptr offset
+                let !n = fromIntegral (asciiDigit b) :: Word64
+                go (offset + 1) (acc * 10 + n)
+            | otherwise = pure acc
+      in go 0 0
 
 
-asciiWord8ToWord8 :: Word8 -> Word8
-asciiWord8ToWord8 b = b - fromIntegral (C.ord '0')
-
-
-newHeaderFromTraceId
-  :: ShortByteString
-  -- ^ 128-bit integer
-  -> ByteString
-  -- ^ ASCII text of 64-bit integer
-newHeaderFromTraceId (SBI.SBS ba) =
-  let w64 = indexByteArrayNbo (ByteArray ba) 1
-  in showWord64BS w64
-
-
-newHeaderFromSpanId
-  :: ShortByteString
-  -- ^ 64-bit integer
-  -> ByteString
-  -- ^ ASCII text of 64-bit integer
-newHeaderFromSpanId (SBI.SBS ba) =
-  let w64 = indexByteArrayNbo (ByteArray ba) 0
-  in showWord64BS w64
-
-
--- | Read 'ByteArray' to 'Word64' with network-byte-order.
-indexByteArrayNbo
-  :: ByteArray
-  -> Int
-  -- ^ Offset in 'Word64'-size unit
-  -> Word64
-indexByteArrayNbo ba offset =
-  loop 0 0
-  where
-    loop 8 acc = acc
-    loop n acc = loop (n + 1) $ shift acc 8 + word8ToWord64 (indexByteArray ba $ 8 * offset + n)
+asciiDigit :: Word8 -> Word8
+asciiDigit b = b - 0x30
 
 
 showWord64BS :: Word64 -> ByteString
 showWord64BS v =
-  -- Safe.
   unsafeDupablePerformIO $
-    BI.createUptoN 20 writeWord64Ptr -- 20 = length (show (maxBound :: Word64))
-  where
-    writeWord64Ptr ptr =
-      loop (19 :: Int) v 0 False
-      where
-        loop 0 v offset _ = do
-          writeOffPtr ptr offset (word8ToAsciiWord8 $ fromIntegral v)
-          pure $ offset + 1
-        loop n v offset upper = do
-          let (p, q) = v `divMod` (10 ^ n)
-          if p == 0 && not upper
-            then loop (n - 1) q offset upper
-            else do
-              writeOffPtr ptr offset (word8ToAsciiWord8 $ fromIntegral p)
-              loop (n - 1) q (offset + 1) True
+    BI.createUptoN 20 $ \ptr ->
+      let go :: Int -> Word64 -> Int -> Bool -> IO Int
+          go 0 v' offset _ = do
+            writeOffPtr ptr offset (toAsciiDigit $ fromIntegral v')
+            pure $ offset + 1
+          go n v' offset upper = do
+            let (!p, !q) = v' `divMod` (10 ^ n)
+            if p == 0 && not upper
+              then go (n - 1) q offset upper
+              else do
+                writeOffPtr ptr offset (toAsciiDigit $ fromIntegral p)
+                go (n - 1) q (offset + 1) True
+      in go (19 :: Int) v 0 False
 
 
-word8ToAsciiWord8 :: Word8 -> Word8
-word8ToAsciiWord8 b = b + fromIntegral (C.ord '0')
-
-
-word8ToWord64 :: Word8 -> Word64
-word8ToWord64 = fromIntegral
+toAsciiDigit :: Word8 -> Word8
+toAsciiDigit b = b + 0x30

--- a/propagators/datadog/test/spec/OpenTelemetry/Propagator/Datadog/InternalSpec.hs
+++ b/propagators/datadog/test/spec/OpenTelemetry/Propagator/Datadog/InternalSpec.hs
@@ -1,76 +1,51 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module OpenTelemetry.Propagator.Datadog.InternalSpec where
 
+import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
-import Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as SB
-import Data.Word (Word64)
-import Hexdump (simpleHex)
+import Data.Word (Word64, Word8)
+import OpenTelemetry.Internal.Trace.Id (SpanId, TraceId, bytesToSpanId, bytesToTraceId)
 import OpenTelemetry.Propagator.Datadog.Internal
-import qualified String
 import Test.Hspec
 import Test.QuickCheck
 
 
+mkTraceId :: [Word8] -> TraceId
+mkTraceId bs = case bytesToTraceId (B.pack bs) of
+  Right t -> t
+  Left _ -> error "bad trace id"
+
+
+mkSpanId :: [Word8] -> SpanId
+mkSpanId bs = case bytesToSpanId (B.pack bs) of
+  Right s -> s
+  Left _ -> error "bad span id"
+
+
 spec :: Spec
-spec = do
-  context "newTraceIdFromHeader" $ do
-    it "is equal to the old implementation" $
-      property $ \x -> do
-        let x' = BC.pack $ show (x :: Word64)
-        HexString (newTraceIdFromHeader x')
-          `shouldBe` HexString (String.newTraceIdFromHeader x')
+spec =
+  -- Datadog decimal trace/parent id header encoding
+  -- https://docs.datadoghq.com/tracing/trace_collection/trace_context_propagation/
+  do
+    context "newTraceIdFromHeader / newHeaderFromTraceId" $ do
+      it "round-trips decimal header bytes to TraceId (zero high bits)" $
+        property $ \(x1, x2, x3, x4, x5, x6, x7, x8) -> do
+          let tid = mkTraceId $ replicate 8 0 ++ [x1, x2, x3, x4, x5, x6, x7, x8]
+          newTraceIdFromHeader (newHeaderFromTraceId tid) `shouldBe` tid
 
-  context "newSpanIdFromHeader" $ do
-    it "is equal to the old implementation" $
-      property $ \x -> do
-        let x' = BC.pack $ show (x :: Word64)
-        HexString (newSpanIdFromHeader x')
-          `shouldBe` HexString (String.newSpanIdFromHeader x')
+      it "round-trips TraceId (zero high) to decimal header" $
+        property $ \x -> do
+          let x' = BC.pack $ show (x :: Word64)
+          newHeaderFromTraceId (newTraceIdFromHeader x') `shouldBe` x'
 
-  context "newHeaderFromTraceId" $ do
-    it "is equal to the old implementation" $
-      property $ \(x1, x2, x3, x4, x5, x6, x7, x8, x9, (x10, x11, x12, x13, x14, x15, x16)) -> do
-        let x' = SB.pack [x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16]
-        newHeaderFromTraceId x'
-          `shouldBe` String.newHeaderFromTraceId x'
+    context "newSpanIdFromHeader / newHeaderFromSpanId" $ do
+      it "round-trips decimal header bytes to SpanId" $
+        property $ \(x1, x2, x3, x4, x5, x6, x7, x8) -> do
+          let sid = mkSpanId [x1, x2, x3, x4, x5, x6, x7, x8]
+          newSpanIdFromHeader (newHeaderFromSpanId sid) `shouldBe` sid
 
-  context "newHeaderFromSpanId" $ do
-    it "is equal to the old implementation" $
-      property $ \(x1, x2, x3, x4, x5, x6, x7, x8) -> do
-        let x' = SB.pack [x1, x2, x3, x4, x5, x6, x7, x8]
-        newHeaderFromSpanId x'
-          `shouldBe` String.newHeaderFromSpanId x'
-
-  context "composition of newTraceIdFromHeader and newHeaderFromTraceId" $ do
-    it "is identical" $
-      property $ \(x1, x2, x3, x4, x5, x6, x7, x8) -> do
-        let x' = SB.pack $ replicate 8 0 ++ [x1, x2, x3, x4, x5, x6, x7, x8]
-        HexString (newTraceIdFromHeader $ newHeaderFromTraceId x') `shouldBe` HexString x'
-
-  context "composition of newHeaderFromTraceId and newTraceIdFromHeader" $ do
-    it "is identical" $
-      property $ \x -> do
-        let x' = BC.pack $ show (x :: Word64)
-        newHeaderFromTraceId (newTraceIdFromHeader x') `shouldBe` x'
-
-  context "composition of newSpanIdFromHeader and newHeaderFromSpanId" $ do
-    it "is identical" $
-      property $ \(x1, x2, x3, x4, x5, x6, x7, x8) -> do
-        let x' = SB.pack [x1, x2, x3, x4, x5, x6, x7, x8]
-        newSpanIdFromHeader (newHeaderFromSpanId x') `shouldBe` x'
-
-  context "composition of newHeaderFromSpanId and newSpanIdFromHeader" $ do
-    it "is identical" $
-      property $ \x -> do
-        let x' = BC.pack $ show (x :: Word64)
-        newHeaderFromSpanId (newSpanIdFromHeader x') `shouldBe` x'
-
-
-newtype HexString = HexString ShortByteString deriving (Eq)
-
-
-instance Show HexString where
-  show (HexString s) = simpleHex $ SB.fromShort s
+      it "round-trips SpanId to decimal header" $
+        property $ \x -> do
+          let x' = BC.pack $ show (x :: Word64)
+          newHeaderFromSpanId (newSpanIdFromHeader x') `shouldBe` x'

--- a/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
+++ b/propagators/jaeger/hs-opentelemetry-propagator-jaeger.cabal
@@ -1,0 +1,71 @@
+cabal-version: 2.4
+
+name:               hs-opentelemetry-propagator-jaeger
+version:            0.0.1.0
+synopsis:           Jaeger trace context propagation for OpenTelemetry.
+description:
+  Propagator implementing the Jaeger trace context format
+  (@uber-trace-id@ header) and Jaeger baggage (@uberctx-*@ headers).
+  .
+  The Jaeger format is deprecated in favour of W3C Trace Context but is
+  still widely deployed. This package lets Haskell services interoperate
+  with legacy Jaeger-instrumented systems.
+  .
+  See <https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format>.
+category:           OpenTelemetry, Tracing, Web
+homepage:           https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
+author:             Ian Duncan
+maintainer:         ian@iankduncan.com
+copyright:          2024 Ian Duncan, Mercury Technologies
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Propagator.Jaeger
+      OpenTelemetry.Propagator.Jaeger.Internal
+  other-modules:
+      Paths_hs_opentelemetry_propagator_jaeger
+  autogen-modules:
+      Paths_hs_opentelemetry_propagator_jaeger
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-propagator-jaeger-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      OpenTelemetry.Propagator.JaegerSpec
+      Paths_hs_opentelemetry_propagator_jaeger
+  autogen-modules:
+      Paths_hs_opentelemetry_propagator_jaeger
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , hs-opentelemetry-propagator-jaeger
+    , hspec
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+  build-tool-depends: hspec-discover:hspec-discover

--- a/propagators/jaeger/src/OpenTelemetry/Propagator/Jaeger.hs
+++ b/propagators/jaeger/src/OpenTelemetry/Propagator/Jaeger.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Jaeger Propagation Format:
+ <https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format>
+
+ The Jaeger propagation format is deprecated in favour of W3C Trace
+ Context. This package exists for interoperability with legacy systems.
+
+ == Header: @uber-trace-id@
+
+ @
+ {trace-id}:{span-id}:{parent-span-id}:{flags}
+ @
+
+ == Baggage: @uberctx-{key}@
+
+ Each baggage entry is a separate header with prefix @uberctx-@.
+-}
+module OpenTelemetry.Propagator.Jaeger (
+  jaegerPropagator,
+  jaegerTraceContextPropagator,
+
+  -- * Registry integration
+  registerJaegerPropagator,
+) where
+
+import qualified Data.ByteString.Char8 as C
+import qualified Data.HashMap.Strict as H
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import OpenTelemetry.Baggage (decodeBaggageHeader)
+import qualified OpenTelemetry.Baggage as Baggage
+import OpenTelemetry.Common (TraceFlags (..))
+import OpenTelemetry.Context (Context)
+import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  TextMap,
+  textMapInsert,
+  textMapKeys,
+  textMapLookup,
+ )
+import OpenTelemetry.Propagator.Jaeger.Internal
+import OpenTelemetry.Registry (registerTextMapPropagator)
+import qualified OpenTelemetry.Trace.Core as Core
+import OpenTelemetry.Trace.TraceState (TraceState (..))
+
+
+{- | Propagator for the Jaeger trace context format.
+
+Handles both the @uber-trace-id@ header (trace context) and
+@uberctx-*@ headers (baggage).
+-}
+jaegerPropagator :: Propagator Context TextMap TextMap
+jaegerPropagator = jaegerTraceContextPropagator <> jaegerBaggagePropagator
+
+
+{- | Propagator for the @uber-trace-id@ header only (no baggage).
+
+Use 'jaegerPropagator' if you also need Jaeger baggage propagation.
+-}
+jaegerTraceContextPropagator :: Propagator Context TextMap TextMap
+jaegerTraceContextPropagator =
+  Propagator
+    { propagatorFields = [uberTraceIdHeader]
+    , extractor = \tm c ->
+        case textMapLookup uberTraceIdHeader tm of
+          Nothing -> pure c
+          Just val ->
+            case decodeUberTraceId (TE.encodeUtf8 val) of
+              Nothing -> pure c
+              Just jh ->
+                let sampled = flagsSampled (jhFlags jh) || flagsDebug (jhFlags jh)
+                    sc =
+                      Core.SpanContext
+                        { Core.traceId = jhTraceId jh
+                        , Core.spanId = jhSpanId jh
+                        , Core.isRemote = True
+                        , Core.traceFlags = if sampled then TraceFlags 1 else TraceFlags 0
+                        , Core.traceState = TraceState []
+                        }
+                in pure $ Context.insertSpan (Core.wrapSpanContext sc) c
+    , injector = \c tm ->
+        case Context.lookupSpan c of
+          Nothing -> pure tm
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            let !sampled = Core.isSampled (Core.traceFlags sc)
+                !headerBs = encodeUberTraceId (Core.traceId sc) (Core.spanId sc) sampled
+                !headerValue = TE.decodeUtf8 headerBs
+            pure $ textMapInsert uberTraceIdHeader headerValue tm
+    }
+
+
+-- | Propagator for Jaeger-style baggage (@uberctx-*@ headers).
+jaegerBaggagePropagator :: Propagator Context TextMap TextMap
+jaegerBaggagePropagator =
+  Propagator
+    { propagatorFields = []
+    , extractor = \tm c -> do
+        let baggageKeys = filter (T.isPrefixOf uberBaggagePrefix) (textMapKeys tm)
+            entries = catMaybes $ map (extractBaggageEntry tm) baggageKeys
+        case entries of
+          [] -> pure c
+          kvs ->
+            case decodeBaggageHeader (C.pack $ encodeBaggageString kvs) of
+              Left _ -> pure c
+              Right bag -> pure $ Context.insertBaggage bag c
+    , injector = \c tm ->
+        case Context.lookupBaggage c of
+          Nothing -> pure tm
+          Just bag ->
+            let entries = H.toList (Baggage.values bag)
+            in pure $
+                 foldl
+                   ( \acc (k, v) ->
+                       let headerName = uberBaggagePrefix <> TE.decodeUtf8 (Baggage.tokenValue k)
+                       in textMapInsert headerName (Baggage.value v) acc
+                   )
+                   tm
+                   entries
+    }
+
+
+extractBaggageEntry :: TextMap -> Text -> Maybe (Text, Text)
+extractBaggageEntry tm headerKey = do
+  val <- textMapLookup headerKey tm
+  let key = T.drop (T.length uberBaggagePrefix) headerKey
+  if T.null key
+    then Nothing
+    else Just (key, val)
+
+
+encodeBaggageString :: [(Text, Text)] -> String
+encodeBaggageString kvs =
+  T.unpack $ T.intercalate "," $ map (\(k, v) -> k <> "=" <> v) kvs
+
+
+{- | Register the Jaeger propagator under the name @\"jaeger\"@ in the
+global registry.
+
+@since 0.0.1.0
+-}
+registerJaegerPropagator :: IO ()
+registerJaegerPropagator =
+  registerTextMapPropagator "jaeger" jaegerPropagator

--- a/propagators/jaeger/src/OpenTelemetry/Propagator/Jaeger/Internal.hs
+++ b/propagators/jaeger/src/OpenTelemetry/Propagator/Jaeger/Internal.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
+
+{- | Internal codec for the Jaeger propagation format.
+
+The wire format for the @uber-trace-id@ header is:
+
+@
+{trace-id}:{span-id}:{parent-span-id}:{flags}
+@
+
+See <https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format>.
+-}
+module OpenTelemetry.Propagator.Jaeger.Internal (
+  -- * Encoders
+  encodeTraceId,
+  encodeSpanId,
+  encodeUberTraceId,
+
+  -- * Decoders
+  decodeUberTraceId,
+
+  -- * Parsed header
+  JaegerHeader (..),
+
+  -- * Flags
+  JaegerFlags (..),
+  flagsSampled,
+  flagsDebug,
+
+  -- * Header keys
+  uberTraceIdHeader,
+  uberBaggagePrefix,
+) where
+
+import Data.Bits (Bits ((.&.)))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import Data.Word (Word8)
+import OpenTelemetry.Trace.Id (
+  Base (..),
+  SpanId,
+  TraceId,
+  baseEncodedToSpanId,
+  baseEncodedToTraceId,
+  bytesToTraceId,
+  spanIdBaseEncodedByteString,
+  spanIdBytes,
+  traceIdBaseEncodedByteString,
+ )
+
+
+-- Header keys ----------------------------------------------------------------
+
+uberTraceIdHeader :: Text
+uberTraceIdHeader = "uber-trace-id"
+
+
+uberBaggagePrefix :: Text
+uberBaggagePrefix = "uberctx-"
+
+
+-- Flags ----------------------------------------------------------------------
+
+-- | Jaeger flags byte from the wire format.
+newtype JaegerFlags = JaegerFlags Word8
+  deriving (Eq, Show)
+
+
+flagsSampled :: JaegerFlags -> Bool
+flagsSampled (JaegerFlags f) = f .&. 0x01 /= 0
+
+
+flagsDebug :: JaegerFlags -> Bool
+flagsDebug (JaegerFlags f) = f .&. 0x02 /= 0
+
+
+-- Parsed header --------------------------------------------------------------
+
+data JaegerHeader = JaegerHeader
+  { jhTraceId :: !TraceId
+  , jhSpanId :: !SpanId
+  , jhParentSpanId :: !(Maybe SpanId)
+  , jhFlags :: !JaegerFlags
+  }
+  deriving (Eq, Show)
+
+
+-- Encoders -------------------------------------------------------------------
+
+encodeTraceId :: TraceId -> ByteString
+encodeTraceId = traceIdBaseEncodedByteString Base16
+{-# INLINE encodeTraceId #-}
+
+
+encodeSpanId :: SpanId -> ByteString
+encodeSpanId = spanIdBaseEncodedByteString Base16
+{-# INLINE encodeSpanId #-}
+
+
+{- | Encode a Jaeger uber-trace-id header value directly as a ByteString.
+
+Format: @{trace-id}:{span-id}:0:{flags}@
+-}
+encodeUberTraceId :: TraceId -> SpanId -> Bool -> ByteString
+encodeUberTraceId tid sid sampled =
+  traceIdBaseEncodedByteString Base16 tid
+    <> ":"
+    <> spanIdBaseEncodedByteString Base16 sid
+    <> ":0:"
+    <> if sampled then "1" else "0"
+
+
+-- Decoders -------------------------------------------------------------------
+
+{- | Decode a Jaeger @uber-trace-id@ header value.
+
+Uses memchr to locate colon delimiters and the existing SIMD hex
+decoders for trace/span ID parsing.
+-}
+decodeUberTraceId :: ByteString -> Maybe JaegerHeader
+decodeUberTraceId bs = do
+  let !len = BS.length bs
+  -- Need at least: 16 (tid) + 1 (:) + 1 (sid) + 1 (:) + 1 (parent) + 1 (:) + 1 (flags) = 22
+  if len < 22
+    then Nothing
+    else do
+      -- Find three colons via memchr.
+      !c1 <- BS.elemIndex 0x3a bs
+      !c2rel <- BS.elemIndex 0x3a (BS.drop (c1 + 1) bs)
+      let !c2 = c1 + 1 + c2rel
+      !c3rel <- BS.elemIndex 0x3a (BS.drop (c2 + 1) bs)
+      let !c3 = c2 + 1 + c3rel
+
+      -- Reject extra colons (trailing garbage).
+      case BS.elemIndex 0x3a (BS.drop (c3 + 1) bs) of
+        Just _ -> Nothing
+        Nothing -> do
+          let !tidHex = BS.take c1 bs
+              !sidHex = BS.take c2rel (BS.drop (c1 + 1) bs)
+              !parentHex = BS.take c3rel (BS.drop (c2 + 1) bs)
+              !flagsHex = BS.drop (c3 + 1) bs
+
+          -- Flags: 1-2 hex digits, validated first (cheapest check).
+          !flags <- parseFlags flagsHex
+
+          -- Trace ID: 16 or 32 hex chars.
+          !tid <- eitherToMaybe (decodeTraceIdFromHex tidHex)
+
+          -- Span ID: must be valid hex (length validated by baseEncodedToSpanId).
+          !sid <- eitherToMaybe (baseEncodedToSpanId Base16 sidHex)
+
+          -- Parent span ID: all-zeros means "no parent".
+          let !parentSid
+                | BS.null parentHex = Nothing
+                | BS.all (== 0x30) parentHex = Nothing
+                | otherwise = eitherToMaybe (baseEncodedToSpanId Base16 parentHex)
+
+          pure
+            JaegerHeader
+              { jhTraceId = tid
+              , jhSpanId = sid
+              , jhParentSpanId = parentSid
+              , jhFlags = flags
+              }
+
+
+-- Internal helpers -----------------------------------------------------------
+
+{- | Decode a trace ID from hex, accepting both 64-bit (16 chars, zero-padded)
+and 128-bit (32 chars) representations.
+-}
+decodeTraceIdFromHex :: ByteString -> Either String TraceId
+decodeTraceIdFromHex hexBs
+  | BS.length hexBs == 32 = baseEncodedToTraceId Base16 hexBs
+  | BS.length hexBs == 16 = do
+      sid <- baseEncodedToSpanId Base16 hexBs
+      bytesToTraceId (BS.replicate 8 0 <> spanIdBytes sid)
+  | otherwise = Left "Jaeger trace id: expected 16 or 32 hex characters"
+
+
+-- | Parse 1-2 hex characters into a flags byte.
+parseFlags :: ByteString -> Maybe JaegerFlags
+parseFlags flagsHex = case BS.length flagsHex of
+  1 -> do
+    !a <- hexNibble (BS.index flagsHex 0)
+    Just $! JaegerFlags a
+  2 -> do
+    !a <- hexNibble (BS.index flagsHex 0)
+    !b <- hexNibble (BS.index flagsHex 1)
+    Just $! JaegerFlags (a * 16 + b)
+  _ -> Nothing
+
+
+hexNibble :: Word8 -> Maybe Word8
+hexNibble c
+  | c >= 0x30 && c <= 0x39 = Just (c - 0x30)
+  | c >= 0x41 && c <= 0x46 = Just (c - 0x41 + 10)
+  | c >= 0x61 && c <= 0x66 = Just (c - 0x61 + 10)
+  | otherwise = Nothing
+{-# INLINE hexNibble #-}
+
+
+eitherToMaybe :: Either a b -> Maybe b
+eitherToMaybe (Right x) = Just x
+eitherToMaybe (Left _) = Nothing
+{-# INLINE eitherToMaybe #-}

--- a/propagators/jaeger/test/OpenTelemetry/Propagator/JaegerSpec.hs
+++ b/propagators/jaeger/test/OpenTelemetry/Propagator/JaegerSpec.hs
@@ -1,0 +1,306 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenTelemetry.Propagator.JaegerSpec (spec) where
+
+import qualified Data.HashMap.Strict as H
+import Data.Maybe (isNothing)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified OpenTelemetry.Baggage as Baggage
+import OpenTelemetry.Common (TraceFlags (..))
+import OpenTelemetry.Context (Context, empty, insertBaggage, insertSpan, lookupBaggage, lookupSpan)
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  TextMap,
+  emptyTextMap,
+  textMapFromList,
+  textMapKeys,
+  textMapLookup,
+ )
+import OpenTelemetry.Propagator.Jaeger (jaegerPropagator, jaegerTraceContextPropagator)
+import qualified OpenTelemetry.Propagator.Jaeger.Internal as JI
+import OpenTelemetry.Trace.Core (SpanContext (..), getSpanContext, isSampled, wrapSpanContext)
+import OpenTelemetry.Trace.Id (Base (..), SpanId, TraceId, baseEncodedToSpanId, baseEncodedToTraceId)
+import OpenTelemetry.Trace.TraceState (TraceState (..))
+import Test.Hspec
+
+
+spec :: Spec
+spec =
+  -- Jaeger uber-trace-id and uberctx-* propagation
+  -- https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format
+  describe "OpenTelemetry.Propagator.Jaeger" $ do
+    describe "Internal codec" $ do
+      -- {trace-id}:{span-id}:{parent-span-id}:{flags} (hex)
+      -- https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format
+      it "parses a 128-bit trace context header" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:1"
+        case JI.decodeUberTraceId (TE.encodeUtf8 hdr) of
+          Nothing -> expectationFailure "expected parse"
+          Just jh -> do
+            JI.jhTraceId jh `shouldBe` expectedTraceId
+            JI.jhSpanId jh `shouldBe` expectedSpanId
+            JI.jhParentSpanId jh `shouldBe` Nothing
+            JI.flagsSampled (JI.jhFlags jh) `shouldBe` True
+            JI.flagsDebug (JI.jhFlags jh) `shouldBe` False
+
+      it "parses a 64-bit trace ID (left-padded to 128-bit)" $ do
+        let hdr = "64fe8b2a57d3eff7:e457b5a2e4d86bd1:0:1"
+        case JI.decodeUberTraceId (TE.encodeUtf8 hdr) of
+          Nothing -> expectationFailure "expected parse"
+          Just jh -> do
+            JI.jhTraceId jh `shouldBe` expectedTraceId64
+            JI.flagsSampled (JI.jhFlags jh) `shouldBe` True
+
+      -- flags: sampled + debug bits
+      -- https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format
+      it "parses debug flag (flags=03 means sampled+debug)" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:03"
+        case JI.decodeUberTraceId (TE.encodeUtf8 hdr) of
+          Nothing -> expectationFailure "expected parse"
+          Just jh -> do
+            JI.flagsSampled (JI.jhFlags jh) `shouldBe` True
+            JI.flagsDebug (JI.jhFlags jh) `shouldBe` True
+
+      it "parses unsampled flag (flags=0)" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:0"
+        case JI.decodeUberTraceId (TE.encodeUtf8 hdr) of
+          Nothing -> expectationFailure "expected parse"
+          Just jh -> do
+            JI.flagsSampled (JI.jhFlags jh) `shouldBe` False
+            JI.flagsDebug (JI.jhFlags jh) `shouldBe` False
+
+      it "parses debug-only flag (flags=2)" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:2"
+        case JI.decodeUberTraceId (TE.encodeUtf8 hdr) of
+          Nothing -> expectationFailure "expected parse"
+          Just jh -> do
+            JI.flagsSampled (JI.jhFlags jh) `shouldBe` False
+            JI.flagsDebug (JI.jhFlags jh) `shouldBe` True
+
+      it "parses non-zero parent span ID" $ do
+        let hdr = "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:05e3ac9a4f6e3b90:1"
+        case JI.decodeUberTraceId (TE.encodeUtf8 hdr) of
+          Nothing -> expectationFailure "expected parse"
+          Just jh -> case JI.jhParentSpanId jh of
+            Nothing -> expectationFailure "expected parent span ID"
+            Just _ -> pure ()
+
+      it "rejects empty input" $ do
+        JI.decodeUberTraceId "" `shouldBe` Nothing
+
+      it "rejects missing fields" $ do
+        JI.decodeUberTraceId "abc:def:0" `shouldBe` Nothing
+
+      it "rejects non-hex characters in trace ID" $ do
+        JI.decodeUberTraceId "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz:e457b5a2e4d86bd1:0:1"
+          `shouldBe` Nothing
+
+      it "rejects trailing garbage" $ do
+        JI.decodeUberTraceId "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:1:extra"
+          `shouldBe` Nothing
+
+    describe "trace context extraction" $ do
+      it "extracts SpanContext from uber-trace-id (sampled)" $ do
+        let headers =
+              textMapFromList
+                [("uber-trace-id", "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:1")]
+        ctx' <- extractor jaegerTraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- getSpanContext span'
+            traceId sc `shouldBe` expectedTraceId
+            spanId sc `shouldBe` expectedSpanId
+            isRemote sc `shouldBe` True
+            isSampled (traceFlags sc) `shouldBe` True
+
+      it "extracts SpanContext from uber-trace-id (unsampled)" $ do
+        let headers =
+              textMapFromList
+                [("uber-trace-id", "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:0")]
+        ctx' <- extractor jaegerTraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- getSpanContext span'
+            isSampled (traceFlags sc) `shouldBe` False
+
+      it "debug flag implies sampled" $ do
+        let headers =
+              textMapFromList
+                [("uber-trace-id", "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:2")]
+        ctx' <- extractor jaegerTraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- getSpanContext span'
+            isSampled (traceFlags sc) `shouldBe` True
+
+      it "leaves context unchanged when header is missing" $ do
+        ctx' <- extractor jaegerTraceContextPropagator emptyTextMap empty
+        lookupSpan ctx' `shouldSatisfy` isNothing
+
+      it "leaves context unchanged for malformed header" $ do
+        let headers = textMapFromList [("uber-trace-id", "not-a-valid-header")]
+        ctx' <- extractor jaegerTraceContextPropagator headers empty
+        lookupSpan ctx' `shouldSatisfy` isNothing
+
+      -- HTTP header names are case-insensitive (RFC 9110)
+      it "header name is case-insensitive" $ do
+        let headers =
+              textMapFromList
+                [("Uber-Trace-Id", "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:1")]
+        ctx' <- extractor jaegerTraceContextPropagator headers empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- getSpanContext span'
+            traceId sc `shouldBe` expectedTraceId
+
+    describe "trace context injection" $ do
+      it "injects uber-trace-id with sampled flag" $ do
+        let ctx = insertSpan (wrapSpanContext sampledSpanContext) empty
+        hs <- injector jaegerTraceContextPropagator ctx emptyTextMap
+        case textMapLookup "uber-trace-id" hs of
+          Nothing -> expectationFailure "expected uber-trace-id header"
+          Just v -> do
+            let parts = T.splitOn ":" v
+            length parts `shouldBe` 4
+            parts !! 0 `shouldBe` traceIdHex
+            parts !! 1 `shouldBe` spanIdHex
+            parts !! 2 `shouldBe` "0"
+            parts !! 3 `shouldBe` "1"
+
+      it "injects uber-trace-id with unsampled flag" $ do
+        let ctx = insertSpan (wrapSpanContext unsampledSpanContext) empty
+        hs <- injector jaegerTraceContextPropagator ctx emptyTextMap
+        case textMapLookup "uber-trace-id" hs of
+          Nothing -> expectationFailure "expected uber-trace-id header"
+          Just v -> do
+            let parts = T.splitOn ":" v
+            parts !! 3 `shouldBe` "0"
+
+      it "does not inject when no span in context" $ do
+        hs <- injector jaegerTraceContextPropagator empty emptyTextMap
+        textMapLookup "uber-trace-id" hs `shouldSatisfy` isNothing
+
+    describe "round-trip" $ do
+      it "extract after inject preserves trace and span IDs" $ do
+        let ctx = insertSpan (wrapSpanContext sampledSpanContext) empty
+        hs <- injector jaegerTraceContextPropagator ctx emptyTextMap
+        ctx' <- extractor jaegerTraceContextPropagator hs empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context after round-trip"
+          Just span' -> do
+            sc <- getSpanContext span'
+            traceId sc `shouldBe` expectedTraceId
+            spanId sc `shouldBe` expectedSpanId
+            isSampled (traceFlags sc) `shouldBe` True
+
+      it "round-trip preserves unsampled flag" $ do
+        let ctx = insertSpan (wrapSpanContext unsampledSpanContext) empty
+        hs <- injector jaegerTraceContextPropagator ctx emptyTextMap
+        ctx' <- extractor jaegerTraceContextPropagator hs empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- getSpanContext span'
+            isSampled (traceFlags sc) `shouldBe` False
+
+    -- Jaeger baggage as uberctx-{key} headers
+    -- https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format
+    describe "baggage propagation" $ do
+      it "extracts baggage from uberctx-* headers" $ do
+        let headers =
+              textMapFromList
+                [ ("uber-trace-id", "80f198ee56343ba864fe8b2a57d3eff7:e457b5a2e4d86bd1:0:1")
+                , ("uberctx-user-id", "42")
+                , ("uberctx-session", "abc123")
+                ]
+        ctx' <- extractor jaegerPropagator headers empty
+        case lookupBaggage ctx' of
+          Nothing -> expectationFailure "expected baggage in context"
+          Just bag -> do
+            let vals = H.toList (Baggage.values bag)
+            length vals `shouldSatisfy` (>= 2)
+
+      it "injects baggage as uberctx-* headers" $ do
+        case Baggage.decodeBaggageHeader "user-id=42,session=abc123" of
+          Left err -> expectationFailure $ "baggage setup failed: " ++ err
+          Right bag -> do
+            let ctx =
+                  insertSpan (wrapSpanContext sampledSpanContext) $
+                    insertBaggage bag empty
+            hs <- injector jaegerPropagator ctx emptyTextMap
+            textMapLookup "uberctx-user-id" hs `shouldBe` Just "42"
+            textMapLookup "uberctx-session" hs `shouldBe` Just "abc123"
+
+      it "does not inject baggage headers when no baggage in context" $ do
+        let ctx = insertSpan (wrapSpanContext sampledSpanContext) empty
+        hs <- injector jaegerPropagator ctx emptyTextMap
+        let baggageHeaders = filter (T.isPrefixOf "uberctx-") $ map fst $ textMapToListImpl hs
+        baggageHeaders `shouldBe` []
+
+    describe "propagatorFields" $ do
+      it "trace context propagator declares uber-trace-id" $ do
+        propagatorFields jaegerTraceContextPropagator `shouldBe` ["uber-trace-id"]
+
+
+-- Helpers --------------------------------------------------------------------
+
+textMapToListImpl :: TextMap -> [(T.Text, T.Text)]
+textMapToListImpl tm =
+  map (\k -> (k, maybe "" id (textMapLookup k tm))) (textMapKeys tm)
+
+
+traceIdHex :: T.Text
+traceIdHex = "80f198ee56343ba864fe8b2a57d3eff7"
+
+
+spanIdHex :: T.Text
+spanIdHex = "e457b5a2e4d86bd1"
+
+
+expectedTraceId :: TraceId
+expectedTraceId =
+  case baseEncodedToTraceId Base16 (TE.encodeUtf8 traceIdHex) of
+    Right t -> t
+    Left e -> error ("expectedTraceId: " ++ e)
+
+
+-- 64-bit trace ID "64fe8b2a57d3eff7" → zero-padded to 128-bit
+expectedTraceId64 :: TraceId
+expectedTraceId64 =
+  case baseEncodedToTraceId Base16 "000000000000000064fe8b2a57d3eff7" of
+    Right t -> t
+    Left e -> error ("expectedTraceId64: " ++ e)
+
+
+expectedSpanId :: SpanId
+expectedSpanId =
+  case baseEncodedToSpanId Base16 (TE.encodeUtf8 spanIdHex) of
+    Right s -> s
+    Left e -> error ("expectedSpanId: " ++ e)
+
+
+sampledSpanContext :: SpanContext
+sampledSpanContext =
+  SpanContext
+    { traceId = expectedTraceId
+    , spanId = expectedSpanId
+    , isRemote = False
+    , traceFlags = TraceFlags 1
+    , traceState = TraceState []
+    }
+
+
+unsampledSpanContext :: SpanContext
+unsampledSpanContext =
+  SpanContext
+    { traceId = expectedTraceId
+    , spanId = expectedSpanId
+    , isRemote = False
+    , traceFlags = TraceFlags 0
+    , traceState = TraceState []
+    }

--- a/propagators/jaeger/test/Spec.hs
+++ b/propagators/jaeger/test/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+

--- a/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
+++ b/propagators/w3c/hs-opentelemetry-propagator-w3c.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -38,8 +38,7 @@ library
       attoparsec
     , base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api ==0.3.*
-    , http-types
+    , hs-opentelemetry-api ==0.4.*
     , text
   default-language: Haskell2010
 
@@ -47,10 +46,10 @@ test-suite hs-opentelemetry-propagator-w3c-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      OpenTelemetry.Propagator.W3CBaggageSpec
       OpenTelemetry.Propagator.W3CIntegrationSpec
       OpenTelemetry.Propagator.W3CMultiHeaderSpec
       OpenTelemetry.Propagator.W3CTraceContextSpec
-      Paths_hs_opentelemetry_propagator_w3c
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
@@ -59,9 +58,10 @@ test-suite hs-opentelemetry-propagator-w3c-test
     , attoparsec
     , base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api
-    , hs-opentelemetry-propagator-w3c
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-propagator-w3c >=0.1.0 && <0.2
     , hspec
     , hspec-discover
     , text
+    , unordered-containers
   default-language: Haskell2010

--- a/propagators/w3c/package.yaml
+++ b/propagators/w3c/package.yaml
@@ -26,25 +26,30 @@ library:
   source-dirs: src
   dependencies:
   - bytestring
-  - hs-opentelemetry-api ^>= 0.3
-  - http-types
+  - hs-opentelemetry-api ^>= 0.4
   - attoparsec
   - text
 
 tests:
   hs-opentelemetry-propagator-w3c-test:
     main:                Spec.hs
+    other-modules:
+    - OpenTelemetry.Propagator.W3CBaggageSpec
+    - OpenTelemetry.Propagator.W3CIntegrationSpec
+    - OpenTelemetry.Propagator.W3CMultiHeaderSpec
+    - OpenTelemetry.Propagator.W3CTraceContextSpec
     source-dirs:         test
     ghc-options:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-propagator-w3c
+    - hs-opentelemetry-propagator-w3c >= 0.1.0 && < 0.2
     - hspec
     - hspec-discover
     - QuickCheck
     - bytestring
     - text
-    - hs-opentelemetry-api
+    - hs-opentelemetry-api == 0.4.*
     - attoparsec
+    - unordered-containers

--- a/propagators/w3c/src/OpenTelemetry/Propagator/W3CBaggage.hs
+++ b/propagators/w3c/src/OpenTelemetry/Propagator/W3CBaggage.hs
@@ -1,13 +1,26 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module OpenTelemetry.Propagator.W3CBaggage where
+{- |
+Module      : OpenTelemetry.Propagator.W3CBaggage
+Description : W3C Baggage propagation (https://www.w3.org/TR/baggage/). Extracts and injects the baggage header.
+Stability   : experimental
+-}
+module OpenTelemetry.Propagator.W3CBaggage (
+  w3cBaggagePropagator,
+  decodeBaggage,
+  encodeBaggage,
 
-import Data.ByteString
-import Network.HTTP.Types
+  -- * Registry integration
+  registerW3CBaggagePropagator,
+) where
+
+import Data.ByteString (ByteString)
+import qualified Data.Text.Encoding as TE
 import qualified OpenTelemetry.Baggage as Baggage
 import OpenTelemetry.Context (Context, insertBaggage, lookupBaggage)
 import OpenTelemetry.Propagator
+import OpenTelemetry.Registry (registerTextMapPropagator)
 
 
 decodeBaggage :: ByteString -> Maybe Baggage.Baggage
@@ -20,18 +33,28 @@ encodeBaggage :: Baggage.Baggage -> ByteString
 encodeBaggage = Baggage.encodeBaggageHeader
 
 
-w3cBaggagePropagator :: Propagator Context RequestHeaders RequestHeaders
+w3cBaggagePropagator :: Propagator Context TextMap TextMap
 w3cBaggagePropagator = Propagator {..}
   where
-    propagatorNames = ["baggage"]
+    propagatorFields = ["baggage"]
 
-    extractor hs c = case Prelude.lookup "baggage" hs of
+    extractor tm c = case textMapLookup "baggage" tm of
       Nothing -> pure c
-      Just baggageHeader -> case decodeBaggage baggageHeader of
+      Just baggageText -> case decodeBaggage (TE.encodeUtf8 baggageText) of
         Nothing -> pure c
         Just baggage -> pure $! insertBaggage baggage c
 
-    injector c hs = do
+    injector c tm = do
       case lookupBaggage c of
-        Nothing -> pure hs
-        Just baggage -> pure $! (("baggage", encodeBaggage baggage) : hs)
+        Nothing -> pure tm
+        Just baggage -> pure $! textMapInsert "baggage" (TE.decodeUtf8 $ encodeBaggage baggage) tm
+
+
+{- | Register the W3C Baggage propagator under the name @\"baggage\"@
+in the global registry.
+
+@since 0.1.0.0
+-}
+registerW3CBaggagePropagator :: IO ()
+registerW3CBaggagePropagator =
+  registerTextMapPropagator "baggage" w3cBaggagePropagator

--- a/propagators/w3c/src/OpenTelemetry/Propagator/W3CTraceContext.hs
+++ b/propagators/w3c/src/OpenTelemetry/Propagator/W3CTraceContext.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -29,54 +30,29 @@
 -}
 module OpenTelemetry.Propagator.W3CTraceContext where
 
-import Data.Attoparsec.ByteString.Char8 (
-  Parser,
-  char,
-  endOfInput,
-  hexadecimal,
-  parseOnly,
-  sepBy,
-  skipSpace,
-  string,
-  takeWhile,
-  takeWhile1,
- )
+import Control.Monad (unless, when)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C8
-import qualified Data.ByteString.Lazy as L
-import Data.Char (isHexDigit)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Word (Word8)
-import Network.HTTP.Types (RequestHeaders)
 import qualified OpenTelemetry.Context as Ctxt
-import OpenTelemetry.Propagator (Propagator (..))
+import OpenTelemetry.Propagator (Propagator (..), TextMap, textMapInsert, textMapLookup)
+import OpenTelemetry.Registry (registerTextMapPropagator)
 import OpenTelemetry.Trace.Core (
   Span,
   SpanContext (..),
-  TraceFlags,
   getSpanContext,
   traceFlagsFromWord8,
   traceFlagsValue,
   wrapSpanContext,
  )
-import OpenTelemetry.Trace.Id (Base (..), SpanId, TraceId, baseEncodedToSpanId, baseEncodedToTraceId, spanIdBaseEncodedBuilder, traceIdBaseEncodedBuilder)
+import OpenTelemetry.Trace.Id (
+  decodeTraceparent,
+  encodeTraceparent,
+ )
 import OpenTelemetry.Trace.TraceState (Key (..), TraceState, Value (..), empty, fromList, toList)
-import Prelude hiding (takeWhile)
-
-
-{-
-TODO: test against the conformance spec:
-https://github.com/w3c/trace-context
--}
-data TraceParent = TraceParent
-  { version :: {-# UNPACK #-} !Word8
-  , traceId :: {-# UNPACK #-} !TraceId
-  , parentId :: {-# UNPACK #-} !SpanId
-  , traceFlags :: {-# UNPACK #-} !TraceFlags
-  }
-  deriving (Show)
 
 
 {- | Attempt to decode a 'SpanContext' from optional @traceparent@ and @tracestate@ header inputs.
@@ -91,129 +67,158 @@ decodeSpanContext
   -> Maybe SpanContext
 decodeSpanContext Nothing _ = Nothing
 decodeSpanContext (Just traceparentHeader) mTracestateHeader = do
-  TraceParent {..} <- decodeTraceparentHeader traceparentHeader
-  ts <- case mTracestateHeader of
-    Nothing -> pure empty
-    Just tracestateHeader -> pure $ decodeTracestateHeader tracestateHeader
-  pure $
+  (_, tid, sid, fl) <- decodeTraceparent traceparentHeader
+  let ts = case mTracestateHeader of
+        Nothing -> empty
+        Just tracestateHeader -> decodeTraceState tracestateHeader
+  pure $!
     SpanContext
-      { traceFlags = traceFlags
+      { traceFlags = traceFlagsFromWord8 fl
       , isRemote = True
-      , traceId = traceId
-      , spanId = parentId
+      , traceId = tid
+      , spanId = sid
       , traceState = ts
       }
-  where
-    decodeTraceparentHeader :: ByteString -> Maybe TraceParent
-    decodeTraceparentHeader tp = case parseOnly traceparentParser tp of
-      Left _ -> Nothing
-      Right ok -> Just ok
-
-    decodeTracestateHeader :: ByteString -> TraceState
-    decodeTracestateHeader ts = case parseOnly tracestateParser ts of
-      Left _ -> empty
-      Right ok -> ok
 
 
-traceparentParser :: Parser TraceParent
-traceparentParser = do
-  version <- hexadecimal
-  _ <- string "-"
-  traceIdBs <- takeWhile isHexDigit
-  traceId <- case baseEncodedToTraceId Base16 traceIdBs of
-    Left err -> fail err
-    Right ok -> pure ok
-  _ <- string "-"
-  parentIdBs <- takeWhile isHexDigit
-  parentId <- case baseEncodedToSpanId Base16 parentIdBs of
-    Left err -> fail err
-    Right ok -> pure ok
-  _ <- string "-"
-  traceFlags <- traceFlagsFromWord8 <$> hexadecimal
-  -- Intentionally not consuming end of input in case of version > 0
-  pure $ TraceParent {..}
+{- | Parse a W3C tracestate header value into a 'TraceState'.
 
+Format: @OWS list-member *( OWS "," OWS list-member ) OWS@
 
-{- | Parser for W3C tracestate header format
-Format: OWS list-member *( OWS "," OWS list-member ) OWS
 See: https://www.w3.org/TR/trace-context/#tracestate-header
+
+Returns 'empty' on parse failure.
+
+@since 0.1.0.0
 -}
-tracestateParser :: Parser TraceState
-tracestateParser = do
-  skipSpace
-  pairs <- tracestateEntry `sepBy` (skipSpace >> char ',' >> skipSpace)
-  skipSpace
-  endOfInput
-  -- Limit to 32 entries as per spec, take first 32 if more
-  let limitedPairs = take 32 pairs
-  pure $ fromList [(Key k, Value v) | (k, v) <- limitedPairs]
+decodeTraceState :: ByteString -> TraceState
+decodeTraceState = parseTraceState
+
+
+{- | Parse a W3C tracestate header value.
+
+Invalid list-members are skipped per W3C Trace Context §3.3.1:
+\"Invalid tracestate entries MAY also be discarded.\"
+Returns 'empty' when nothing valid remains.
+
+@since 0.1.0.0
+-}
+parseTraceState :: ByteString -> TraceState
+parseTraceState bs =
+  let !trimmed = C8.dropWhile isOWS bs
+  in if BS.null trimmed
+       then empty
+       else fromList (go trimmed [])
   where
-    -- Parse a single key=value entry (list-member)
-    tracestateEntry = do
-      key <- tracestateKey
-      _ <- char '='
-      value <- tracestateValue
-      pure (key, value)
+    go !remaining !acc
+      | BS.null remaining = reverse acc
+      | otherwise =
+          case scanMember remaining of
+            Right (!pair, !rest) ->
+              let !rest' = skipCommaOWS rest
+              in go rest' (pair : acc)
+            Left _err ->
+              let !rest = skipToNextMember remaining
+              in go rest acc
 
-    -- Parse tracestate key according to W3C spec
-    -- key = simple-key / multi-tenant-key
-    -- simple-key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-    -- multi-tenant-key = tenant-id "@" system-id
-    tracestateKey = do
-      keyBytes <- takeWhile1 isTracestateKeyChar
-      let keyText = TE.decodeUtf8 keyBytes
-      -- Validate key format and length (max 256 chars)
-      if T.length keyText <= 256 && isValidTracestateKey keyText
-        then pure keyText
-        else fail "Invalid tracestate key"
+    scanMember :: ByteString -> Either String ((Key, Value), ByteString)
+    scanMember !input = do
+      (!key, !afterKey) <- scanKey input
+      if BS.null afterKey || BS.index afterKey 0 /= 0x3d
+        then Left "expected '=' after key"
+        else do
+          let !valStart = BS.drop 1 afterKey
+          (!val, !afterVal) <- scanValue valStart
+          Right ((Key (TE.decodeUtf8 key), Value (TE.decodeUtf8 val)), afterVal)
 
-    -- Parse tracestate value according to W3C spec
-    -- value = 0*255(chr) nblk-chr
-    -- chr = %x20 / %x21-2B / %x2D-3C / %x3E-7E
-    -- nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
-    tracestateValue = do
-      valueBytes <- takeWhile1 isTracestateValueChar
-      let valueText = T.stripEnd $ TE.decodeUtf8 valueBytes -- Strip trailing whitespace
-      -- Validate value length (max 256 chars)
-      if T.length valueText <= 256 && not (T.null valueText)
-        then pure valueText
-        else fail "Invalid tracestate value"
+    skipToNextMember :: ByteString -> ByteString
+    skipToNextMember !input =
+      case C8.elemIndex ',' input of
+        Nothing -> BS.empty
+        Just idx -> C8.dropWhile isOWS (BS.drop (idx + 1) input)
 
-    -- Valid characters for tracestate keys
-    isTracestateKeyChar c =
-      (c >= 'a' && c <= 'z')
-        || (c >= '0' && c <= '9')
-        || c == '_'
-        || c == '-'
-        || c == '*'
-        || c == '/'
-        || c == '@'
+    scanKey :: ByteString -> Either String (ByteString, ByteString)
+    scanKey !input =
+      let !keyLen = BS.length (C8.takeWhile isTracestateKeyChar input)
+      in if keyLen == 0
+           then Left "empty tracestate key"
+           else
+             let !keyBs = BS.take keyLen input
+             in if keyLen > 256
+                  then Left "tracestate key too long"
+                  else validateKey keyBs >> Right (keyBs, BS.drop keyLen input)
 
-    -- Valid characters for tracestate values (chr)
-    -- %x20 / %x21-2B / %x2D-3C / %x3E-7E (excludes comma and equals)
-    isTracestateValueChar c =
-      c == ' ' || (c >= '!' && c <= '+') || (c >= '-' && c <= '<') || (c >= '>' && c <= '~')
+    validateKey :: ByteString -> Either String ()
+    validateKey !keyBs =
+      case C8.elemIndex '@' keyBs of
+        Nothing ->
+          unless (isLcAlpha (BS.index keyBs 0)) $
+            Left "simple tracestate key must start with a-z"
+        Just atIdx -> do
+          let !tenantPart = BS.take atIdx keyBs
+              !systemPart = BS.drop (atIdx + 1) keyBs
+          when (BS.null tenantPart) $ Left "empty tenant-id in multi-tenant key"
+          when (BS.null systemPart) $ Left "empty system-id in multi-tenant key"
+          unless (isLcAlphaOrDigit (BS.index tenantPart 0)) $ Left "tenant-id must start with a-z or 0-9"
+          unless (isLcAlpha (BS.index systemPart 0)) $ Left "system-id must start with a-z"
+          when (C8.elem '@' systemPart) $ Left "multiple '@' in tracestate key"
+          when (BS.length tenantPart > 241) $ Left "tenant-id too long"
+          when (BS.length systemPart > 14) $ Left "system-id too long"
 
-    -- Validate tracestate key format
-    isValidTracestateKey key =
-      case T.uncons key of
-        Nothing -> False
-        Just (firstChar, rest) ->
-          -- Must start with lowercase letter or digit
-          (firstChar >= 'a' && firstChar <= 'z' || firstChar >= '0' && firstChar <= '9')
-            &&
-            -- Rest must be valid key characters
-            T.all
-              ( \c ->
-                  (c >= 'a' && c <= 'z')
-                    || (c >= '0' && c <= '9')
-                    || c == '_'
-                    || c == '-'
-                    || c == '*'
-                    || c == '/'
-                    || c == '@'
-              )
-              rest
+    isLcAlpha :: Word8 -> Bool
+    isLcAlpha w = w >= 0x61 && w <= 0x7a
+
+    isLcAlphaOrDigit :: Word8 -> Bool
+    isLcAlphaOrDigit w = isLcAlpha w || (w >= 0x30 && w <= 0x39)
+
+    scanValue :: ByteString -> Either String (ByteString, ByteString)
+    scanValue !input =
+      let !valLen = BS.length (C8.takeWhile isTracestateValueChar input)
+      in if valLen == 0
+           then Left "empty tracestate value"
+           else
+             let !raw = BS.take valLen input
+                 !stripped = fst (BS.spanEnd isOWSByte raw)
+             in if BS.null stripped
+                  then Left "tracestate value is only whitespace"
+                  else
+                    if BS.length stripped > 256
+                      then Left "tracestate value too long"
+                      else Right (stripped, BS.drop valLen input)
+
+    skipCommaOWS :: ByteString -> ByteString
+    skipCommaOWS !input =
+      let !s1 = C8.dropWhile isOWS input
+      in if BS.null s1
+           then s1
+           else
+             if BS.index s1 0 == 0x2c -- ','
+               then C8.dropWhile isOWS (BS.drop 1 s1)
+               else s1
+
+
+isOWS :: Char -> Bool
+isOWS c = c == ' ' || c == '\t'
+
+
+isOWSByte :: Word8 -> Bool
+isOWSByte w = w == 0x20 || w == 0x09
+
+
+isTracestateKeyChar :: Char -> Bool
+isTracestateKeyChar c =
+  (c >= 'a' && c <= 'z')
+    || (c >= '0' && c <= '9')
+    || c == '_'
+    || c == '-'
+    || c == '*'
+    || c == '/'
+    || c == '@'
+
+
+isTracestateValueChar :: Char -> Bool
+isTracestateValueChar c =
+  c == ' ' || (c >= '!' && c <= '+') || (c >= '-' && c <= '<') || (c >= '>' && c <= '~')
 
 
 -- | Encode TraceState to W3C tracestate header format
@@ -278,7 +283,7 @@ encodeTraceStateMultiple maxSize ts =
     buildHeader :: Int -> [ByteString] -> [ByteString] -> (ByteString, [ByteString])
     buildHeader _ [] acc = (C8.intercalate "," (reverse acc), [])
     buildHeader limit (entry : rest) acc =
-      let currentSize = if null acc then 0 else sum (map C8.length acc) + length acc - 1 -- account for commas
+      let currentSize = if null acc then 0 else sum (map C8.length acc) + length acc - 1
           newSize = currentSize + C8.length entry + if null acc then 0 else 1
       in if newSize <= limit || null acc -- Always include at least one entry
            then buildHeader limit rest (entry : acc)
@@ -299,11 +304,7 @@ decodeTraceStateMultiple :: [ByteString] -> TraceState
 decodeTraceStateMultiple headers =
   let nonEmptyHeaders = filter (not . C8.all (\c -> c == ' ' || c == '\t')) headers
       combinedHeader = C8.intercalate "," nonEmptyHeaders
-  in if C8.null combinedHeader
-       then empty
-       else case parseOnly tracestateParser combinedHeader of
-         Right ts -> ts
-         Left _ -> empty -- Fallback to empty on parse failure
+  in if C8.null combinedHeader then empty else parseTraceState combinedHeader
 
 
 {- | Encoded the given 'Span' into a @traceparent@, @tracestate@ tuple.
@@ -313,42 +314,42 @@ decodeTraceStateMultiple headers =
 encodeSpanContext :: Span -> IO (ByteString, ByteString)
 encodeSpanContext s = do
   ctxt <- getSpanContext s
-  pure (L.toStrict $ B.toLazyByteString $ traceparentHeader ctxt, encodeTraceState (traceState ctxt))
-  where
-    traceparentHeader SpanContext {..} =
-      -- version
-      B.word8HexFixed 0
-        <> B.char7 '-'
-        <> traceIdBaseEncodedBuilder Base16 traceId
-        <> B.char7 '-'
-        <> spanIdBaseEncodedBuilder Base16 spanId
-        <> B.char7 '-'
-        <> B.word8HexFixed (traceFlagsValue traceFlags)
+  let !tp = encodeTraceparent 0 (traceId ctxt) (spanId ctxt) (traceFlagsValue (traceFlags ctxt))
+  pure (tp, encodeTraceState (traceState ctxt))
 
 
 {- | Propagate trace context information via headers using the w3c specification format
 
  @since 0.0.1.0
 -}
-w3cTraceContextPropagator :: Propagator Ctxt.Context RequestHeaders RequestHeaders
+w3cTraceContextPropagator :: Propagator Ctxt.Context TextMap TextMap
 w3cTraceContextPropagator = Propagator {..}
   where
-    propagatorNames = ["tracecontext"]
+    propagatorFields = ["traceparent", "tracestate"]
 
-    extractor hs c = do
-      let traceParentHeader = Prelude.lookup "traceparent" hs
-          traceStateHeader = Prelude.lookup "tracestate" hs
-          mspanContext = decodeSpanContext traceParentHeader traceStateHeader
+    extractor tm c = do
+      let traceParentHeader = TE.encodeUtf8 <$> textMapLookup "traceparent" tm
+          combinedTraceState = TE.encodeUtf8 <$> textMapLookup "tracestate" tm
+          mspanContext = decodeSpanContext traceParentHeader combinedTraceState
       pure $! case mspanContext of
         Nothing -> c
         Just s -> Ctxt.insertSpan (wrapSpanContext (s {isRemote = True})) c
 
-    injector c hs = case Ctxt.lookupSpan c of
-      Nothing -> pure hs
+    injector c tm = case Ctxt.lookupSpan c of
+      Nothing -> pure tm
       Just s -> do
         (traceParentHeader, traceStateHeader) <- encodeSpanContext s
-        pure
-          ( ("traceparent", traceParentHeader)
-              : ("tracestate", traceStateHeader)
-              : hs
-          )
+        pure $
+          textMapInsert "traceparent" (TE.decodeUtf8 traceParentHeader) $
+            textMapInsert "tracestate" (TE.decodeUtf8 traceStateHeader) $
+              tm
+
+
+{- | Register the W3C Trace Context propagator under the name
+@\"tracecontext\"@ in the global registry.
+
+@since 0.1.0.0
+-}
+registerW3CTraceContextPropagator :: IO ()
+registerW3CTraceContextPropagator =
+  registerTextMapPropagator "tracecontext" w3cTraceContextPropagator

--- a/propagators/w3c/test/OpenTelemetry/Propagator/W3CBaggageSpec.hs
+++ b/propagators/w3c/test/OpenTelemetry/Propagator/W3CBaggageSpec.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenTelemetry.Propagator.W3CBaggageSpec (spec) where
+
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.HashMap.Strict as HM
+import Data.Maybe (isJust, isNothing)
+import qualified Data.Text as T
+import OpenTelemetry.Baggage (Element (..), element, empty, insert, mkToken, values)
+import OpenTelemetry.Context (insertBaggage, lookupBaggage)
+import qualified OpenTelemetry.Context as Ctxt
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  emptyTextMap,
+  extract,
+  inject,
+  textMapFromList,
+  textMapLookup,
+ )
+import OpenTelemetry.Propagator.W3CBaggage (
+  decodeBaggage,
+  encodeBaggage,
+  w3cBaggagePropagator,
+ )
+import Test.Hspec
+
+
+spec :: Spec
+spec =
+  -- W3C Baggage: header format and propagation
+  -- https://www.w3.org/TR/baggage/
+  describe "W3C Baggage propagator" $ do
+    -- §2.2 baggage-string: list of baggage-members
+    -- https://www.w3.org/TR/baggage/#baggage-string
+    it "decodeBaggage decodes valid header" $ do
+      let Just k = mkToken "userid"
+      case decodeBaggage "userid=alice" of
+        Nothing -> expectationFailure "expected decode"
+        Just b -> HM.lookup k (values b) `shouldBe` Just (element "alice")
+
+    it "decodeBaggage returns Nothing for invalid input" $ do
+      decodeBaggage "" `shouldSatisfy` isNothing
+      decodeBaggage "%%%not-baggage%%%" `shouldSatisfy` isNothing
+
+    -- §2.3.2 serialize baggage-header
+    -- https://www.w3.org/TR/baggage/#header-content
+    it "encodeBaggage produces valid header" $ do
+      let Just k = mkToken "session"
+          b = insert k (element "abc-123") empty
+          hdr = encodeBaggage b
+      C8.unpack hdr `shouldContain` "session="
+      C8.unpack hdr `shouldContain` "abc-123"
+
+    it "encodeBaggage roundtrips with decodeBaggage" $ do
+      let Just k1 = mkToken "k1"
+          Just k2 = mkToken "k2"
+          b0 =
+            insert k2 (element "y") $
+              insert k1 (element "x") $
+                empty
+          b1 = decodeBaggage (encodeBaggage b0)
+      b1 `shouldBe` Just b0
+
+    -- OpenTelemetry TextMapPropagator fields (baggage header name)
+    -- https://www.w3.org/TR/baggage/#header-name
+    it "w3cBaggagePropagator propagatorFields is [\"baggage\"]" $
+      propagatorFields w3cBaggagePropagator `shouldBe` ["baggage"]
+
+    it "w3cBaggagePropagator extractor extracts baggage from headers" $ do
+      let hs = textMapFromList [("baggage", "userid=nobody")]
+      c <- extract w3cBaggagePropagator hs Ctxt.empty
+      case lookupBaggage c of
+        Nothing -> expectationFailure "expected baggage"
+        Just b -> do
+          let Just uid = mkToken "userid"
+          HM.lookup uid (values b) `shouldBe` Just (element "nobody")
+
+    it "w3cBaggagePropagator extractor ignores missing header" $ do
+      c <- extract w3cBaggagePropagator emptyTextMap Ctxt.empty
+      lookupBaggage c `shouldBe` Nothing
+
+    it "w3cBaggagePropagator injector adds baggage header" $ do
+      let Just k = mkToken "key"
+          b = insert k (element "v") empty
+          c = insertBaggage b Ctxt.empty
+      hs <- inject w3cBaggagePropagator c emptyTextMap
+      textMapLookup "baggage" hs `shouldNotBe` Nothing
+
+    it "w3cBaggagePropagator injector no-ops without baggage" $ do
+      hs <- inject w3cBaggagePropagator Ctxt.empty emptyTextMap
+      textMapLookup "baggage" hs `shouldBe` Nothing
+
+    -- §2.3.1 percent-encoding in baggage values
+    -- https://www.w3.org/TR/baggage/#value
+    it "decodeBaggage handles percent-encoded values" $ do
+      let Just k = mkToken "key"
+      case decodeBaggage "key=value%20with%20spaces" of
+        Nothing -> expectationFailure "expected decode of percent-encoded value"
+        Just b -> do
+          case HM.lookup k (values b) of
+            Nothing -> expectationFailure "expected key in baggage"
+            Just el ->
+              value el `shouldSatisfy` (not . T.null)
+
+    -- §2.2 baggage-string: multiple baggage-members separated by commas
+    -- https://www.w3.org/TR/baggage/#baggage-string
+    it "decodeBaggage handles multiple entries" $ do
+      let Just k1 = mkToken "k1"
+          Just k2 = mkToken "k2"
+      case decodeBaggage "k1=v1,k2=v2" of
+        Nothing -> expectationFailure "expected decode of multi-entry"
+        Just b -> do
+          HM.lookup k1 (values b) `shouldSatisfy` isJust
+          HM.lookup k2 (values b) `shouldSatisfy` isJust
+
+    -- §2.2.2 metadata (property) after value
+    -- https://www.w3.org/TR/baggage/#property
+    it "decodeBaggage handles entry with metadata properties" $ do
+      let Just k = mkToken "key"
+      case decodeBaggage "key=value;property1=p1" of
+        Nothing -> expectationFailure "expected decode with properties"
+        Just b -> HM.lookup k (values b) `shouldSatisfy` isJust
+
+    -- §2.3.2 value encoding in header
+    -- https://www.w3.org/TR/baggage/#value
+    it "encodeBaggage handles special characters in values" $ do
+      let Just k = mkToken "key"
+          b = insert k (element "val=ue") empty
+          hdr = encodeBaggage b
+      C8.unpack hdr `shouldContain` "key="

--- a/propagators/w3c/test/OpenTelemetry/Propagator/W3CIntegrationSpec.hs
+++ b/propagators/w3c/test/OpenTelemetry/Propagator/W3CIntegrationSpec.hs
@@ -8,7 +8,13 @@ import qualified Data.ByteString.Char8 as C8
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import OpenTelemetry.Common (TraceFlags (..))
-import OpenTelemetry.Propagator.W3CTraceContext
+import qualified OpenTelemetry.Context as Ctxt
+import OpenTelemetry.Propagator (Propagator (..), emptyTextMap, textMapFromList, textMapLookup)
+import OpenTelemetry.Propagator.W3CTraceContext (
+  decodeSpanContext,
+  encodeTraceState,
+  w3cTraceContextPropagator,
+ )
 import OpenTelemetry.Trace.Core
 import OpenTelemetry.Trace.Id
 import OpenTelemetry.Trace.TraceState (Key (..), Value (..), empty, fromList, insert, toList)
@@ -16,164 +22,375 @@ import Test.Hspec
 
 
 spec :: Spec
-spec = describe "W3C TraceContext Integration" $ do
-  describe "decodeSpanContext" $ do
-    it "decodes traceparent and empty tracestate" $ do
-      let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          tracestate = Nothing
-          result = decodeSpanContext traceparent tracestate
-      case result of
-        Just spanCtx -> do
-          OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
-          traceState spanCtx `shouldBe` empty
-        Nothing -> expectationFailure "Failed to decode span context"
+spec =
+  -- W3C Trace Context: traceparent + tracestate integration
+  -- https://www.w3.org/TR/trace-context/
+  describe "W3C TraceContext Integration" $ do
+    -- §2.2.2 traceparent + §3.3 tracestate
+    -- https://www.w3.org/TR/trace-context/#traceparent-header
+    describe "decodeSpanContext" $ do
+      -- traceparent: version-trace_id-parent_id-trace_flags; tracestate optional
+      -- https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+      it "decodes traceparent and empty tracestate" $ do
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            tracestate = Nothing
+            result = decodeSpanContext traceparent tracestate
+        case result of
+          Just spanCtx -> do
+            OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
+            traceState spanCtx `shouldBe` empty
+          Nothing -> expectationFailure "Failed to decode span context"
 
-    it "decodes traceparent and tracestate with single entry" $ do
-      let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          tracestate = Just "vendor1=value1"
-          result = decodeSpanContext traceparent tracestate
-      case result of
-        Just spanCtx -> do
-          OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
-          traceState spanCtx `shouldBe` insert (Key "vendor1") (Value "value1") empty
-        Nothing -> expectationFailure "Failed to decode span context"
+      -- §3.3 tracestate with valid list-members
+      -- https://www.w3.org/TR/trace-context/#tracestate-header
+      it "decodes traceparent and tracestate with single entry" $ do
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            tracestate = Just "vendor1=value1"
+            result = decodeSpanContext traceparent tracestate
+        case result of
+          Just spanCtx -> do
+            OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
+            traceState spanCtx `shouldBe` insert (Key "vendor1") (Value "value1") empty
+          Nothing -> expectationFailure "Failed to decode span context"
 
-    it "decodes traceparent and tracestate with multiple entries" $ do
-      let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          tracestate = Just "vendor1=value1,vendor2=value2,vendor3=value3"
-          result = decodeSpanContext traceparent tracestate
-      case result of
-        Just spanCtx -> do
-          OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
-          let decodedPairs = toList (traceState spanCtx)
-          decodedPairs `shouldContain` [(Key "vendor1", Value "value1")]
-          decodedPairs `shouldContain` [(Key "vendor2", Value "value2")]
-          decodedPairs `shouldContain` [(Key "vendor3", Value "value3")]
-          length decodedPairs `shouldBe` 3
-        Nothing -> expectationFailure "Failed to decode span context"
+      -- §3.3.1 comma-separated list-members
+      -- https://www.w3.org/TR/trace-context/#tracestate-list
+      it "decodes traceparent and tracestate with multiple entries" $ do
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            tracestate = Just "vendor1=value1,vendor2=value2,vendor3=value3"
+            result = decodeSpanContext traceparent tracestate
+        case result of
+          Just spanCtx -> do
+            OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
+            let decodedPairs = toList (traceState spanCtx)
+            decodedPairs `shouldContain` [(Key "vendor1", Value "value1")]
+            decodedPairs `shouldContain` [(Key "vendor2", Value "value2")]
+            decodedPairs `shouldContain` [(Key "vendor3", Value "value3")]
+            length decodedPairs `shouldBe` 3
+          Nothing -> expectationFailure "Failed to decode span context"
 
-    it "handles invalid tracestate gracefully" $ do
-      let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          tracestate = Just "INVALID$KEY=value1" -- Invalid key format
-          result = decodeSpanContext traceparent tracestate
-      case result of
-        Just spanCtx -> do
-          OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
-          traceState spanCtx `shouldBe` empty -- Should fall back to empty
-        Nothing -> expectationFailure "Failed to decode span context"
+      -- §3.3.1 invalid list-members ignored; traceparent still valid
+      -- https://www.w3.org/TR/trace-context/#tracestate-list
+      it "handles invalid tracestate gracefully" $ do
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            tracestate = Just "INVALID$KEY=value1" -- Invalid key format
+            result = decodeSpanContext traceparent tracestate
+        case result of
+          Just spanCtx -> do
+            OpenTelemetry.Trace.Core.traceFlags spanCtx `shouldBe` TraceFlags 1
+            traceState spanCtx `shouldBe` empty -- Should fall back to empty
+          Nothing -> expectationFailure "Failed to decode span context"
 
-    it "returns Nothing for invalid traceparent" $ do
-      let traceparent = Just "invalid-traceparent"
-          tracestate = Just "vendor1=value1"
-          result = decodeSpanContext traceparent tracestate
-      result `shouldBe` Nothing
+      -- §2.2.2 invalid traceparent → no trace context
+      -- https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+      it "returns Nothing for invalid traceparent" $ do
+        let traceparent = Just "invalid-traceparent"
+            tracestate = Just "vendor1=value1"
+            result = decodeSpanContext traceparent tracestate
+        result `shouldBe` Nothing
 
-    it "returns Nothing for missing traceparent" $ do
-      let traceparent = Nothing
-          tracestate = Just "vendor1=value1"
-          result = decodeSpanContext traceparent tracestate
-      result `shouldBe` Nothing
+      -- §2.2.2 traceparent required when propagating trace context
+      -- https://www.w3.org/TR/trace-context/#traceparent-header
+      it "returns Nothing for missing traceparent" $ do
+        let traceparent = Nothing
+            tracestate = Just "vendor1=value1"
+            result = decodeSpanContext traceparent tracestate
+        result `shouldBe` Nothing
 
-  describe "encodeTraceState integration" $ do
-    it "encodes complex tracestate correctly" $ do
-      let complexState =
-            fromList
-              [ (Key "tenant@vendor", Value "complex-value_with*chars")
-              , (Key "simple", Value "value")
-              , (Key "numeric123", Value "123-456")
+      -- §2.2.2 trace-id all zeros invalid
+      -- https://www.w3.org/TR/trace-context/#trace-id
+      it "rejects all-zero trace-id" $ do
+        let traceparent = Just "00-00000000000000000000000000000000-b7ad6b7169203331-01"
+            result = decodeSpanContext traceparent Nothing
+        result `shouldBe` Nothing
+
+      -- §2.2.2 parent-id all zeros invalid
+      -- https://www.w3.org/TR/trace-context/#parent-id
+      it "rejects all-zero parent-id" $ do
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01"
+            result = decodeSpanContext traceparent Nothing
+        result `shouldBe` Nothing
+
+      -- §2.2.2 combined invalid trace-id and parent-id
+      -- https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+      it "rejects all-zero trace-id and parent-id" $ do
+        let traceparent = Just "00-00000000000000000000000000000000-0000000000000000-01"
+            result = decodeSpanContext traceparent Nothing
+        result `shouldBe` Nothing
+
+    -- §3.3 tracestate round-trip with traceparent
+    -- https://www.w3.org/TR/trace-context/#tracestate-header
+    describe "encodeTraceState integration" $ do
+      it "encodes complex tracestate correctly" $ do
+        let complexState =
+              fromList
+                [ (Key "tenant@vendor", Value "complex-value_with*chars")
+                , (Key "simple", Value "value")
+                , (Key "numeric123", Value "123-456")
+                ]
+            encoded = encodeTraceState complexState
+        -- Verify it can be round-tripped
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            result = decodeSpanContext traceparent (Just encoded)
+        case result of
+          Just spanCtx -> do
+            let decodedState = traceState spanCtx
+            decodedState `shouldBe` complexState
+          Nothing -> expectationFailure "Failed to round-trip complex tracestate"
+
+      -- §3.3 empty tracestate / absent header equivalence
+      -- https://www.w3.org/TR/trace-context/#tracestate-header
+      it "handles empty tracestate in round-trip" $ do
+        let encoded = encodeTraceState empty
+        encoded `shouldBe` ""
+        let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            result = decodeSpanContext traceparent (if encoded == "" then Nothing else Just encoded)
+        case result of
+          Just spanCtx -> traceState spanCtx `shouldBe` empty
+          Nothing -> expectationFailure "Failed to handle empty tracestate"
+
+    -- §3.3 tracestate limits and key/value rules
+    -- https://www.w3.org/TR/trace-context/#tracestate-limits
+    describe "W3C specification compliance" $ do
+      -- §3.3.3 at most 32 list-members
+      -- https://www.w3.org/TR/trace-context/#tracestate-limits
+      it "respects 32 entry limit in parsing" $ do
+        let entries = ["key" ++ show i ++ "=value" ++ show i | i <- [1 .. 40]]
+            longTracestate = C8.intercalate "," $ map C8.pack entries
+            traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            result = decodeSpanContext traceparent (Just longTracestate)
+        case result of
+          Just spanCtx -> do
+            let stateEntries = traceState spanCtx
+            length (toList stateEntries) `shouldBe` 32
+          Nothing -> expectationFailure "Failed to parse long tracestate"
+
+      -- §3.3.2.1 key ABNF (simple-key / multi-tenant-key)
+      -- https://www.w3.org/TR/trace-context/#key
+      it "validates key format according to spec" $ do
+        let testCases =
+              [ ("validkey", True)
+              , ("valid123", True)
+              , ("valid_key", True)
+              , ("valid-key", True)
+              , ("valid*key", True)
+              , ("valid/key", True)
+              , ("tenant@vendor", True)
+              , ("123numeric", False) -- simple-key must start with lcalpha (§3.3.2.1)
+              , ("INVALIDKEY", False) -- Must start with lowercase
+              , ("invalid$key", False) -- Invalid character
+              , ("", False) -- Empty key
               ]
-          encoded = encodeTraceState complexState
-      -- Verify it can be round-tripped
-      let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          result = decodeSpanContext traceparent (Just encoded)
-      case result of
-        Just spanCtx -> do
-          let decodedState = traceState spanCtx
-          decodedState `shouldBe` complexState
-        Nothing -> expectationFailure "Failed to round-trip complex tracestate"
+        mapM_
+          ( \(key, shouldSucceed) -> do
+              let tracestate = C8.pack $ T.unpack key ++ "=value"
+                  traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+                  result = decodeSpanContext traceparent (Just tracestate)
+              if shouldSucceed
+                then
+                  result
+                    `shouldSatisfy` ( \case
+                                        Just spanCtx -> not $ null $ toList $ traceState spanCtx
+                                        Nothing -> False
+                                    )
+                else
+                  result
+                    `shouldSatisfy` ( \case
+                                        Just spanCtx -> null $ toList $ traceState spanCtx
+                                        Nothing -> True
+                                    )
+          )
+          testCases
 
-    it "handles empty tracestate in round-trip" $ do
-      let encoded = encodeTraceState empty
-      encoded `shouldBe` ""
-      let traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          result = decodeSpanContext traceparent (if encoded == "" then Nothing else Just encoded)
-      case result of
-        Just spanCtx -> traceState spanCtx `shouldBe` empty
-        Nothing -> expectationFailure "Failed to handle empty tracestate"
+      -- §3.3.2.2 value ABNF
+      -- https://www.w3.org/TR/trace-context/#value
+      it "validates value format according to spec" $ do
+        let testCases =
+              [ ("validvalue", True)
+              , ("valid value with spaces", True)
+              , ("valid-value_with*special/chars", True)
+              , ("valid!value#with$symbols%", True)
+              , ("value,with,comma", False) -- Comma ends value; member still parsed leniently (§3.3.1)
+              , ("value=with=equals", False) -- '=' ends value; same lenient behavior
+              ]
+        mapM_
+          ( \(value, shouldSucceed) -> do
+              let tracestate = C8.pack $ "validkey=" ++ T.unpack value
+                  traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+                  result = decodeSpanContext traceparent (Just tracestate)
+              if shouldSucceed
+                then
+                  result
+                    `shouldSatisfy` ( \case
+                                        Just spanCtx -> not $ null $ toList $ traceState spanCtx
+                                        Nothing -> False
+                                    )
+                else
+                  result
+                    `shouldSatisfy` ( \case
+                                        Just spanCtx ->
+                                          toList (traceState spanCtx)
+                                            == [(Key "validkey", Value "value")]
+                                        Nothing -> False
+                                    )
+          )
+          testCases
 
-  describe "W3C specification compliance" $ do
-    it "respects 32 entry limit in parsing" $ do
-      let entries = ["key" ++ show i ++ "=value" ++ show i | i <- [1 .. 40]]
-          longTracestate = C8.intercalate "," $ map C8.pack entries
-          traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-          result = decodeSpanContext traceparent (Just longTracestate)
-      case result of
-        Just spanCtx -> do
-          let stateEntries = traceState spanCtx
-          length (toList stateEntries) `shouldBe` 32
-        Nothing -> expectationFailure "Failed to parse long tracestate"
+    -- OpenTelemetry propagator API + W3C header names (traceparent, tracestate)
+    -- https://www.w3.org/TR/trace-context/#traceparent-header
+    describe "w3cTraceContextPropagator injector" $ do
+      -- §2.2.2 + §3.3 inject traceparent and tracestate
+      -- https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+      it "injects traceparent and tracestate headers" $ do
+        case baseEncodedToTraceId Base16 "0af7651916cd43dd8448eb211c80319c" of
+          Left err -> expectationFailure err
+          Right tid ->
+            case baseEncodedToSpanId Base16 "b7ad6b7169203331" of
+              Left err -> expectationFailure err
+              Right sid -> do
+                let ts = insert (Key "vendor1") (Value "value1") empty
+                    spanCtx =
+                      SpanContext
+                        { traceFlags = TraceFlags 1
+                        , isRemote = False
+                        , traceId = tid
+                        , spanId = sid
+                        , traceState = ts
+                        }
+                    ctxt = Ctxt.insertSpan (wrapSpanContext spanCtx) Ctxt.empty
+                hdrs <- injector w3cTraceContextPropagator ctxt emptyTextMap
+                textMapLookup "traceparent" hdrs
+                  `shouldBe` Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+                textMapLookup "tracestate" hdrs `shouldBe` Just "vendor1=value1"
 
-    it "validates key format according to spec" $ do
-      let testCases =
-            [ ("validkey", True)
-            , ("valid123", True)
-            , ("valid_key", True)
-            , ("valid-key", True)
-            , ("valid*key", True)
-            , ("valid/key", True)
-            , ("tenant@vendor", True)
-            , ("123numeric", True)
-            , ("INVALIDKEY", False) -- Must start with lowercase
-            , ("invalid$key", False) -- Invalid character
-            , ("", False) -- Empty key
-            ]
-      mapM_
-        ( \(key, shouldSucceed) -> do
-            let tracestate = C8.pack $ T.unpack key ++ "=value"
-                traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-                result = decodeSpanContext traceparent (Just tracestate)
-            if shouldSucceed
-              then
-                result
-                  `shouldSatisfy` ( \case
-                                      Just spanCtx -> not $ null $ toList $ traceState spanCtx
-                                      Nothing -> False
-                                  )
-              else
-                result
-                  `shouldSatisfy` ( \case
-                                      Just spanCtx -> null $ toList $ traceState spanCtx
-                                      Nothing -> True
-                                  )
-        )
-        testCases
+      -- §3.3 tracestate header present but empty when no vendor state
+      -- https://www.w3.org/TR/trace-context/#tracestate-header
+      it "injects empty tracestate for span with no tracestate" $ do
+        case baseEncodedToTraceId Base16 "0af7651916cd43dd8448eb211c80319c" of
+          Left err -> expectationFailure err
+          Right tid ->
+            case baseEncodedToSpanId Base16 "b7ad6b7169203331" of
+              Left err -> expectationFailure err
+              Right sid -> do
+                let spanCtx =
+                      SpanContext
+                        { traceFlags = TraceFlags 1
+                        , isRemote = False
+                        , traceId = tid
+                        , spanId = sid
+                        , traceState = empty
+                        }
+                    ctxt = Ctxt.insertSpan (wrapSpanContext spanCtx) Ctxt.empty
+                hdrs <- injector w3cTraceContextPropagator ctxt emptyTextMap
+                textMapLookup "tracestate" hdrs `shouldBe` Just ""
 
-    it "validates value format according to spec" $ do
-      let testCases =
-            [ ("validvalue", True)
-            , ("valid value with spaces", True)
-            , ("valid-value_with*special/chars", True)
-            , ("valid!value#with$symbols%", True)
-            , ("value,with,comma", False) -- Comma not allowed
-            , ("value=with=equals", False) -- Equals not allowed in continuation
-            ]
-      mapM_
-        ( \(value, shouldSucceed) -> do
-            let tracestate = C8.pack $ "validkey=" ++ T.unpack value
-                traceparent = Just "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-                result = decodeSpanContext traceparent (Just tracestate)
-            if shouldSucceed
-              then
-                result
-                  `shouldSatisfy` ( \case
-                                      Just spanCtx -> not $ null $ toList $ traceState spanCtx
-                                      Nothing -> False
-                                  )
-              else
-                result
-                  `shouldSatisfy` ( \case
-                                      Just spanCtx -> null $ toList $ traceState spanCtx
-                                      Nothing -> True
-                                  )
-        )
-        testCases
+      it "does not inject when context has no span" $ do
+        hdrs <- injector w3cTraceContextPropagator Ctxt.empty emptyTextMap
+        hdrs `shouldBe` emptyTextMap
+
+    -- §2.2.2 extract traceparent; §3.3 extract tracestate
+    -- https://www.w3.org/TR/trace-context/#traceparent-header
+    describe "w3cTraceContextPropagator extractor" $ do
+      it "extracts span from traceparent header" $ do
+        case baseEncodedToTraceId Base16 "0af7651916cd43dd8448eb211c80319c" of
+          Left err -> expectationFailure err
+          Right tid ->
+            case baseEncodedToSpanId Base16 "b7ad6b7169203331" of
+              Left err -> expectationFailure err
+              Right sid -> do
+                let hs =
+                      textMapFromList
+                        [ ("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                        ]
+                ctxt <- extractor w3cTraceContextPropagator hs Ctxt.empty
+                case Ctxt.lookupSpan ctxt of
+                  Nothing -> expectationFailure "expected span in context"
+                  Just sp -> do
+                    sc <- getSpanContext sp
+                    traceFlags sc `shouldBe` TraceFlags 1
+                    traceId sc `shouldBe` tid
+                    spanId sc `shouldBe` sid
+                    traceState sc `shouldBe` empty
+
+      -- §3.3 multiple tracestate header fields (RFC 7230 comma vs multiple headers)
+      -- https://www.w3.org/TR/trace-context/#tracestate-header
+      it "combines multiple tracestate headers" $ do
+        let hs =
+              textMapFromList
+                [ ("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                , ("tracestate", "vendor1=value1,vendor2=value2")
+                ]
+        ctxt <- extractor w3cTraceContextPropagator hs Ctxt.empty
+        case Ctxt.lookupSpan ctxt of
+          Nothing -> expectationFailure "expected span in context"
+          Just sp -> do
+            sc <- getSpanContext sp
+            let pairs = toList (traceState sc)
+            pairs `shouldContain` [(Key "vendor1", Value "value1")]
+            pairs `shouldContain` [(Key "vendor2", Value "value2")]
+
+      -- §2.2.2 no valid traceparent → no context update
+      -- https://www.w3.org/TR/trace-context/#traceparent-header
+      it "leaves context unchanged when traceparent missing" $ do
+        ctxt <- extractor w3cTraceContextPropagator emptyTextMap Ctxt.empty
+        case Ctxt.lookupSpan ctxt of
+          Nothing -> pure ()
+          Just _ -> expectationFailure "expected no span in context"
+
+      -- TextMap normalizes keys to lowercase on construction, so traceparent lookup is
+      -- case-insensitive (HTTP header semantics). Duplicate keys collapse to one entry:
+      -- Data.HashMap.Strict.fromList keeps the last association for a key.
+
+      -- HTTP field-name case-insensitivity (RFC 9110); traceparent field name
+      -- https://www.w3.org/TR/trace-context/#traceparent-header
+      it "extracts span when duplicate traceparent keys appear (last value wins)" $ do
+        let tp1 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            tp2 = "00-0af7651916cd43dd8448eb211c80319c-1111111111111111-01"
+        case baseEncodedToSpanId Base16 "1111111111111111" of
+          Left err -> expectationFailure err
+          Right expectedSid -> do
+            let hs =
+                  textMapFromList
+                    [ ("traceparent", tp1)
+                    , ("traceparent", tp2)
+                    ]
+            ctxt <- extractor w3cTraceContextPropagator hs Ctxt.empty
+            case Ctxt.lookupSpan ctxt of
+              Nothing -> expectationFailure "expected span in context"
+              Just sp -> do
+                sc <- getSpanContext sp
+                spanId sc `shouldBe` expectedSid
+
+      it "extracts span when traceparent header name uses non-lowercase spelling" $ do
+        let tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        case baseEncodedToTraceId Base16 "0af7651916cd43dd8448eb211c80319c" of
+          Left err -> expectationFailure err
+          Right tid ->
+            case baseEncodedToSpanId Base16 "b7ad6b7169203331" of
+              Left err2 -> expectationFailure err2
+              Right sid -> do
+                let hs = textMapFromList [("TraceParent", tp)]
+                ctxt <- extractor w3cTraceContextPropagator hs Ctxt.empty
+                case Ctxt.lookupSpan ctxt of
+                  Nothing -> expectationFailure "expected span in context"
+                  Just sp -> do
+                    sc <- getSpanContext sp
+                    traceId sc `shouldBe` tid
+                    spanId sc `shouldBe` sid
+
+      it "extracts span when traceparent header name is uppercase" $ do
+        let tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        case baseEncodedToTraceId Base16 "0af7651916cd43dd8448eb211c80319c" of
+          Left err -> expectationFailure err
+          Right tid ->
+            case baseEncodedToSpanId Base16 "b7ad6b7169203331" of
+              Left err2 -> expectationFailure err2
+              Right sid -> do
+                let hs = textMapFromList [("TRACEPARENT", tp)]
+                ctxt <- extractor w3cTraceContextPropagator hs Ctxt.empty
+                case Ctxt.lookupSpan ctxt of
+                  Nothing -> expectationFailure "expected span in context"
+                  Just sp -> do
+                    sc <- getSpanContext sp
+                    traceId sc `shouldBe` tid
+                    spanId sc `shouldBe` sid

--- a/propagators/w3c/test/OpenTelemetry/Propagator/W3CMultiHeaderSpec.hs
+++ b/propagators/w3c/test/OpenTelemetry/Propagator/W3CMultiHeaderSpec.hs
@@ -6,168 +6,192 @@ import qualified Data.ByteString.Char8 as C8
 import Data.List (intercalate)
 import qualified Data.Text as T
 import OpenTelemetry.Propagator.W3CTraceContext
-import OpenTelemetry.Trace.TraceState (Key (..), Value (..), empty, fromList, toList)
+import OpenTelemetry.Trace.TraceState (Key (..), Value (..), empty, fromList, insert, toList)
 import Test.Hspec
 
 
 spec :: Spec
-spec = describe "W3C TraceContext Multi-Header Support" $ do
-  describe "encodeTraceStateMultiple" $ do
-    it "returns single header for small tracestate" $ do
-      let ts = fromList [(Key "vendor1", Value "value1"), (Key "vendor2", Value "value2")]
-          result = encodeTraceStateMultiple 512 ts
-      result `shouldBe` ["vendor1=value1,vendor2=value2"]
+spec =
+  -- W3C Trace Context §3.3 tracestate (splitting across headers / size limits)
+  -- https://www.w3.org/TR/trace-context/#tracestate-limits
+  describe "W3C TraceContext Multi-Header Support" $ do
+    describe "encodeTraceStateMultiple" $ do
+      -- §3.3 combined header value within limits (single field value)
+      -- https://www.w3.org/TR/trace-context/#combined-header-value
+      it "returns single header for small tracestate" $ do
+        let ts = fromList [(Key "vendor1", Value "value1"), (Key "vendor2", Value "value2")]
+            result = encodeTraceStateMultiple 512 ts
+        result `shouldBe` ["vendor1=value1,vendor2=value2"]
 
-    it "splits into multiple headers when size limit exceeded" $ do
-      let mediumValue = T.replicate 50 "x" -- Use smaller values that won't be filtered
-          ts =
-            fromList
-              [ (Key "vendor1", Value mediumValue)
-              , (Key "vendor2", Value mediumValue)
-              , (Key "vendor3", Value mediumValue)
-              , (Key "vendor4", Value mediumValue)
+      -- §3.3.3 tracestate size limits (implementation splits to satisfy limits)
+      -- https://www.w3.org/TR/trace-context/#tracestate-limits
+      it "splits into multiple headers when size limit exceeded" $ do
+        let mediumValue = T.replicate 50 "x" -- Use smaller values that won't be filtered
+            ts =
+              fromList
+                [ (Key "vendor1", Value mediumValue)
+                , (Key "vendor2", Value mediumValue)
+                , (Key "vendor3", Value mediumValue)
+                , (Key "vendor4", Value mediumValue)
+                ]
+            result = encodeTraceStateMultiple 150 ts -- Small limit to force splitting
+        length result `shouldSatisfy` (> 1)
+        -- Each header should be under the size limit
+        all (\h -> C8.length h <= 150) result `shouldBe` True
+
+      -- §3.3.2.2 value length; oversized members omitted
+      -- https://www.w3.org/TR/trace-context/#value
+      it "removes entries larger than 128 characters" $ do
+        let longValue = T.replicate 200 "x" -- This entry will be > 128 chars total
+            shortValue = "short"
+            ts =
+              fromList
+                [ (Key "long", Value longValue)
+                , (Key "vendor1", Value shortValue)
+                , (Key "vendor2", Value shortValue)
+                ]
+            result = encodeTraceStateMultiple 512 ts
+            combinedResult = C8.intercalate "," result
+        -- The long entry should be filtered out
+        combinedResult `shouldNotSatisfy` C8.isInfixOf "long="
+        combinedResult `shouldSatisfy` C8.isInfixOf "vendor1=short"
+        combinedResult `shouldSatisfy` C8.isInfixOf "vendor2=short"
+
+      -- §3.3.3 at most 32 list-members
+      -- https://www.w3.org/TR/trace-context/#tracestate-limits
+      it "respects 32 entry limit before splitting" $ do
+        let pairs = [(Key (T.pack $ "key" ++ show i), Value (T.pack $ "val" ++ show i)) | i <- [1 .. 40]]
+            ts = fromList pairs
+            result = encodeTraceStateMultiple 512 ts
+            combinedResult = C8.intercalate "," result
+            entryCount = length $ filter (== '=') $ C8.unpack combinedResult
+        entryCount `shouldBe` 32
+
+      it "returns empty list for empty tracestate" $ do
+        let result = encodeTraceStateMultiple 512 empty
+        result `shouldBe` []
+
+      it "handles single very large header correctly" $ do
+        let pairs = [(Key (T.pack $ "k" ++ show i), Value (T.pack $ "v" ++ show i)) | i <- [1 .. 20]]
+            ts = fromList pairs
+            result = encodeTraceStateMultiple 50 ts -- Very small limit
+        length result `shouldSatisfy` (> 1)
+        -- Should not exceed the limit
+        all (\h -> C8.length h <= 50) result `shouldBe` True
+
+    -- §3.3.1 parsing list-members from multiple combined field values
+    -- https://www.w3.org/TR/trace-context/#tracestate-list
+    describe "decodeTraceStateMultiple" $ do
+      it "combines single header correctly" $ do
+        let headers = ["vendor1=value1,vendor2=value2"]
+            result = decodeTraceStateMultiple headers
+            pairs = toList result
+        pairs `shouldContain` [(Key "vendor1", Value "value1")]
+        pairs `shouldContain` [(Key "vendor2", Value "value2")]
+
+      -- Order of tracestate headers preserved when merging (RFC 7230 field order)
+      -- https://www.w3.org/TR/trace-context/#tracestate-header
+      it "combines multiple headers in order" $ do
+        let headers = ["vendor1=value1,vendor2=value2", "vendor3=value3,vendor4=value4"]
+            result = decodeTraceStateMultiple headers
+            pairs = toList result
+        length pairs `shouldBe` 4
+        pairs `shouldContain` [(Key "vendor1", Value "value1")]
+        pairs `shouldContain` [(Key "vendor2", Value "value2")]
+        pairs `shouldContain` [(Key "vendor3", Value "value3")]
+        pairs `shouldContain` [(Key "vendor4", Value "value4")]
+
+      it "handles empty headers gracefully" $ do
+        let headers = ["vendor1=value1", "", "vendor2=value2"]
+            result = decodeTraceStateMultiple headers
+            pairs = toList result
+        pairs `shouldContain` [(Key "vendor1", Value "value1")]
+        pairs `shouldContain` [(Key "vendor2", Value "value2")]
+
+      -- §3.3.1 invalid list-members skipped
+      -- https://www.w3.org/TR/trace-context/#tracestate-list
+      it "skips invalid members when combining headers (§3.3.1)" $ do
+        let headers = ["invalid$key=value", "another=bad,value"]
+            result = decodeTraceStateMultiple headers
+        result `shouldBe` insert (Key "another") (Value "bad") empty
+
+      it "returns empty tracestate for empty header list" $ do
+        let result = decodeTraceStateMultiple []
+        result `shouldBe` empty
+
+      it "handles whitespace-only headers" $ do
+        let headers = ["vendor1=value1", "   ", "vendor2=value2"]
+            result = decodeTraceStateMultiple headers
+            pairs = toList result
+        pairs `shouldContain` [(Key "vendor1", Value "value1")]
+        pairs `shouldContain` [(Key "vendor2", Value "value2")]
+
+    describe "round-trip multi-header property" $ do
+      it "round-trips through multiple headers" $ do
+        let originalPairs =
+              [ (Key "vendor1", Value "value1")
+              , (Key "vendor2", Value "value2")
+              , (Key "vendor3", Value "value3")
               ]
-          result = encodeTraceStateMultiple 150 ts -- Small limit to force splitting
-      length result `shouldSatisfy` (> 1)
-      -- Each header should be under the size limit
-      all (\h -> C8.length h <= 150) result `shouldBe` True
+            ts = fromList originalPairs
+            encoded = encodeTraceStateMultiple 512 ts
+            decoded = decodeTraceStateMultiple encoded
+            decodedPairs = toList decoded
+        decodedPairs `shouldBe` originalPairs
 
-    it "removes entries larger than 128 characters" $ do
-      let longValue = T.replicate 200 "x" -- This entry will be > 128 chars total
-          shortValue = "short"
-          ts =
-            fromList
-              [ (Key "long", Value longValue)
-              , (Key "vendor1", Value shortValue)
-              , (Key "vendor2", Value shortValue)
+      it "round-trips with size-constrained splitting" $ do
+        let originalPairs =
+              [ (Key "vendor1", Value "val1")
+              , (Key "vendor2", Value "val2")
+              , (Key "vendor3", Value "val3")
+              , (Key "vendor4", Value "val4")
               ]
-          result = encodeTraceStateMultiple 512 ts
-          combinedResult = C8.intercalate "," result
-      -- The long entry should be filtered out
-      combinedResult `shouldNotSatisfy` C8.isInfixOf "long="
-      combinedResult `shouldSatisfy` C8.isInfixOf "vendor1=short"
-      combinedResult `shouldSatisfy` C8.isInfixOf "vendor2=short"
+            ts = fromList originalPairs
+            encoded = encodeTraceStateMultiple 25 ts -- Force splitting
+            decoded = decodeTraceStateMultiple encoded
+            decodedPairs = toList decoded
+        -- Should contain all original entries (order may vary due to splitting)
+        length decodedPairs `shouldBe` 4
+        all (`elem` decodedPairs) originalPairs `shouldBe` True
 
-    it "respects 32 entry limit before splitting" $ do
-      let pairs = [(Key (T.pack $ "key" ++ show i), Value (T.pack $ "val" ++ show i)) | i <- [1 .. 40]]
-          ts = fromList pairs
-          result = encodeTraceStateMultiple 512 ts
-          combinedResult = C8.intercalate "," result
-          entryCount = length $ filter (== '=') $ C8.unpack combinedResult
-      entryCount `shouldBe` 32
+    -- RFC 7230 §3.2.2 field order; tracestate parsing across header fields
+    -- https://www.w3.org/TR/trace-context/#tracestate-header
+    describe "RFC7230 compliance" $ do
+      it "maintains header order when combining" $ do
+        let headers = ["first=1", "second=2", "third=3"]
+            result = decodeTraceStateMultiple headers
+        -- The combined header should be processed in order
+        result `shouldSatisfy` (/= empty)
 
-    it "returns empty list for empty tracestate" $ do
-      let result = encodeTraceStateMultiple 512 empty
-      result `shouldBe` []
+      it "handles comma-separated values correctly" $ do
+        let headers = ["a=1,b=2", "c=3,d=4"]
+            result = decodeTraceStateMultiple headers
+            pairs = toList result
+        length pairs `shouldBe` 4
+        pairs `shouldContain` [(Key "a", Value "1")]
+        pairs `shouldContain` [(Key "b", Value "2")]
+        pairs `shouldContain` [(Key "c", Value "3")]
+        pairs `shouldContain` [(Key "d", Value "4")]
 
-    it "handles single very large header correctly" $ do
-      let pairs = [(Key (T.pack $ "k" ++ show i), Value (T.pack $ "v" ++ show i)) | i <- [1 .. 20]]
-          ts = fromList pairs
-          result = encodeTraceStateMultiple 50 ts -- Very small limit
-      length result `shouldSatisfy` (> 1)
-      -- Should not exceed the limit
-      all (\h -> C8.length h <= 50) result `shouldBe` True
+    describe "W3C specification compliance" $ do
+      -- §3.3.3 recommendation: tracestate at least 512 characters
+      -- https://www.w3.org/TR/trace-context/#tracestate-limits
+      it "supports at least 512 character recommendation" $ do
+        let longValuePairs = [(Key (T.pack $ "vendor" ++ show i), Value (T.pack $ replicate 30 'x')) | i <- [1 .. 10]]
+            ts = fromList longValuePairs
+            encoded = encodeTraceStateMultiple 512 ts
+            totalSize = sum $ map C8.length encoded
+        -- Should handle at least 512 characters worth of data
+        totalSize `shouldSatisfy` (>= 300) -- Conservative check given filtering
 
-  describe "decodeTraceStateMultiple" $ do
-    it "combines single header correctly" $ do
-      let headers = ["vendor1=value1,vendor2=value2"]
-          result = decodeTraceStateMultiple headers
-          pairs = toList result
-      pairs `shouldContain` [(Key "vendor1", Value "value1")]
-      pairs `shouldContain` [(Key "vendor2", Value "value2")]
-
-    it "combines multiple headers in order" $ do
-      let headers = ["vendor1=value1,vendor2=value2", "vendor3=value3,vendor4=value4"]
-          result = decodeTraceStateMultiple headers
-          pairs = toList result
-      length pairs `shouldBe` 4
-      pairs `shouldContain` [(Key "vendor1", Value "value1")]
-      pairs `shouldContain` [(Key "vendor2", Value "value2")]
-      pairs `shouldContain` [(Key "vendor3", Value "value3")]
-      pairs `shouldContain` [(Key "vendor4", Value "value4")]
-
-    it "handles empty headers gracefully" $ do
-      let headers = ["vendor1=value1", "", "vendor2=value2"]
-          result = decodeTraceStateMultiple headers
-          pairs = toList result
-      pairs `shouldContain` [(Key "vendor1", Value "value1")]
-      pairs `shouldContain` [(Key "vendor2", Value "value2")]
-
-    it "returns empty tracestate for invalid headers" $ do
-      let headers = ["invalid$key=value", "another=bad,value"]
-          result = decodeTraceStateMultiple headers
-      result `shouldBe` empty
-
-    it "returns empty tracestate for empty header list" $ do
-      let result = decodeTraceStateMultiple []
-      result `shouldBe` empty
-
-    it "handles whitespace-only headers" $ do
-      let headers = ["vendor1=value1", "   ", "vendor2=value2"]
-          result = decodeTraceStateMultiple headers
-          pairs = toList result
-      pairs `shouldContain` [(Key "vendor1", Value "value1")]
-      pairs `shouldContain` [(Key "vendor2", Value "value2")]
-
-  describe "round-trip multi-header property" $ do
-    it "round-trips through multiple headers" $ do
-      let originalPairs =
-            [ (Key "vendor1", Value "value1")
-            , (Key "vendor2", Value "value2")
-            , (Key "vendor3", Value "value3")
-            ]
-          ts = fromList originalPairs
-          encoded = encodeTraceStateMultiple 512 ts
-          decoded = decodeTraceStateMultiple encoded
-          decodedPairs = toList decoded
-      decodedPairs `shouldBe` originalPairs
-
-    it "round-trips with size-constrained splitting" $ do
-      let originalPairs =
-            [ (Key "vendor1", Value "val1")
-            , (Key "vendor2", Value "val2")
-            , (Key "vendor3", Value "val3")
-            , (Key "vendor4", Value "val4")
-            ]
-          ts = fromList originalPairs
-          encoded = encodeTraceStateMultiple 25 ts -- Force splitting
-          decoded = decodeTraceStateMultiple encoded
-          decodedPairs = toList decoded
-      -- Should contain all original entries (order may vary due to splitting)
-      length decodedPairs `shouldBe` 4
-      all (`elem` decodedPairs) originalPairs `shouldBe` True
-
-  describe "RFC7230 compliance" $ do
-    it "maintains header order when combining" $ do
-      let headers = ["first=1", "second=2", "third=3"]
-          result = decodeTraceStateMultiple headers
-      -- The combined header should be processed in order
-      result `shouldSatisfy` (/= empty)
-
-    it "handles comma-separated values correctly" $ do
-      let headers = ["a=1,b=2", "c=3,d=4"]
-          result = decodeTraceStateMultiple headers
-          pairs = toList result
-      length pairs `shouldBe` 4
-      pairs `shouldContain` [(Key "a", Value "1")]
-      pairs `shouldContain` [(Key "b", Value "2")]
-      pairs `shouldContain` [(Key "c", Value "3")]
-      pairs `shouldContain` [(Key "d", Value "4")]
-
-  describe "W3C specification compliance" $ do
-    it "supports at least 512 character recommendation" $ do
-      let longValuePairs = [(Key (T.pack $ "vendor" ++ show i), Value (T.pack $ replicate 30 'x')) | i <- [1 .. 10]]
-          ts = fromList longValuePairs
-          encoded = encodeTraceStateMultiple 512 ts
-          totalSize = sum $ map C8.length encoded
-      -- Should handle at least 512 characters worth of data
-      totalSize `shouldSatisfy` (>= 300) -- Conservative check given filtering
-    it "removes oversized entries as per spec" $ do
-      let oversizedEntry = (Key "big", Value (T.replicate 200 "x"))
-          normalEntry = (Key "small", Value "value")
-          ts = fromList [oversizedEntry, normalEntry]
-          encoded = encodeTraceStateMultiple 512 ts
-          combined = C8.intercalate "," encoded
-      -- Oversized entry should be filtered out
-      combined `shouldNotSatisfy` C8.isInfixOf "big="
-      combined `shouldSatisfy` C8.isInfixOf "small=value"
+      -- §3.3.2.2 value length limits when encoding
+      -- https://www.w3.org/TR/trace-context/#value
+      it "removes oversized entries as per spec" $ do
+        let oversizedEntry = (Key "big", Value (T.replicate 200 "x"))
+            normalEntry = (Key "small", Value "value")
+            ts = fromList [oversizedEntry, normalEntry]
+            encoded = encodeTraceStateMultiple 512 ts
+            combined = C8.intercalate "," encoded
+        -- Oversized entry should be filtered out
+        combined `shouldNotSatisfy` C8.isInfixOf "big="
+        combined `shouldSatisfy` C8.isInfixOf "small=value"

--- a/propagators/w3c/test/OpenTelemetry/Propagator/W3CTraceContextSpec.hs
+++ b/propagators/w3c/test/OpenTelemetry/Propagator/W3CTraceContextSpec.hs
@@ -3,10 +3,8 @@
 
 module OpenTelemetry.Propagator.W3CTraceContextSpec (spec) where
 
-import Data.Attoparsec.ByteString (parseOnly)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as C8
-import Data.Either (isLeft)
 import qualified Data.Text as T
 import OpenTelemetry.Propagator.W3CTraceContext
 import OpenTelemetry.Trace.TraceState (Key (..), Value (..), empty, fromList, insert, toList)
@@ -15,79 +13,67 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "W3C TraceContext TraceState" $ do
-  describe "tracestateParser" $ do
+  describe "parseTraceState" $ do
     it "parses empty tracestate" $ do
-      parseOnly tracestateParser "" `shouldBe` Right empty
+      parseTraceState "" `shouldBe` empty
 
     it "parses single key=value pair" $ do
-      let result = parseOnly tracestateParser "vendor1=value1"
-      result `shouldBe` Right (insert (Key "vendor1") (Value "value1") empty)
+      parseTraceState "vendor1=value1" `shouldBe` insert (Key "vendor1") (Value "value1") empty
 
     it "parses multiple key=value pairs" $ do
-      let result = parseOnly tracestateParser "vendor1=value1,vendor2=value2"
-      case result of
-        Right ts -> do
-          let pairs = toList ts
-          pairs `shouldContain` [(Key "vendor1", Value "value1")]
-          pairs `shouldContain` [(Key "vendor2", Value "value2")]
-        Left err -> expectationFailure $ "Parse failed: " ++ err
+      let ts = parseTraceState "vendor1=value1,vendor2=value2"
+          pairs = toList ts
+      pairs `shouldContain` [(Key "vendor1", Value "value1")]
+      pairs `shouldContain` [(Key "vendor2", Value "value2")]
 
     it "parses key=value pairs with spaces" $ do
-      let result = parseOnly tracestateParser " vendor1=value1 , vendor2=value2 "
-      case result of
-        Right ts -> do
-          let pairs = toList ts
-          pairs `shouldContain` [(Key "vendor1", Value "value1")]
-          pairs `shouldContain` [(Key "vendor2", Value "value2")]
-        Left err -> expectationFailure $ "Parse failed: " ++ err
+      let ts = parseTraceState " vendor1=value1 , vendor2=value2 "
+          pairs = toList ts
+      pairs `shouldContain` [(Key "vendor1", Value "value1")]
+      pairs `shouldContain` [(Key "vendor2", Value "value2")]
 
     it "handles multi-tenant keys" $ do
-      let result = parseOnly tracestateParser "tenant@vendor=value1"
-      result `shouldBe` Right (insert (Key "tenant@vendor") (Value "value1") empty)
+      parseTraceState "tenant@vendor=value1"
+        `shouldBe` insert (Key "tenant@vendor") (Value "value1") empty
 
     it "handles special characters in keys" $ do
-      let result = parseOnly tracestateParser "vendor-1_2*3/4@tenant=value1"
-      result `shouldBe` Right (insert (Key "vendor-1_2*3/4@tenant") (Value "value1") empty)
+      parseTraceState "vendor-1_2*3/4@tenant=value1"
+        `shouldBe` insert (Key "vendor-1_2*3/4@tenant") (Value "value1") empty
 
     it "handles special characters in values" $ do
-      let result = parseOnly tracestateParser "vendor1=value-with_special*chars/and@symbols"
-      result `shouldBe` Right (insert (Key "vendor1") (Value "value-with_special*chars/and@symbols") empty)
+      parseTraceState "vendor1=value-with_special*chars/and@symbols"
+        `shouldBe` insert (Key "vendor1") (Value "value-with_special*chars/and@symbols") empty
 
     it "limits to 32 entries" $ do
-      let pairs = [C8.pack $ "key" ++ show i ++ "=value" ++ show i | i <- [1 .. 40]]
+      let pairs = [C8.pack $ "key" ++ show i ++ "=value" ++ show i | i <- [1 :: Int .. 40]]
           input = C8.intercalate "," pairs
-          result = parseOnly tracestateParser input
-      case result of
-        Right ts -> length (toList ts) `shouldBe` 32
-        Left err -> expectationFailure $ "Parse failed: " ++ err
+          ts = parseTraceState input
+      length (toList ts) `shouldBe` 32
 
-    it "rejects invalid key starting with uppercase" $ do
-      let result = parseOnly tracestateParser "VENDOR=value1"
-      result `shouldSatisfy` isLeft
+    it "skips invalid key starting with uppercase" $ do
+      parseTraceState "VENDOR=value1" `shouldBe` empty
 
-    it "rejects invalid key with invalid characters" $ do
-      let result = parseOnly tracestateParser "vendor$=value1"
-      result `shouldSatisfy` isLeft
+    it "skips invalid key with invalid characters" $ do
+      parseTraceState "vendor$=value1" `shouldBe` empty
 
-    it "rejects keys that are too long" $ do
+    it "skips keys that are too long" $ do
       let longKey = T.replicate 257 "a"
           input = C8.pack $ T.unpack longKey ++ "=value1"
-          result = parseOnly tracestateParser input
-      result `shouldSatisfy` isLeft
+      parseTraceState input `shouldBe` empty
 
-    it "rejects values that are too long" $ do
+    it "skips values that are too long" $ do
       let longValue = T.replicate 257 "a"
           input = C8.pack $ "vendor1=" ++ T.unpack longValue
-          result = parseOnly tracestateParser input
-      result `shouldSatisfy` isLeft
+      parseTraceState input `shouldBe` empty
 
-    it "rejects invalid value with comma" $ do
-      let result = parseOnly tracestateParser "vendor1=value,with,comma"
-      result `shouldSatisfy` isLeft
+    it "splits at comma in value (comma delimits entries)" $ do
+      let ts = parseTraceState "vendor1=value,with,comma"
+          pairs = toList ts
+      pairs `shouldContain` [(Key "vendor1", Value "value")]
 
-    it "rejects invalid value with equals" $ do
-      let result = parseOnly tracestateParser "vendor1=value=with=equals"
-      result `shouldSatisfy` isLeft
+    it "truncates value at equals sign" $ do
+      parseTraceState "vendor1=value=with=equals"
+        `shouldBe` insert (Key "vendor1") (Value "value") empty
 
   describe "encodeTraceState" $ do
     it "encodes empty tracestate" $ do
@@ -100,7 +86,6 @@ spec = describe "W3C TraceContext TraceState" $ do
     it "encodes multiple key=value pairs" $ do
       let ts = fromList [(Key "vendor1", Value "value1"), (Key "vendor2", Value "value2")]
       let encoded = encodeTraceState ts
-      -- Order might vary, so check both possibilities
       encoded `shouldSatisfy` \s ->
         s == "vendor1=value1,vendor2=value2"
           || s == "vendor2=value2,vendor1=value1"
@@ -114,10 +99,11 @@ spec = describe "W3C TraceContext TraceState" $ do
                     (Key $ T.pack $ "key" ++ show n)
                     (Value $ T.pack $ "value" ++ show n)
                     acc
-          ts = buildTS 1 empty
+          ts = buildTS (1 :: Int) empty
           encoded = encodeTraceState ts
           entryCount = length $ filter (== ',') $ C8.unpack encoded
-      entryCount `shouldBe` 31 -- 32 entries = 31 commas
+      entryCount `shouldBe` 31
+
     it "handles special characters in encoding" $ do
       let ts = insert (Key "vendor-1_2*3/4@tenant") (Value "value-with_special*chars/and@symbols") empty
       encodeTraceState ts `shouldBe` "vendor-1_2*3/4@tenant=value-with_special*chars/and@symbols"
@@ -131,13 +117,14 @@ spec = describe "W3C TraceContext TraceState" $ do
       encodeTraceStateFull ts `shouldBe` "vendor1=value1"
 
     it "encodes at most 32 entries (W3C list-member limit via fromList)" $ do
-      let pairs = [(Key $ T.pack $ "key" ++ show i, Value $ T.pack $ "value" ++ show i) | i <- [1 .. 40]]
+      let pairs = [(Key $ T.pack $ "key" ++ show i, Value $ T.pack $ "value" ++ show i) | i <- [1 :: Int .. 40]]
           ts = fromList pairs
           encoded = encodeTraceStateFull ts
           entryCount = length $ filter (== '=') $ C8.unpack encoded
-      entryCount `shouldBe` 32 -- fromList truncates to 32 per W3C spec
+      entryCount `shouldBe` 32
+
     it "does not filter oversized entries" $ do
-      let longValue = T.replicate 200 "x" -- Much longer than 128 char limit
+      let longValue = T.replicate 200 "x"
           ts = insert (Key "longentry") (Value longValue) empty
           encoded = encodeTraceStateFull ts
       encoded `shouldSatisfy` C8.isInfixOf "longentry="
@@ -152,16 +139,10 @@ spec = describe "W3C TraceContext TraceState" $ do
       let validPairs = [("vendor1", "value1"), ("vendor2", "value2")]
           ts = fromList [(Key $ T.pack k, Value $ T.pack v) | (k, v) <- validPairs]
           encoded = encodeTraceState ts
-          parsed = parseOnly tracestateParser encoded
-      case parsed of
-        Right ts' -> toList ts' `shouldBe` toList ts
-        Left err -> expectationFailure $ "Round-trip failed: " ++ err
+      toList (parseTraceState encoded) `shouldBe` toList ts
 
     it "round-trips complex valid tracestate" $ do
       let validPairs = [("tenant@vendor", "complex-value_with*chars"), ("simple123", "value")]
           ts = fromList [(Key $ T.pack k, Value $ T.pack v) | (k, v) <- validPairs]
           encoded = encodeTraceState ts
-          parsed = parseOnly tracestateParser encoded
-      case parsed of
-        Right ts' -> toList ts' `shouldBe` toList ts
-        Left err -> expectationFailure $ "Round-trip failed: " ++ err
+      toList (parseTraceState encoded) `shouldBe` toList ts

--- a/propagators/xray/hs-opentelemetry-propagator-xray.cabal
+++ b/propagators/xray/hs-opentelemetry-propagator-xray.cabal
@@ -1,0 +1,72 @@
+cabal-version: 2.4
+
+name:               hs-opentelemetry-propagator-xray
+version:            0.0.1.0
+synopsis:           AWS X-Ray trace context propagation for OpenTelemetry.
+description:
+  Propagator implementing the AWS X-Ray trace context format
+  (@X-Amzn-Trace-Id@ header).
+  .
+  The X-Ray format is used by AWS services such as Application Load
+  Balancer, API Gateway, and Lambda. This package lets Haskell services
+  participate in traces originated or propagated by AWS infrastructure.
+  .
+  Use alongside W3C Trace Context for mixed environments:
+  @OTEL_PROPAGATORS=tracecontext,baggage,xray@.
+  .
+  See <https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader>.
+category:           OpenTelemetry, Tracing, AWS, Web
+homepage:           https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
+author:             Ian Duncan
+maintainer:         ian@iankduncan.com
+copyright:          2024 Ian Duncan, Mercury Technologies
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files:
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Propagator.XRay
+      OpenTelemetry.Propagator.XRay.Internal
+  other-modules:
+      Paths_hs_opentelemetry_propagator_xray
+  autogen-modules:
+      Paths_hs_opentelemetry_propagator_xray
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , text
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-propagator-xray-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      OpenTelemetry.Propagator.XRaySpec
+      Paths_hs_opentelemetry_propagator_xray
+  autogen-modules:
+      Paths_hs_opentelemetry_propagator_xray
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , hs-opentelemetry-propagator-xray
+    , hspec
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+  build-tool-depends: hspec-discover:hspec-discover

--- a/propagators/xray/src/OpenTelemetry/Propagator/XRay.hs
+++ b/propagators/xray/src/OpenTelemetry/Propagator/XRay.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | AWS X-Ray Propagation Format.
+
+The @X-Amzn-Trace-Id@ header is used by AWS services (ALB, API Gateway,
+Lambda, etc.) to propagate trace context. The trace ID embeds a Unix
+epoch timestamp in its first 4 bytes, but is otherwise a standard 128-bit
+identifier that maps directly to an OpenTelemetry trace ID.
+
+== Header format
+
+@
+X-Amzn-Trace-Id: Root=1-{epoch8hex}-{unique24hex};Parent={spanid16hex};Sampled={0|1}
+@
+
+== Interoperability with W3C Trace Context
+
+Use alongside W3C propagators for mixed AWS / non-AWS environments:
+
+@
+OTEL_PROPAGATORS=tracecontext,baggage,xray
+@
+
+Both propagators will extract context from their respective headers.
+On injection both headers are emitted, so downstream services can
+consume whichever format they understand.
+
+See <https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader>.
+-}
+module OpenTelemetry.Propagator.XRay (
+  xrayPropagator,
+
+  -- * Registry integration
+  registerXRayPropagator,
+) where
+
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text.Encoding as TE
+import OpenTelemetry.Common (TraceFlags (..))
+import OpenTelemetry.Context (Context)
+import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  TextMap,
+  textMapInsert,
+  textMapLookup,
+ )
+import OpenTelemetry.Propagator.XRay.Internal
+import OpenTelemetry.Registry (registerTextMapPropagator)
+import qualified OpenTelemetry.Trace.Core as Core
+import OpenTelemetry.Trace.Id (Base (..), spanIdBaseEncodedBuilder)
+import OpenTelemetry.Trace.TraceState (TraceState (..))
+
+
+{- | Propagator for the AWS X-Ray @X-Amzn-Trace-Id@ header.
+
+Extracts @Root@, @Parent@, and @Sampled@ fields from incoming headers
+and injects them on outgoing headers.
+
+@since 0.0.1.0
+-}
+xrayPropagator :: Propagator Context TextMap TextMap
+xrayPropagator =
+  Propagator
+    { propagatorFields = [xrayTraceIdHeader]
+    , extractor = \tm c ->
+        case textMapLookup xrayTraceIdHeader tm of
+          Nothing -> pure c
+          Just val ->
+            case decodeXRayHeader (TE.encodeUtf8 val) of
+              Nothing -> pure c
+              Just xh ->
+                let sc =
+                      Core.SpanContext
+                        { Core.traceId = xhTraceId xh
+                        , Core.spanId = xhSpanId xh
+                        , Core.isRemote = True
+                        , Core.traceFlags = case xhSampled xh of
+                            Just True -> TraceFlags 1
+                            _ -> TraceFlags 0 -- absent or explicitly unsampled
+                        , Core.traceState = TraceState []
+                        }
+                in pure $ Context.insertSpan (Core.wrapSpanContext sc) c
+    , injector = \c tm ->
+        case Context.lookupSpan c of
+          Nothing -> pure tm
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            let root = TE.decodeUtf8 $ otelTraceIdToXRay (Core.traceId sc)
+                parent =
+                  TE.decodeUtf8 $
+                    BL.toStrict $
+                      BB.toLazyByteString $
+                        spanIdBaseEncodedBuilder Base16 (Core.spanId sc)
+                sampled = if Core.isSampled (Core.traceFlags sc) then "1" else "0"
+                headerValue = "Root=" <> root <> ";Parent=" <> parent <> ";Sampled=" <> sampled
+            pure $ textMapInsert xrayTraceIdHeader headerValue tm
+    }
+
+
+{- | Register the X-Ray propagator under the name @\"xray\"@ in the
+global registry.
+
+@since 0.0.1.0
+-}
+registerXRayPropagator :: IO ()
+registerXRayPropagator =
+  registerTextMapPropagator "xray" xrayPropagator

--- a/propagators/xray/src/OpenTelemetry/Propagator/XRay/Internal.hs
+++ b/propagators/xray/src/OpenTelemetry/Propagator/XRay/Internal.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
+
+{- | Internal codec for the AWS X-Ray propagation format.
+
+The wire format for the @X-Amzn-Trace-Id@ header is:
+
+@
+Root=1-{8hex-epoch}-{24hex-unique};Parent={16hex-spanid};Sampled={0|1}
+@
+
+The trace ID is a standard 128-bit value. X-Ray splits it into a 4-byte
+epoch timestamp and a 12-byte unique part, separated by dashes and
+prefixed with a version number (@1@). Stripping the delimiters yields a
+32-hex-char OpenTelemetry trace ID.
+
+See <https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader>.
+-}
+module OpenTelemetry.Propagator.XRay.Internal (
+  -- * Header key
+  xrayTraceIdHeader,
+
+  -- * Parsed header
+  XRayHeader (..),
+
+  -- * Decoders
+  decodeXRayHeader,
+
+  -- * Trace ID conversion
+  otelTraceIdToXRay,
+  xrayTraceIdToOTel,
+) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+import Data.Word (Word8)
+import OpenTelemetry.Trace.Id (
+  Base (..),
+  SpanId,
+  TraceId,
+  baseEncodedToSpanId,
+  baseEncodedToTraceId,
+  traceIdBaseEncodedBuilder,
+ )
+
+
+-- Header key -----------------------------------------------------------------
+
+xrayTraceIdHeader :: Text
+xrayTraceIdHeader = "x-amzn-trace-id"
+
+
+-- Parsed header --------------------------------------------------------------
+
+data XRayHeader = XRayHeader
+  { xhTraceId :: !TraceId
+  , xhSpanId :: !SpanId
+  , xhSampled :: !(Maybe Bool)
+  {- ^ @Nothing@ when the @Sampled@ field is absent (deferred decision).
+  @Just True@ = sampled, @Just False@ = not sampled.
+  -}
+  }
+  deriving (Eq, Show)
+
+
+-- Trace ID conversion --------------------------------------------------------
+
+-- | Convert an OTel 128-bit trace ID to X-Ray format: @1-{epoch8}-{unique24}@.
+otelTraceIdToXRay :: TraceId -> ByteString
+otelTraceIdToXRay tid =
+  let hex = BL.toStrict $ BB.toLazyByteString $ traceIdBaseEncodedBuilder Base16 tid
+      (epoch, unique) = BS.splitAt 8 hex
+  in "1-" <> epoch <> "-" <> unique
+
+
+{- | Parse an X-Ray trace ID (@1-{epoch8}-{unique24}@) into an OTel trace ID.
+Returns 'Nothing' on malformed input.
+-}
+xrayTraceIdToOTel :: ByteString -> Maybe TraceId
+xrayTraceIdToOTel bs
+  | BS.length bs /= 35 = Nothing
+  | BS.index bs 0 /= charW8 '1' = Nothing
+  | BS.index bs 1 /= charW8 '-' = Nothing
+  | BS.index bs 10 /= charW8 '-' = Nothing
+  | otherwise =
+      let epoch = BS.take 8 (BS.drop 2 bs)
+          unique = BS.drop 11 bs
+          combined = epoch <> unique
+      in case baseEncodedToTraceId Base16 combined of
+           Left _ -> Nothing
+           Right tid -> Just tid
+
+
+-- Decoders -------------------------------------------------------------------
+
+-- | Parse a full @X-Amzn-Trace-Id@ header value.
+decodeXRayHeader :: ByteString -> Maybe XRayHeader
+decodeXRayHeader = parseXRayKVs
+
+
+{- | Hand-rolled parser for semicolon-separated key=value pairs.
+Extracts Root, Parent, Sampled; ignores other fields.
+-}
+parseXRayKVs :: ByteString -> Maybe XRayHeader
+parseXRayKVs bs = go bs Nothing Nothing Nothing
+  where
+    go !remaining mRoot mParent mSampled
+      | BS.null remaining =
+          case (mRoot, mParent) of
+            (Just tid, Just sid) -> Just $! XRayHeader tid sid mSampled
+            _ -> Nothing
+      | otherwise =
+          let !trimmed = BS.dropWhile (== charW8 ' ') remaining
+              (!key, !afterEq) = BS.break (== charW8 '=') trimmed
+          in if BS.null afterEq
+               then Nothing -- no '=' found
+               else
+                 let !valAndRest = BS.drop 1 afterEq -- skip '='
+                     (!val, !rest) = breakSemicolon valAndRest
+                     !next = skipSpacesAfterSemicolon rest
+                 in if
+                    | key == "Root" ->
+                        case xrayTraceIdToOTel val of
+                          Nothing -> Nothing
+                          Just !tid -> go next (Just tid) mParent mSampled
+                    | key == "Parent" ->
+                        case parseSpanIdHex val of
+                          Nothing -> Nothing
+                          Just !sid -> go next mRoot (Just sid) mSampled
+                    | key == "Sampled" ->
+                        let !s = val == "1"
+                        in go next mRoot mParent (Just s)
+                    | otherwise ->
+                        go next mRoot mParent mSampled
+
+    breakSemicolon :: ByteString -> (ByteString, ByteString)
+    breakSemicolon bs' =
+      let (!v, !rest) = BS.break (== charW8 ';') bs'
+      in (stripTrailingSpaces v, rest)
+
+    stripTrailingSpaces :: ByteString -> ByteString
+    stripTrailingSpaces = fst . BS.spanEnd (== charW8 ' ')
+
+    skipSpacesAfterSemicolon :: ByteString -> ByteString
+    skipSpacesAfterSemicolon !rest
+      | BS.null rest = rest
+      | otherwise =
+          let !afterSemi = BS.drop 1 rest -- skip ';'
+          in BS.dropWhile (== charW8 ' ') afterSemi
+
+
+parseSpanIdHex :: ByteString -> Maybe SpanId
+parseSpanIdHex bs
+  | BS.length bs /= 16 = Nothing
+  | otherwise = case baseEncodedToSpanId Base16 bs of
+      Left _ -> Nothing
+      Right sid -> Just sid
+
+
+charW8 :: Char -> Word8
+charW8 = fromIntegral . fromEnum

--- a/propagators/xray/test/OpenTelemetry/Propagator/XRaySpec.hs
+++ b/propagators/xray/test/OpenTelemetry/Propagator/XRaySpec.hs
@@ -1,0 +1,262 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenTelemetry.Propagator.XRaySpec (spec) where
+
+import Data.Maybe (isJust, isNothing)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import OpenTelemetry.Common (TraceFlags (..))
+import OpenTelemetry.Context (Context, empty, insertSpan, lookupSpan)
+import OpenTelemetry.Propagator (
+  Propagator (..),
+  TextMap,
+  emptyTextMap,
+  textMapFromList,
+  textMapLookup,
+ )
+import OpenTelemetry.Propagator.XRay (xrayPropagator)
+import OpenTelemetry.Propagator.XRay.Internal
+import qualified OpenTelemetry.Trace.Core as Core
+import OpenTelemetry.Trace.Id (
+  Base (..),
+  SpanId,
+  TraceId,
+  baseEncodedToSpanId,
+  baseEncodedToTraceId,
+ )
+import OpenTelemetry.Trace.TraceState (TraceState (..))
+import Test.Hspec
+
+
+mkTraceId :: String -> TraceId
+mkTraceId hex = case baseEncodedToTraceId Base16 (TE.encodeUtf8 $ T.pack hex) of
+  Right tid -> tid
+  Left err -> error $ "bad test trace id: " ++ err
+
+
+mkSpanId :: String -> SpanId
+mkSpanId hex = case baseEncodedToSpanId Base16 (TE.encodeUtf8 $ T.pack hex) of
+  Right sid -> sid
+  Left err -> error $ "bad test span id: " ++ err
+
+
+mkContext :: TraceId -> SpanId -> Bool -> IO Context
+mkContext tid sid sampled = do
+  let sc =
+        Core.SpanContext
+          { Core.traceId = tid
+          , Core.spanId = sid
+          , Core.isRemote = False
+          , Core.traceFlags = if sampled then TraceFlags 1 else TraceFlags 0
+          , Core.traceState = TraceState []
+          }
+  pure $ insertSpan (Core.wrapSpanContext sc) empty
+
+
+extractWith :: T.Text -> IO Context
+extractWith headerVal = do
+  let tm = textMapFromList [("x-amzn-trace-id", headerVal)]
+  extractor xrayPropagator tm empty
+
+
+spec :: Spec
+spec =
+  -- AWS X-Ray tracing header (Root, Parent, Sampled)
+  -- https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+  describe "OpenTelemetry.Propagator.XRay" $ do
+    describe "Internal: trace ID conversion" $ do
+      -- Root=1-{8 hex epoch}-{24 hex unique}
+      -- https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+      it "converts OTel trace ID to X-Ray format" $ do
+        let tid = mkTraceId "5759e988bd862e3fe1be46a994272793"
+        otelTraceIdToXRay tid `shouldBe` "1-5759e988-bd862e3fe1be46a994272793"
+
+      it "converts X-Ray trace ID back to OTel format" $ do
+        let expected = mkTraceId "5759e988bd862e3fe1be46a994272793"
+        xrayTraceIdToOTel "1-5759e988-bd862e3fe1be46a994272793" `shouldBe` Just expected
+
+      it "round-trips trace ID through X-Ray encoding" $ do
+        let tid = mkTraceId "463ac35c9f6413ad48485a3953bb6124"
+            xray = otelTraceIdToXRay tid
+        xrayTraceIdToOTel xray `shouldBe` Just tid
+
+      it "rejects trace ID with wrong version" $ do
+        xrayTraceIdToOTel "2-5759e988-bd862e3fe1be46a994272793" `shouldBe` Nothing
+
+      it "rejects trace ID with wrong length" $ do
+        xrayTraceIdToOTel "1-5759e988-bd862e3fe1be46a99427279" `shouldBe` Nothing
+
+      it "rejects trace ID with missing delimiters" $ do
+        xrayTraceIdToOTel "1-5759e988bd862e3fe1be46a994272793" `shouldBe` Nothing
+
+    describe "Internal: header parsing" $ do
+      it "parses a standard X-Ray header" $ do
+        let hdr = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+        let result = decodeXRayHeader hdr
+        result `shouldSatisfy` \case
+          Just xh ->
+            xhTraceId xh == mkTraceId "5759e988bd862e3fe1be46a994272793"
+              && xhSpanId xh == mkSpanId "53995c3f42cd8ad8"
+              && xhSampled xh == Just True
+          Nothing -> False
+
+      it "parses header with Sampled=0" $ do
+        let hdr = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0"
+        let result = decodeXRayHeader hdr
+        result `shouldSatisfy` \case
+          Just xh -> xhSampled xh == Just False
+          Nothing -> False
+
+      it "handles missing Sampled field (deferred — Nothing)" $ do
+        let hdr = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8"
+        let result = decodeXRayHeader hdr
+        result `shouldSatisfy` \case
+          Just xh -> xhSampled xh == Nothing
+          Nothing -> False
+
+      it "handles reordered fields" $ do
+        let hdr = "Sampled=1;Parent=53995c3f42cd8ad8;Root=1-5759e988-bd862e3fe1be46a994272793"
+        let result = decodeXRayHeader hdr
+        result `shouldSatisfy` \case
+          Just xh ->
+            xhTraceId xh == mkTraceId "5759e988bd862e3fe1be46a994272793"
+              && xhSpanId xh == mkSpanId "53995c3f42cd8ad8"
+              && xhSampled xh == Just True
+          Nothing -> False
+
+      it "ignores extra fields (Self, Lineage, etc.)" $ do
+        let hdr = "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;Self=1-abc12345-def67890123456789012"
+        let result = decodeXRayHeader hdr
+        result `shouldSatisfy` \case
+          Just xh ->
+            xhTraceId xh == mkTraceId "5759e988bd862e3fe1be46a994272793"
+              && xhSampled xh == Just True
+          Nothing -> False
+
+      it "handles spaces around semicolons" $ do
+        let hdr = "Root=1-5759e988-bd862e3fe1be46a994272793 ; Parent=53995c3f42cd8ad8 ; Sampled=1"
+        let result = decodeXRayHeader hdr
+        result `shouldSatisfy` \case
+          Just xh ->
+            xhTraceId xh == mkTraceId "5759e988bd862e3fe1be46a994272793"
+          Nothing -> False
+
+      it "rejects header with missing Root" $ do
+        let hdr = "Parent=53995c3f42cd8ad8;Sampled=1"
+        decodeXRayHeader hdr `shouldSatisfy` isNothing
+
+      it "rejects header with missing Parent" $ do
+        let hdr = "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1"
+        decodeXRayHeader hdr `shouldSatisfy` isNothing
+
+      it "rejects header with invalid trace ID" $ do
+        let hdr = "Root=1-ZZZZZZZZ-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1"
+        decodeXRayHeader hdr `shouldSatisfy` isNothing
+
+      it "rejects empty header" $ do
+        decodeXRayHeader "" `shouldSatisfy` isNothing
+
+    describe "trace context extraction" $ do
+      it "extracts sampled span context from header" $ do
+        ctx <- extractWith "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=1"
+        case lookupSpan ctx of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            Core.traceId sc `shouldBe` mkTraceId "65a8c9d20abcdef1234567890abcdef0"
+            Core.spanId sc `shouldBe` mkSpanId "53995c3f42cd8ad8"
+            Core.isRemote sc `shouldBe` True
+            Core.isSampled (Core.traceFlags sc) `shouldBe` True
+
+      it "extracts unsampled span context from header" $ do
+        ctx <- extractWith "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=0"
+        case lookupSpan ctx of
+          Nothing -> expectationFailure "expected span in context"
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            Core.isSampled (Core.traceFlags sc) `shouldBe` False
+
+      it "returns unchanged context when header is missing" $ do
+        ctx <- extractor xrayPropagator emptyTextMap empty
+        lookupSpan ctx `shouldSatisfy` (not . isJust)
+
+      it "returns unchanged context on malformed header" $ do
+        ctx <- extractWith "not-a-valid-header"
+        lookupSpan ctx `shouldSatisfy` (not . isJust)
+
+    describe "trace context injection" $ do
+      it "injects X-Ray header from span context" $ do
+        let tid = mkTraceId "65a8c9d20abcdef1234567890abcdef0"
+            sid = mkSpanId "53995c3f42cd8ad8"
+        ctx <- mkContext tid sid True
+        tm <- injector xrayPropagator ctx emptyTextMap
+        textMapLookup "x-amzn-trace-id" tm
+          `shouldBe` Just "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=1"
+
+      it "injects unsampled X-Ray header" $ do
+        let tid = mkTraceId "65a8c9d20abcdef1234567890abcdef0"
+            sid = mkSpanId "53995c3f42cd8ad8"
+        ctx <- mkContext tid sid False
+        tm <- injector xrayPropagator ctx emptyTextMap
+        textMapLookup "x-amzn-trace-id" tm
+          `shouldBe` Just "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=0"
+
+      it "does not inject when no span in context" $ do
+        tm <- injector xrayPropagator empty emptyTextMap
+        textMapLookup "x-amzn-trace-id" tm `shouldBe` Nothing
+
+    describe "round-trip" $ do
+      it "inject then extract preserves trace identity" $ do
+        let tid = mkTraceId "5759e988bd862e3fe1be46a994272793"
+            sid = mkSpanId "abcdef0123456789"
+        ctx <- mkContext tid sid True
+        tm <- injector xrayPropagator ctx emptyTextMap
+        ctx' <- extractor xrayPropagator tm empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span after round-trip"
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            Core.traceId sc `shouldBe` tid
+            Core.spanId sc `shouldBe` sid
+            Core.isSampled (Core.traceFlags sc) `shouldBe` True
+            Core.isRemote sc `shouldBe` True
+
+      it "round-trips unsampled spans" $ do
+        let tid = mkTraceId "0000000100000002000000030000000f"
+            sid = mkSpanId "1234567890abcdef"
+        ctx <- mkContext tid sid False
+        tm <- injector xrayPropagator ctx emptyTextMap
+        ctx' <- extractor xrayPropagator tm empty
+        case lookupSpan ctx' of
+          Nothing -> expectationFailure "expected span after round-trip"
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            Core.traceId sc `shouldBe` tid
+            Core.spanId sc `shouldBe` sid
+            Core.isSampled (Core.traceFlags sc) `shouldBe` False
+
+    -- X-Ray vs W3C in same carrier (extractor behavior with multiple formats)
+    describe "W3C interoperability" $ do
+      it "works alongside W3C headers in the same TextMap" $ do
+        let tm =
+              textMapFromList
+                [ ("traceparent", "00-65a8c9d20abcdef1234567890abcdef0-53995c3f42cd8ad8-01")
+                , ("x-amzn-trace-id", "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=1")
+                ]
+        ctx <- extractor xrayPropagator tm empty
+        case lookupSpan ctx of
+          Nothing -> expectationFailure "expected X-Ray extraction to succeed"
+          Just span' -> do
+            sc <- Core.getSpanContext span'
+            Core.traceId sc `shouldBe` mkTraceId "65a8c9d20abcdef1234567890abcdef0"
+
+      it "injected header can be extracted by the same propagator" $ do
+        let tid = mkTraceId "aabbccdd11223344aabbccdd11223344"
+            sid = mkSpanId "ff00ff00ff00ff00"
+        ctx <- mkContext tid sid True
+        tm <- injector xrayPropagator ctx emptyTextMap
+        let headerVal = textMapLookup "x-amzn-trace-id" tm
+        headerVal `shouldSatisfy` \case
+          Just v -> "Root=1-aabbccdd-11223344aabbccdd11223344" `T.isPrefixOf` v
+          Nothing -> False

--- a/propagators/xray/test/Spec.hs
+++ b/propagators/xray/test/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -5,6 +5,11 @@ packages:
 - api
 - otlp
 - semantic-conventions
+- propagators/b3
+- propagators/jaeger
+- propagators/xray
+- propagators/datadog
+- propagators/w3c
 
 extra-deps:
 - unix-compat-0.7.1@sha256:bd5bb4e04b2ed707f3e3466470a452354310389506cf0a7a73bf10e4d533f6d1,3619


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #253.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)