### PR TITLE
feat(exporters): update handle, in-memory, OTLP, prometheus exporters for API 0.4

### DIFF
--- a/exporters/handle/hs-opentelemetry-exporter-handle.cabal
+++ b/exporters/handle/hs-opentelemetry-exporter-handle.cabal
@@ -1,12 +1,14 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-handle
 version:        0.0.1.3
+synopsis:       Handle-based exporter for OpenTelemetry (e.g. stdout)
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/handle#readme>
+category:       OpenTelemetry, Telemetry, Monitoring
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
 author:         Ian Duncan
@@ -35,7 +37,24 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , text
+    , vector
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-exporter-handle-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_exporter_handle
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-handle >=0.0.1 && <0.1
+    , hspec
+    , unordered-containers
     , vector
   default-language: Haskell2010

--- a/exporters/handle/package.yaml
+++ b/exporters/handle/package.yaml
@@ -11,8 +11,8 @@ extra-source-files:
 - ChangeLog.md
 
 # Metadata used when publishing your package
-# synopsis:            Short description of your package
-# category:            Web
+synopsis: Handle-based exporter for OpenTelemetry (e.g. stdout)
+category: OpenTelemetry, Telemetry, Monitoring
 
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
@@ -30,12 +30,11 @@ library:
   - OpenTelemetry.Exporter.Handle.Metric
   - OpenTelemetry.Exporter.Handle.Span
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - text
   - vector
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-exporter-handle-test:
     main:                Spec.hs
     source-dirs:         test
@@ -44,4 +43,8 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-exporter-handle
+    - hs-opentelemetry-exporter-handle >= 0.0.1 && < 0.1
+    - hs-opentelemetry-api == 0.4.*
+    - hspec
+    - unordered-containers
+    - vector

--- a/exporters/handle/src/OpenTelemetry/Exporter/Handle.hs
+++ b/exporters/handle/src/OpenTelemetry/Exporter/Handle.hs
@@ -1,3 +1,8 @@
+{- |
+Module      : OpenTelemetry.Exporter.Handle
+Description : Re-exports for handle-based (stdout/stderr) exporters.
+Stability   : experimental
+-}
 module OpenTelemetry.Exporter.Handle (
   module OpenTelemetry.Exporter.Handle.Span,
   module OpenTelemetry.Exporter.Handle.Metric,

--- a/exporters/handle/src/OpenTelemetry/Exporter/Handle/Metric.hs
+++ b/exporters/handle/src/OpenTelemetry/Exporter/Handle/Metric.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | Console \/ handle metric exporter (@OTEL_METRICS_EXPORTER=console@).
+{- |
+Module      :  OpenTelemetry.Exporter.Handle.Metric
+Copyright   :  (c) Ian Duncan, 2024-2026
+License     :  BSD-3
+Description :  Console \/ handle metric exporter (@OTEL_METRICS_EXPORTER=console@).
+Stability   :  experimental
 
 Renders each export batch using 'OpenTelemetry.Debug.MetricExport.renderResourceMetricsExportDebug'
 and writes the text to the given 'Handle'.
@@ -12,7 +17,7 @@ module OpenTelemetry.Exporter.Handle.Metric (
   stderrMetricExporter,
 ) where
 
-import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.IO.Class (MonadIO)
 import qualified Data.Text.IO as TIO
 import qualified Data.Vector as V
 import OpenTelemetry.Debug.MetricExport (renderResourceMetricsExportDebug)

--- a/exporters/handle/test/Spec.hs
+++ b/exporters/handle/test/Spec.hs
@@ -1,3 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
+import OpenTelemetry.Exporter.Handle.LogRecord (makeHandleLogRecordExporter)
+import OpenTelemetry.Exporter.Handle.Span (makeHandleExporter)
+import OpenTelemetry.Exporter.LogRecord (
+  logRecordExporterExport,
+  logRecordExporterForceFlush,
+  logRecordExporterShutdown,
+ )
+import OpenTelemetry.Exporter.Span (SpanExporter (..))
+import OpenTelemetry.Internal.Common.Types (ExportResult (..))
+import System.IO (stdout)
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec spec
+
+
+spec :: Spec
+spec =
+  -- Handle-based exporters (implementation-specific; SpanExporter / LogRecordExporter shape)
+  -- https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter
+  -- https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordexporter
+  do
+    describe "Handle Span exporter" $ do
+      -- SpanExporter.Export must accept empty batches (SDK contract)
+      -- https://opentelemetry.io/docs/specs/otel/trace/sdk/#export-batch
+      it "returns Success for empty batch" $ do
+        let formatter _span = pure "test"
+            exporter = makeHandleExporter stdout formatter
+        result <- spanExporterExport exporter HM.empty
+        case result of
+          Success -> pure ()
+          Failure _ -> expectationFailure "expected Success"
+
+      it "forceFlush does not throw" $ do
+        let exporter = makeHandleExporter stdout (\_ -> pure "test")
+        _ <- spanExporterForceFlush exporter
+        pure ()
+
+      it "shutdown does not throw" $ do
+        let exporter = makeHandleExporter stdout (\_ -> pure "test")
+        _ <- spanExporterShutdown exporter
+        pure ()
+
+    describe "Handle LogRecord exporter" $ do
+      it "returns Success for empty batch" $ do
+        exporter <- makeHandleLogRecordExporter stdout (\_ -> pure "test")
+        result <- logRecordExporterExport exporter V.empty
+        case result of
+          Success -> pure ()
+          Failure _ -> expectationFailure "expected Success"
+
+      it "forceFlush does not throw" $ do
+        exporter <- makeHandleLogRecordExporter stdout (\_ -> pure "test")
+        _ <- logRecordExporterForceFlush exporter
+        pure ()
+
+      it "shutdown does not throw" $ do
+        exporter <- makeHandleLogRecordExporter stdout (\_ -> pure "test")
+        _ <- logRecordExporterShutdown exporter
+        pure ()

--- a/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
+++ b/exporters/in-memory/hs-opentelemetry-exporter-in-memory.cabal
@@ -1,12 +1,14 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hs-opentelemetry-exporter-in-memory
 version:        0.0.1.5
+synopsis:       In-memory exporter for OpenTelemetry testing
 description:    Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/exporters/in-memory#readme>
+category:       OpenTelemetry, Telemetry, Testing
 homepage:       https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
 author:         Ian Duncan
@@ -26,6 +28,7 @@ source-repository head
 library
   exposed-modules:
       OpenTelemetry.Exporter.InMemory
+      OpenTelemetry.Exporter.InMemory.Assertions
       OpenTelemetry.Exporter.InMemory.LogRecord
       OpenTelemetry.Exporter.InMemory.Metric
       OpenTelemetry.Exporter.InMemory.Span
@@ -37,7 +40,24 @@ library
   build-depends:
       async
     , base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
+    , text
     , unagi-chan
     , vector
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-exporter-in-memory-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_exporter_in_memory
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hspec
+    , text
   default-language: Haskell2010

--- a/exporters/in-memory/package.yaml
+++ b/exporters/in-memory/package.yaml
@@ -11,8 +11,8 @@ extra-source-files:
 - ChangeLog.md
 
 # Metadata used when publishing your package
-# synopsis:            Short description of your package
-# category:            Web
+synopsis: In-memory exporter for OpenTelemetry testing
+category: OpenTelemetry, Telemetry, Testing
 
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
@@ -27,17 +27,18 @@ library:
   source-dirs: src
   exposed-modules:
   - OpenTelemetry.Exporter.InMemory
+  - OpenTelemetry.Exporter.InMemory.Assertions
   - OpenTelemetry.Exporter.InMemory.LogRecord
   - OpenTelemetry.Exporter.InMemory.Metric
   - OpenTelemetry.Exporter.InMemory.Span
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - async
+  - text
   - unagi-chan
   - vector
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-exporter-in-memory-test:
     main:                Spec.hs
     source-dirs:         test
@@ -46,4 +47,7 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-exporter-in-memory
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - hs-opentelemetry-api == 0.4.*
+    - hspec
+    - text

--- a/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory.hs
+++ b/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory.hs
@@ -1,9 +1,16 @@
+{- |
+Module      : OpenTelemetry.Exporter.InMemory
+Description : Re-exports for in-memory exporters, primarily used for testing.
+Stability   : experimental
+-}
 module OpenTelemetry.Exporter.InMemory (
   module OpenTelemetry.Exporter.InMemory.Span,
   module OpenTelemetry.Exporter.InMemory.Metric,
   module OpenTelemetry.Exporter.InMemory.LogRecord,
+  module OpenTelemetry.Exporter.InMemory.Assertions,
 ) where
 
+import OpenTelemetry.Exporter.InMemory.Assertions
 import OpenTelemetry.Exporter.InMemory.LogRecord
 import OpenTelemetry.Exporter.InMemory.Metric
 import OpenTelemetry.Exporter.InMemory.Span

--- a/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory/Assertions.hs
+++ b/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory/Assertions.hs
@@ -1,0 +1,225 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      :  OpenTelemetry.Exporter.InMemory.Assertions
+Copyright   :  (c) Ian Duncan, 2024-2026
+License     :  BSD-3
+Description :  Testing assertion helpers built on top of in-memory exporters.
+Stability   :  experimental
+
+Import this module in your test suite alongside 'OpenTelemetry.Exporter.InMemory'
+to get ergonomic span/metric/log assertions without writing manual IORef reads and
+list searches.
+
+@
+(proc, spansRef) <- inMemoryListExporter
+-- ... run instrumented code ...
+span <- assertSpanNamed spansRef "my-operation"
+assertSpanAttribute span "http.method" (AttributeValue (TextAttribute "GET"))
+@
+-}
+module OpenTelemetry.Exporter.InMemory.Assertions (
+  -- * Span assertions
+  getSpans,
+  assertSpanNamed,
+  assertSpanCount,
+  assertNoSpans,
+  assertSpanAttribute,
+  assertSpanHasParent,
+  assertSpanStatus,
+
+  -- * Metric assertions
+  getMetricExports,
+  assertMetricNamed,
+  assertMetricCount,
+  assertNoMetrics,
+
+  -- * Log assertions
+  getLogRecords,
+  assertLogCount,
+  assertNoLogs,
+) where
+
+import Control.Exception (throwIO)
+import Control.Monad (unless)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.IORef (IORef, readIORef)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import OpenTelemetry.Attributes (Attribute, lookupAttribute)
+import OpenTelemetry.Exporter.Metric (
+  MetricExport (..),
+  ResourceMetricsExport (..),
+  ScopeMetricsExport (..),
+ )
+import OpenTelemetry.Log.Core (ReadableLogRecord)
+import OpenTelemetry.Trace.Core (
+  ImmutableSpan (..),
+  SpanHot (..),
+  SpanStatus (..),
+ )
+
+
+-- Spans
+
+-- | Read all spans currently in the in-memory exporter.
+getSpans :: (MonadIO m) => IORef [ImmutableSpan] -> m [ImmutableSpan]
+getSpans = liftIO . readIORef
+
+
+{- | Find the first span with the given name. Throws if not found.
+When multiple spans share a name, returns the most recently ended one
+(the in-memory list exporter prepends).
+-}
+assertSpanNamed :: (MonadIO m) => IORef [ImmutableSpan] -> Text -> m ImmutableSpan
+assertSpanNamed ref name = liftIO $ do
+  spans <- readIORef ref
+  result <- findByName name spans
+  case result of
+    Nothing -> do
+      names <- mapM (\s -> hotName <$> readIORef (spanHot s)) spans
+      throwIO $ userError $ "Expected span named " <> show name <> " but found: [" <> T.unpack (T.intercalate ", " names) <> "]"
+    Just s -> pure s
+
+
+-- | Assert the total number of exported spans.
+assertSpanCount :: (MonadIO m) => IORef [ImmutableSpan] -> Int -> m ()
+assertSpanCount ref expected = liftIO $ do
+  spans <- readIORef ref
+  let actual = length spans
+  unless (actual == expected) $
+    throwIO $
+      userError $
+        "Expected " <> show expected <> " spans but found " <> show actual
+
+
+-- | Assert no spans have been exported.
+assertNoSpans :: (MonadIO m) => IORef [ImmutableSpan] -> m ()
+assertNoSpans ref = assertSpanCount ref 0
+
+
+-- | Assert a span has a specific attribute value.
+assertSpanAttribute :: (MonadIO m) => ImmutableSpan -> Text -> Attribute -> m ()
+assertSpanAttribute span_ key expected = liftIO $ do
+  hot <- readIORef (spanHot span_)
+  let actual = lookupAttribute (hotAttributes hot) key
+      name = hotName hot
+  case actual of
+    Nothing ->
+      throwIO $ userError $ "Span " <> show name <> " missing attribute " <> show key
+    Just v ->
+      unless (v == expected) $
+        throwIO $
+          userError $
+            "Span " <> show name <> " attribute " <> show key <> ": expected " <> show expected <> " but got " <> show v
+
+
+-- | Assert a span has a parent span.
+assertSpanHasParent :: (MonadIO m) => ImmutableSpan -> m ()
+assertSpanHasParent span_ = liftIO $ do
+  case spanParent span_ of
+    Nothing -> do
+      name <- hotName <$> readIORef (spanHot span_)
+      throwIO $ userError $ "Span " <> show name <> " has no parent"
+    Just _ -> pure ()
+
+
+-- | Assert a span's status.
+assertSpanStatus :: (MonadIO m) => ImmutableSpan -> SpanStatus -> m ()
+assertSpanStatus span_ expected = liftIO $ do
+  hot <- readIORef (spanHot span_)
+  let actual = hotStatus hot
+      name = hotName hot
+  unless (actual == expected) $
+    throwIO $
+      userError $
+        "Span " <> show name <> " status: expected " <> show expected <> " but got " <> show actual
+
+
+-- Metrics
+
+-- | Read all metric export batches.
+getMetricExports :: (MonadIO m) => IORef [ResourceMetricsExport] -> m [ResourceMetricsExport]
+getMetricExports = liftIO . readIORef
+
+
+-- | Find the first metric with the given name across all exports.
+assertMetricNamed :: (MonadIO m) => IORef [ResourceMetricsExport] -> Text -> m MetricExport
+assertMetricNamed ref name = liftIO $ do
+  batches <- readIORef ref
+  case findMetricByName name batches of
+    Nothing ->
+      throwIO $ userError $ "Expected metric named " <> show name <> " but not found in exports"
+    Just m -> pure m
+
+
+-- | Assert the total number of distinct metric names across all exports.
+assertMetricCount :: (MonadIO m) => IORef [ResourceMetricsExport] -> Int -> m ()
+assertMetricCount ref expected = liftIO $ do
+  batches <- readIORef ref
+  let actual = length (allMetrics batches)
+  unless (actual == expected) $
+    throwIO $
+      userError $
+        "Expected " <> show expected <> " metrics but found " <> show actual
+
+
+-- | Assert no metrics have been exported.
+assertNoMetrics :: (MonadIO m) => IORef [ResourceMetricsExport] -> m ()
+assertNoMetrics ref = assertMetricCount ref 0
+
+
+-- Logs
+
+-- | Read all exported log records.
+getLogRecords :: (MonadIO m) => IORef [ReadableLogRecord] -> m [ReadableLogRecord]
+getLogRecords = liftIO . readIORef
+
+
+-- | Assert the total number of exported log records.
+assertLogCount :: (MonadIO m) => IORef [ReadableLogRecord] -> Int -> m ()
+assertLogCount ref expected = liftIO $ do
+  logs <- readIORef ref
+  let actual = length logs
+  unless (actual == expected) $
+    throwIO $
+      userError $
+        "Expected " <> show expected <> " log records but found " <> show actual
+
+
+-- | Assert no log records have been exported.
+assertNoLogs :: (MonadIO m) => IORef [ReadableLogRecord] -> m ()
+assertNoLogs ref = assertLogCount ref 0
+
+
+-- Internal helpers
+
+findByName :: Text -> [ImmutableSpan] -> IO (Maybe ImmutableSpan)
+findByName _ [] = pure Nothing
+findByName name (s : rest) = do
+  n <- hotName <$> readIORef (spanHot s)
+  if n == name then pure (Just s) else findByName name rest
+
+
+metricExportName :: MetricExport -> Text
+metricExportName (MetricExportSum n _ _ _ _ _ _ _) = n
+metricExportName (MetricExportHistogram n _ _ _ _ _) = n
+metricExportName (MetricExportExponentialHistogram n _ _ _ _ _) = n
+metricExportName (MetricExportGauge n _ _ _ _ _) = n
+
+
+findMetricByName :: Text -> [ResourceMetricsExport] -> Maybe MetricExport
+findMetricByName name batches = go (allMetrics batches)
+  where
+    go [] = Nothing
+    go (m : rest)
+      | metricExportName m == name = Just m
+      | otherwise = go rest
+
+
+allMetrics :: [ResourceMetricsExport] -> [MetricExport]
+allMetrics = concatMap extractMetrics
+  where
+    extractMetrics (ResourceMetricsExport _ scopes) =
+      concatMap (\(ScopeMetricsExport _ ms) -> V.toList ms) (V.toList scopes)

--- a/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory/LogRecord.hs
+++ b/exporters/in-memory/src/OpenTelemetry/Exporter/InMemory/LogRecord.hs
@@ -1,3 +1,8 @@
+{- |
+Module      : OpenTelemetry.Exporter.InMemory.LogRecord
+Description : In-memory log record exporter for testing. Stores exported log records in an IORef.
+Stability   : experimental
+-}
 module OpenTelemetry.Exporter.InMemory.LogRecord (
   inMemoryLogRecordExporter,
   getExportedLogRecords,

--- a/exporters/in-memory/test/Spec.hs
+++ b/exporters/in-memory/test/Spec.hs
@@ -1,3 +1,79 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Data.IORef
+import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryChannelExporter, inMemoryListExporter, readChan)
+import OpenTelemetry.Trace.Core
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec spec
+
+
+spec :: Spec
+spec =
+  -- In-memory span exporter / processor (implementation-specific test helper)
+  -- https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor
+  do
+    describe "inMemoryListExporter" $ do
+      it "starts with empty list" $ do
+        (_, ref) <- inMemoryListExporter
+        spans <- readIORef ref
+        length spans `shouldBe` 0
+
+      -- Ended spans exported to processor (SimpleSpanProcessor behavior)
+      -- https://opentelemetry.io/docs/specs/otel/trace/sdk/#simplespanprocessor
+      it "captures ended spans" $ do
+        (processor, ref) <- inMemoryListExporter
+        tp <- createTracerProvider [processor] emptyTracerProviderOptions
+        let t = makeTracer tp "test" tracerOptions
+        s <- createSpan t Context.empty "test-span" defaultSpanArguments
+        endSpan s Nothing
+        _ <- shutdownTracerProvider tp Nothing
+        spans <- readIORef ref
+        length spans `shouldBe` 1
+        case spans of
+          (s : _) -> do
+            hot <- readIORef (spanHot s)
+            hotName hot `shouldBe` "test-span"
+          [] -> expectationFailure "no spans"
+
+      it "captures multiple spans in order of completion" $ do
+        (processor, ref) <- inMemoryListExporter
+        tp <- createTracerProvider [processor] emptyTracerProviderOptions
+        let t = makeTracer tp "test" tracerOptions
+        s1 <- createSpan t Context.empty "first" defaultSpanArguments
+        s2 <- createSpan t Context.empty "second" defaultSpanArguments
+        endSpan s1 Nothing
+        endSpan s2 Nothing
+        _ <- shutdownTracerProvider tp Nothing
+        spans <- readIORef ref
+        length spans `shouldBe` 2
+
+      it "does not capture spans that have not ended" $ do
+        (processor, ref) <- inMemoryListExporter
+        tp <- createTracerProvider [processor] emptyTracerProviderOptions
+        let t = makeTracer tp "test" tracerOptions
+        _ <- createSpan t Context.empty "unfinished" defaultSpanArguments
+        _ <- shutdownTracerProvider tp Nothing
+        spans <- readIORef ref
+        length spans `shouldBe` 0
+
+    describe "inMemoryChannelExporter" $ do
+      it "creates a processor and channel" $ do
+        (_, _chan) <- inMemoryChannelExporter
+        pure () :: IO ()
+
+      it "captures ended spans via channel" $ do
+        (processor, chan) <- inMemoryChannelExporter
+        tp <- createTracerProvider [processor] emptyTracerProviderOptions
+        let t = makeTracer tp "test" tracerOptions
+        s <- createSpan t Context.empty "chan-span" defaultSpanArguments
+        endSpan s Nothing
+        _ <- shutdownTracerProvider tp Nothing
+        element <- readChan chan
+        hot <- readIORef (spanHot element)
+        hotName hot `shouldBe` "chan-span"

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -25,12 +25,18 @@ source-repository head
   type: git
   location: https://github.com/iand675/hs-opentelemetry
 
+flag grpc
+  description: Enable gRPC export support (requires grapesy)
+  manual: True
+  default: False
+
 library
   exposed-modules:
       OpenTelemetry.Exporter.OTLP
       OpenTelemetry.Exporter.OTLP.LogRecord
       OpenTelemetry.Exporter.OTLP.Span
       OpenTelemetry.Exporter.OTLP.Metric
+      OpenTelemetry.Exporter.OTLP.Internal.Config
   other-modules:
       Paths_hs_opentelemetry_exporter_otlp
   hs-source-dirs:
@@ -40,19 +46,26 @@ library
       base >=4.7 && <5
     , bytestring
     , case-insensitive
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-otlp ==0.2.*
-    , hs-opentelemetry-propagator-w3c
+    , hs-opentelemetry-propagator-w3c >=0.1.0 && <0.2
     , http-client
     , http-conduit
     , http-types
     , microlens
     , proto-lens >=0.7.1.0
+    , random
     , text
+    , time
     , unordered-containers
     , vector
     , zlib
   default-language: Haskell2010
+  if flag(grpc)
+    exposed-modules:
+        OpenTelemetry.Exporter.OTLP.GRPC
+    build-depends:
+        grapesy
 
 test-suite hs-opentelemetry-exporter-otlp-test
   type: exitcode-stdio-1.0
@@ -64,12 +77,15 @@ test-suite hs-opentelemetry-exporter-otlp-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
-    , hs-opentelemetry-exporter-otlp
+    , bytestring
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-otlp ==0.1.*
     , hs-opentelemetry-otlp ==0.2.*
     , hspec
+    , http-types
     , microlens
     , proto-lens
     , text
+    , unordered-containers
     , vector
   default-language: Haskell2010

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -30,21 +30,38 @@ library:
   - OpenTelemetry.Exporter.OTLP.LogRecord
   - OpenTelemetry.Exporter.OTLP.Span
   - OpenTelemetry.Exporter.OTLP.Metric
+  - OpenTelemetry.Exporter.OTLP.Internal.Config
+  other-modules:
+  - Paths_hs_opentelemetry_exporter_otlp
   dependencies:
   - bytestring
   - case-insensitive
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hs-opentelemetry-otlp ^>= 0.2
-  - hs-opentelemetry-propagator-w3c
+  - hs-opentelemetry-propagator-w3c >= 0.1.0 && < 0.2
   - http-client
   - http-conduit
   - http-types
   - microlens
   - proto-lens >= 0.7.1.0
+  - random
   - text
+  - time
   - unordered-containers
   - vector
   - zlib
+  when:
+  - condition: flag(grpc)
+    exposed-modules:
+    - OpenTelemetry.Exporter.OTLP.GRPC
+    dependencies:
+    - grapesy
+
+flags:
+  grpc:
+    description: Enable gRPC export support (requires grapesy)
+    manual: true
+    default: false
 
 tests:
   hs-opentelemetry-exporter-otlp-test:
@@ -55,11 +72,14 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-api ^>= 0.3
-    - hs-opentelemetry-exporter-otlp
+    - bytestring
+    - hs-opentelemetry-api ^>= 0.4
+    - hs-opentelemetry-exporter-otlp == 0.1.*
     - hs-opentelemetry-otlp ^>= 0.2
     - hspec
+    - http-types
     - microlens
     - proto-lens
     - text
+    - unordered-containers
     - vector

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP.hs
@@ -1,3 +1,8 @@
+{- |
+Module      : OpenTelemetry.Exporter.OTLP
+Description : Re-exports for OTLP (OpenTelemetry Protocol) exporters.
+Stability   : experimental
+-}
 module OpenTelemetry.Exporter.OTLP (
   module OpenTelemetry.Exporter.OTLP.Span,
   module OpenTelemetry.Exporter.OTLP.Metric,

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/GRPC.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/GRPC.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | gRPC transport for OTLP export via grapesy.
+
+Provides gRPC-based span, metric, and log exporters that speak the native
+OTLP\/gRPC protocol (default port 4317).
+
+Requires the @grpc@ cabal flag to be enabled.
+
+@since 0.2.0.0
+-}
+module OpenTelemetry.Exporter.OTLP.GRPC (
+  grpcOtlpSpanExporter,
+  grpcOtlpMetricExporter,
+  grpcOtlpLogRecordExporter,
+  grpcEndpoint,
+  grpcTracesEndpoint,
+  grpcMetricsEndpoint,
+  grpcLogsEndpoint,
+) where
+
+import Control.Applicative ((<|>))
+import Control.Exception (SomeException (..), catch)
+import Control.Monad (void)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.HashMap.Strict (HashMap)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import Data.List (isPrefixOf)
+import Data.Vector (Vector)
+import Network.GRPC.Client (
+  Address (..),
+  CertificateStoreSpec,
+  Server (..),
+  ServerValidation (..),
+  certStoreFromPath,
+  certStoreFromSystem,
+  closeConnection,
+  openConnection,
+  rpc,
+ )
+import Network.GRPC.Client.StreamType.IO (nonStreaming)
+import Network.GRPC.Common (
+  NoMetadata,
+  RequestMetadata,
+  ResponseInitialMetadata,
+  ResponseTrailingMetadata,
+  def,
+ )
+import Network.GRPC.Common.Protobuf (Proto (..), Protobuf)
+import OpenTelemetry.Exporter.Metric (MetricExporter (..), ResourceMetricsExport)
+import OpenTelemetry.Exporter.OTLP.Internal.Config (
+  OTLPExporterConfig (..),
+  grpcEndpoint,
+  grpcLogsEndpoint,
+  grpcMetricsEndpoint,
+  grpcTracesEndpoint,
+ )
+import OpenTelemetry.Exporter.Span (SpanExporter (..))
+import OpenTelemetry.Internal.Common.Types (ExportResult (..), FlushResult (..), InstrumentationLibrary, ShutdownResult (..))
+import OpenTelemetry.Internal.Log.Types (LogRecordExporter, LogRecordExporterArguments (..), ReadableLogRecord, mkLogRecordExporter)
+import OpenTelemetry.Internal.Logging (otelLogWarning)
+import qualified OpenTelemetry.Trace.Core as OT
+import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService (ExportLogsServiceRequest, LogsService)
+import Proto.Opentelemetry.Proto.Collector.Metrics.V1.MetricsService (ExportMetricsServiceRequest, MetricsService)
+import Proto.Opentelemetry.Proto.Collector.Trace.V1.TraceService (ExportTraceServiceRequest, TraceService)
+import System.Timeout (timeout)
+
+
+type ExportTracesRPC = Protobuf TraceService "export"
+
+
+type ExportMetricsRPC = Protobuf MetricsService "export"
+
+
+type ExportLogsRPC = Protobuf LogsService "export"
+
+
+type instance RequestMetadata (Protobuf TraceService meth) = NoMetadata
+
+
+type instance ResponseInitialMetadata (Protobuf TraceService meth) = NoMetadata
+
+
+type instance ResponseTrailingMetadata (Protobuf TraceService meth) = NoMetadata
+
+
+type instance RequestMetadata (Protobuf MetricsService meth) = NoMetadata
+
+
+type instance ResponseInitialMetadata (Protobuf MetricsService meth) = NoMetadata
+
+
+type instance ResponseTrailingMetadata (Protobuf MetricsService meth) = NoMetadata
+
+
+type instance RequestMetadata (Protobuf LogsService meth) = NoMetadata
+
+
+type instance ResponseInitialMetadata (Protobuf LogsService meth) = NoMetadata
+
+
+type instance ResponseTrailingMetadata (Protobuf LogsService meth) = NoMetadata
+
+
+parseGrpcAddress :: String -> Address
+parseGrpcAddress url =
+  let stripped = dropScheme url
+      (host, portPart) = break (== ':') stripped
+      port = case portPart of
+        ':' : rest -> case reads rest of
+          [(p, "")] -> p
+          [(p, "/")] -> p
+          _ -> 4317
+        _ -> 4317
+  in Address
+       { addressHost = host
+       , addressPort = port
+       , addressAuthority = Nothing
+       }
+  where
+    dropScheme s = case break (== '/') (drop 1 $ dropWhile (/= ':') s) of
+      (_, '/' : rest) -> rest
+      _ -> s
+
+
+resolveGrpcServer :: Bool -> Maybe FilePath -> String -> Server
+resolveGrpcServer insecure mCert endpoint
+  | insecure = ServerInsecure addr
+  | "https://" `isPrefixOf` endpoint = ServerSecure validation def addr
+  | otherwise = ServerInsecure addr
+  where
+    addr = parseGrpcAddress endpoint
+    validation = case mCert of
+      Just certPath -> ValidateServer (certStoreFromPath certPath)
+      Nothing -> ValidateServer certStoreFromSystem
+
+
+{- | Create a gRPC-based span exporter.
+
+The serialization function converts the SDK's span map into the OTLP
+protobuf request. Pass 'OpenTelemetry.Exporter.OTLP.Span.immutableSpansToProtobuf'.
+-}
+grpcOtlpSpanExporter
+  :: (MonadIO m)
+  => OTLPExporterConfig
+  -> (HashMap InstrumentationLibrary (Vector OT.ImmutableSpan) -> IO ExportTraceServiceRequest)
+  -> m SpanExporter
+grpcOtlpSpanExporter conf toProto = liftIO $ do
+  let endpoint = grpcTracesEndpoint conf
+      server = resolveGrpcServer (otlpTracesInsecure conf || otlpInsecure conf) (otlpTracesCertificate conf <|> otlpCertificate conf) endpoint
+  conn <- openConnection def server
+  shutdownRef <- newIORef False
+  pure $
+    SpanExporter
+      { spanExporterExport = \spans_ -> do
+          isShut <- readIORef shutdownRef
+          if isShut
+            then pure $ Failure Nothing
+            else do
+              req <- toProto spans_
+              let timeoutUs = maybe 10_000_000 (* 1_000) (otlpTracesTimeout conf <|> otlpTimeout conf)
+              ( do
+                  result <- timeout timeoutUs $ nonStreaming conn (rpc @ExportTracesRPC) (Proto req)
+                  case result of
+                    Nothing -> do
+                      otelLogWarning "gRPC trace export timed out"
+                      pure $ Failure Nothing
+                    Just _ -> pure Success
+                )
+                `catch` \(e :: SomeException) -> do
+                  otelLogWarning $ "gRPC trace export failed: " <> show e
+                  pure $ Failure (Just e)
+      , spanExporterShutdown = do
+          void $ atomicModifyIORef' shutdownRef $ \s -> (True, s)
+          closeConnection conn
+          pure ShutdownSuccess
+      , spanExporterForceFlush = pure FlushSuccess
+      }
+
+
+{- | Create a gRPC-based metric exporter.
+
+The serialization function converts metric batches into the OTLP
+protobuf request. Pass 'OpenTelemetry.Exporter.OTLP.Metric.resourceMetricsToExportRequest'.
+-}
+grpcOtlpMetricExporter
+  :: (MonadIO m)
+  => OTLPExporterConfig
+  -> (Vector ResourceMetricsExport -> ExportMetricsServiceRequest)
+  -> m MetricExporter
+grpcOtlpMetricExporter conf toProto = liftIO $ do
+  let endpoint = grpcMetricsEndpoint conf
+      server = resolveGrpcServer (otlpMetricsInsecure conf || otlpInsecure conf) (otlpMetricsCertificate conf <|> otlpCertificate conf) endpoint
+  conn <- openConnection def server
+  shutdownRef <- newIORef False
+  pure $
+    MetricExporter
+      { metricExporterExport = \rmes -> do
+          isShut <- readIORef shutdownRef
+          if isShut
+            then pure $ Failure Nothing
+            else do
+              let req = toProto rmes
+                  timeoutUs = maybe 10_000_000 (* 1_000) (otlpMetricsTimeout conf <|> otlpTimeout conf)
+              ( do
+                  result <- timeout timeoutUs $ nonStreaming conn (rpc @ExportMetricsRPC) (Proto req)
+                  case result of
+                    Nothing -> do
+                      otelLogWarning "gRPC metric export timed out"
+                      pure $ Failure Nothing
+                    Just _ -> pure Success
+                )
+                `catch` \(e :: SomeException) -> do
+                  otelLogWarning $ "gRPC metric export failed: " <> show e
+                  pure $ Failure (Just e)
+      , metricExporterShutdown = do
+          void $ atomicModifyIORef' shutdownRef $ \s -> (True, s)
+          closeConnection conn
+          pure ShutdownSuccess
+      , metricExporterForceFlush = pure FlushSuccess
+      }
+
+
+{- | Create a gRPC-based log record exporter.
+
+The serialization function converts log records into the OTLP
+protobuf request.
+-}
+grpcOtlpLogRecordExporter
+  :: (MonadIO m)
+  => OTLPExporterConfig
+  -> (Vector ReadableLogRecord -> IO ExportLogsServiceRequest)
+  -> m LogRecordExporter
+grpcOtlpLogRecordExporter conf toProto = liftIO $ do
+  let endpoint = grpcLogsEndpoint conf
+      server = resolveGrpcServer (otlpLogsInsecure conf || otlpInsecure conf) (otlpLogsCertificate conf <|> otlpCertificate conf) endpoint
+  conn <- openConnection def server
+  shutdownRef <- newIORef False
+  mkLogRecordExporter
+    LogRecordExporterArguments
+      { logRecordExporterArgumentsExport = \lrs -> do
+          isShut <- readIORef shutdownRef
+          if isShut
+            then pure $ Failure Nothing
+            else do
+              req <- toProto lrs
+              let timeoutUs = maybe 10_000_000 (* 1_000) (otlpLogsTimeout conf <|> otlpTimeout conf)
+              ( do
+                  result <- timeout timeoutUs $ nonStreaming conn (rpc @ExportLogsRPC) (Proto req)
+                  case result of
+                    Nothing -> do
+                      otelLogWarning "gRPC log export timed out"
+                      pure $ Failure Nothing
+                    Just _ -> pure Success
+                )
+                `catch` \(e :: SomeException) -> do
+                  otelLogWarning $ "gRPC log export failed: " <> show e
+                  pure $ Failure (Just e)
+      , logRecordExporterArgumentsForceFlush = pure FlushSuccess
+      , logRecordExporterArgumentsShutdown = do
+          void $ atomicModifyIORef' shutdownRef $ \s -> (True, s)
+          closeConnection conn
+      }

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Internal/Config.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Internal/Config.hs
@@ -1,0 +1,395 @@
+{- FOURMOLU_DISABLE -}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | Internal module containing shared OTLP exporter configuration types.
+
+Not intended for direct use — import via "OpenTelemetry.Exporter.OTLP.Span" instead.
+
+= Environment variables
+
+'loadExporterEnvironmentVariables' reads the following @OTEL_EXPORTER_OTLP_*@
+variables. Each generic variable has per-signal overrides for traces, metrics,
+and logs (e.g. @OTEL_EXPORTER_OTLP_TRACES_ENDPOINT@). Per-signal values take
+precedence over generic ones.
+
+=== Endpoint
+
+* @OTEL_EXPORTER_OTLP_ENDPOINT@ (default: @http:\/\/localhost:4318@ HTTP,
+  @http:\/\/localhost:4317@ gRPC)
+* @OTEL_EXPORTER_OTLP_TRACES_ENDPOINT@, @OTEL_EXPORTER_OTLP_METRICS_ENDPOINT@,
+  @OTEL_EXPORTER_OTLP_LOGS_ENDPOINT@
+
+=== Security
+
+* @OTEL_EXPORTER_OTLP_INSECURE@ (default: @false@)
+* @OTEL_EXPORTER_OTLP_TRACES_INSECURE@ (fallback: @OTEL_EXPORTER_OTLP_SPAN_INSECURE@)
+* @OTEL_EXPORTER_OTLP_METRICS_INSECURE@ (fallback: @OTEL_EXPORTER_OTLP_METRIC_INSECURE@)
+* @OTEL_EXPORTER_OTLP_LOGS_INSECURE@
+* @OTEL_EXPORTER_OTLP_CERTIFICATE@, @OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE@,
+  @OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE@, @OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE@
+
+=== Headers
+
+* @OTEL_EXPORTER_OTLP_HEADERS@, @OTEL_EXPORTER_OTLP_TRACES_HEADERS@,
+  @OTEL_EXPORTER_OTLP_METRICS_HEADERS@, @OTEL_EXPORTER_OTLP_LOGS_HEADERS@
+
+Format: @key1=value1,key2=value2@ (W3C Baggage encoding).
+
+=== Compression
+
+* @OTEL_EXPORTER_OTLP_COMPRESSION@, @OTEL_EXPORTER_OTLP_TRACES_COMPRESSION@,
+  @OTEL_EXPORTER_OTLP_METRICS_COMPRESSION@, @OTEL_EXPORTER_OTLP_LOGS_COMPRESSION@
+
+Values: @gzip@, @none@ (default: @none@).
+
+=== Timeout
+
+* @OTEL_EXPORTER_OTLP_TIMEOUT@, @OTEL_EXPORTER_OTLP_TRACES_TIMEOUT@,
+  @OTEL_EXPORTER_OTLP_METRICS_TIMEOUT@, @OTEL_EXPORTER_OTLP_LOGS_TIMEOUT@
+
+Milliseconds (default: @10000@).
+
+=== Protocol
+
+* @OTEL_EXPORTER_OTLP_PROTOCOL@, @OTEL_EXPORTER_OTLP_TRACES_PROTOCOL@,
+  @OTEL_EXPORTER_OTLP_METRICS_PROTOCOL@, @OTEL_EXPORTER_OTLP_LOGS_PROTOCOL@
+
+Values: @http\/protobuf@ (default), @grpc@.
+-}
+module OpenTelemetry.Exporter.OTLP.Internal.Config (
+  OTLPExporterConfig (..),
+  CompressionFormat (..),
+  Protocol (..),
+  loadExporterEnvironmentVariables,
+  otlpExporterHttpEndpoint,
+  otlpExporterGRpcEndpoint,
+  defaultExporterTimeout,
+  readCompressionFormat,
+  readProtocol,
+  readTimeout,
+  putWarningLn,
+
+  -- * Shared HTTP transport helpers
+  otlpUserAgent,
+  httpProtobufContentType,
+  httpSignalEndpointUrl,
+  isRetryableHttpStatus,
+
+  -- * Retry-After parsing
+  parseRetryAfterMicros,
+
+  -- * gRPC endpoint resolution (same env vars as HTTP; default port 4317)
+  grpcEndpoint,
+  grpcTracesEndpoint,
+  grpcMetricsEndpoint,
+  grpcLogsEndpoint,
+) where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Char (toLower)
+import Data.Function ((&))
+import Data.Maybe (fromMaybe)
+import Data.Version (showVersion)
+import qualified Data.ByteString.Char8 as C
+import qualified Data.CaseInsensitive as CI
+import qualified Data.HashMap.Strict as H
+import qualified Data.Text.Encoding as T
+import Data.Time.Clock (getCurrentTime, diffUTCTime)
+import Data.Time.Format (parseTimeM, defaultTimeLocale, rfc822DateFormat)
+import Network.HTTP.Types.Header (Header)
+import Network.HTTP.Types.Status (Status, status429, status502, status503, status504)
+import qualified OpenTelemetry.Baggage as Baggage
+import OpenTelemetry.Environment (lookupBooleanEnv)
+import OpenTelemetry.Internal.Logging (otelLogWarning)
+import Paths_hs_opentelemetry_exporter_otlp (version)
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
+
+
+data OTLPExporterConfig = OTLPExporterConfig
+  { otlpEndpoint :: Maybe String
+  , otlpTracesEndpoint :: Maybe String
+  , otlpMetricsEndpoint :: Maybe String
+  , otlpLogsEndpoint :: Maybe String
+  , otlpInsecure :: Bool
+  , otlpTracesInsecure :: Bool
+  , otlpMetricsInsecure :: Bool
+  , otlpLogsInsecure :: Bool
+  , otlpCertificate :: Maybe FilePath
+  , otlpTracesCertificate :: Maybe FilePath
+  , otlpMetricsCertificate :: Maybe FilePath
+  , otlpLogsCertificate :: Maybe FilePath
+  , otlpHeaders :: Maybe [Header]
+  , otlpTracesHeaders :: Maybe [Header]
+  , otlpMetricsHeaders :: Maybe [Header]
+  , otlpLogsHeaders :: Maybe [Header]
+  , otlpCompression :: Maybe CompressionFormat
+  , otlpTracesCompression :: Maybe CompressionFormat
+  , otlpMetricsCompression :: Maybe CompressionFormat
+  , otlpLogsCompression :: Maybe CompressionFormat
+  , otlpTimeout :: Maybe Int
+  -- ^ Measured in milliseconds.
+  , otlpTracesTimeout :: Maybe Int
+  -- ^ Measured in milliseconds.
+  , otlpMetricsTimeout :: Maybe Int
+  -- ^ Measured in milliseconds.
+  , otlpLogsTimeout :: Maybe Int
+  -- ^ Measured in milliseconds.
+  , otlpProtocol :: Maybe Protocol
+  , otlpTracesProtocol :: Maybe Protocol
+  , otlpMetricsProtocol :: Maybe Protocol
+  , otlpLogsProtocol :: Maybe Protocol
+  , otlpConcurrentExports :: !Int
+  -- ^ Maximum number of concurrent export requests per signal.
+  -- Default: 1 (sequential). Set higher for pipelined export.
+  -- Spec: <https://opentelemetry.io/docs/specs/otlp/>
+  }
+
+
+loadExporterEnvironmentVariables :: (MonadIO m) => m OTLPExporterConfig
+loadExporterEnvironmentVariables = liftIO $ do
+  hdrs <- lookupDecodeHeaders "OTEL_EXPORTER_OTLP_HEADERS"
+  tracesHdrs <- lookupDecodeHeaders "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+  metricsHdrs <- lookupDecodeHeaders "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
+  logsHdrs <- lookupDecodeHeaders "OTEL_EXPORTER_OTLP_LOGS_HEADERS"
+  OTLPExporterConfig
+    <$> lookupEnv "OTEL_EXPORTER_OTLP_ENDPOINT"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+    <*> lookupBooleanEnv "OTEL_EXPORTER_OTLP_INSECURE"
+    <*> lookupBooleanEnvFallback "OTEL_EXPORTER_OTLP_TRACES_INSECURE" "OTEL_EXPORTER_OTLP_SPAN_INSECURE"
+    <*> lookupBooleanEnvFallback "OTEL_EXPORTER_OTLP_METRICS_INSECURE" "OTEL_EXPORTER_OTLP_METRIC_INSECURE"
+    <*> lookupBooleanEnv "OTEL_EXPORTER_OTLP_LOGS_INSECURE"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_CERTIFICATE"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"
+    <*> lookupEnv "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE"
+    <*> pure hdrs
+    <*> pure tracesHdrs
+    <*> pure metricsHdrs
+    <*> pure logsHdrs
+    <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_COMPRESSION")
+    <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
+    <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
+    <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION")
+    <*> (traverse readTimeout =<< lookupEnv "OTEL_EXPORTER_OTLP_TIMEOUT")
+    <*> (traverse readTimeout =<< lookupEnv "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT")
+    <*> (traverse readTimeout =<< lookupEnv "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
+    <*> (traverse readTimeout =<< lookupEnv "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT")
+    <*> (traverse readProtocol =<< lookupEnv "OTEL_EXPORTER_OTLP_PROTOCOL")
+    <*> (traverse readProtocol =<< lookupEnv "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+    <*> (traverse readProtocol =<< lookupEnv "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
+    <*> (traverse readProtocol =<< lookupEnv "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
+    <*> (maybe 1 (\s -> max 1 (fromMaybe 1 (readMaybe s))) <$> lookupEnv "OTEL_EXPORTER_OTLP_CONCURRENT_EXPORTS")
+  where
+    lookupDecodeHeaders :: String -> IO (Maybe [Header])
+    lookupDecodeHeaders envName = do
+      m <- lookupEnv envName
+      case m of
+        Nothing -> pure Nothing
+        Just hsString -> case Baggage.decodeBaggageHeader $ C.pack hsString of
+          Left _err -> do
+            otelLogWarning ("Failed to parse " <> envName <> ", ignoring")
+            pure (Just [])
+          Right baggageFmt ->
+            pure $
+              Just $
+                (\(k, v) -> (CI.mk $ Baggage.tokenValue k, T.encodeUtf8 $ Baggage.value v))
+                  <$> H.toList (Baggage.values baggageFmt)
+
+    lookupBooleanEnvFallback primary fallback = do
+      p <- lookupBooleanEnv primary
+      if p then pure True else lookupBooleanEnv fallback
+
+
+data CompressionFormat
+  = None
+  | GZip
+
+
+{- |
+The OpenTelemetry Protocol.
+
+@http\/protobuf@ is always available. When the @grpc@ cabal flag is enabled,
+@grpc@ is also supported (native HTTP\/2 gRPC via grapesy).
+-}
+data Protocol
+  = HttpProtobuf
+#ifdef GRPC_ENABLED
+  | GRpc
+#endif
+
+
+readCompressionFormat :: (MonadIO m) => String -> m CompressionFormat
+readCompressionFormat compressionFormat =
+  compressionFormat & fmap toLower & \case
+    "gzip" -> pure GZip
+    "none" -> pure None
+    _ -> do
+      putWarningLn $ "Unsupported compression format '" <> compressionFormat <> "'"
+      pure None
+
+
+readProtocol :: (MonadIO m) => String -> m Protocol
+readProtocol protocol =
+  protocol & fmap toLower & \case
+    "http/protobuf" -> pure HttpProtobuf
+#ifdef GRPC_ENABLED
+    "grpc" -> pure GRpc
+#endif
+    _ -> do
+      putWarningLn $ "Unsupported protocol '" <> protocol <> "'"
+      pure HttpProtobuf
+
+
+readTimeout :: (MonadIO m) => String -> m Int
+readTimeout timeout =
+  case readMaybe timeout of
+    Just timeoutInt | timeoutInt >= 0 -> pure timeoutInt
+    _otherwise -> do
+      putWarningLn $ "Unsupported timeout value '" <> timeout <> "'"
+      pure defaultExporterTimeout
+
+
+defaultExporterTimeout :: Int
+defaultExporterTimeout = 10_000
+
+
+otlpExporterHttpEndpoint :: C.ByteString
+otlpExporterHttpEndpoint = "http://localhost:4318"
+
+
+otlpExporterGRpcEndpoint :: C.ByteString
+otlpExporterGRpcEndpoint = "http://localhost:4317"
+
+
+{- | Base OTLP gRPC URL from @OTEL_EXPORTER_OTLP_ENDPOINT@.
+
+Defaults to @http:\/\/localhost:4317@. Per-signal
+@OTEL_EXPORTER_OTLP_TRACES_ENDPOINT@ (and metrics\/logs variants) override via
+'grpcTracesEndpoint' and siblings.
+-}
+grpcEndpoint :: OTLPExporterConfig -> String
+grpcEndpoint conf =
+  fromMaybe "http://localhost:4317" (otlpEndpoint conf)
+
+
+{- | Effective gRPC URL for traces: per-signal env overrides the generic endpoint.
+
+See <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls>.
+-}
+grpcTracesEndpoint :: OTLPExporterConfig -> String
+grpcTracesEndpoint conf =
+  fromMaybe (grpcEndpoint conf) (otlpTracesEndpoint conf)
+
+
+{- | Effective gRPC URL for metrics (per-signal override or generic base).
+-}
+grpcMetricsEndpoint :: OTLPExporterConfig -> String
+grpcMetricsEndpoint conf =
+  fromMaybe (grpcEndpoint conf) (otlpMetricsEndpoint conf)
+
+
+{- | Effective gRPC URL for logs (per-signal override or generic base).
+-}
+grpcLogsEndpoint :: OTLPExporterConfig -> String
+grpcLogsEndpoint conf =
+  fromMaybe (grpcEndpoint conf) (otlpLogsEndpoint conf)
+
+
+putWarningLn :: (MonadIO m) => String -> m ()
+putWarningLn = liftIO . otelLogWarning
+
+
+-- | @OTel-OTLP-Exporter-Haskell\/\<version\>@ per the OTLP spec User-Agent convention.
+otlpUserAgent :: C.ByteString
+otlpUserAgent = C.pack $ "OTel-OTLP-Exporter-Haskell/" <> showVersion version
+
+
+httpProtobufContentType :: C.ByteString
+httpProtobufContentType = "application/x-protobuf"
+
+
+{- | Build the effective endpoint URL for a signal.
+
+Per the OTLP exporter spec:
+
+* If a per-signal endpoint is set, use it as-is.
+* Otherwise, append the signal path (@\/v1\/traces@, @\/v1\/metrics@, @\/v1\/logs@)
+  to the base endpoint.
+-}
+httpSignalEndpointUrl
+  :: Maybe String
+  -- ^ Per-signal endpoint (e.g. 'otlpTracesEndpoint')
+  -> OTLPExporterConfig
+  -> String
+  -- ^ Signal path, e.g. @\"\/v1\/traces\"@
+  -> String
+httpSignalEndpointUrl perSignalEndpoint conf signalPath =
+  case perSignalEndpoint of
+    Just url -> url
+    Nothing ->
+      let base = maybe "http://localhost:4318" id (otlpEndpoint conf)
+      in ensureTrailingSlash base <> dropWhile (== '/') signalPath
+
+
+ensureTrailingSlash :: String -> String
+ensureTrailingSlash [] = "/"
+ensureTrailingSlash s
+  | last s == '/' = s
+  | otherwise = s <> "/"
+
+
+{- | Whether an HTTP status code is retryable per the OTLP spec.
+
+Only 429 (Too Many Requests), 502 (Bad Gateway), 503 (Service Unavailable),
+and 504 (Gateway Timeout) are retryable. All other status codes, including
+other 4xx\/5xx codes, MUST NOT be retried.
+
+Spec: <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#retry>
+-}
+isRetryableHttpStatus :: Status -> Bool
+isRetryableHttpStatus s =
+  s == status429 || s == status502 || s == status503 || s == status504
+
+
+{- | Parse an HTTP @Retry-After@ header value into microseconds.
+
+Supports both formats defined in RFC 7231 Section 7.1.3:
+
+* @delay-seconds@ — a non-negative integer (e.g. @\"120\"@)
+* @HTTP-date@ — RFC 822 / RFC 1123 format (e.g. @\"Fri, 31 Dec 1999 23:59:59 GMT\"@)
+
+Returns 'Nothing' when the value cannot be parsed in either format or
+the resulting delay is non-positive.
+
+Spec: <https://opentelemetry.io/docs/specs/otlp/#failures>
+
+@since 0.1.2.0
+-}
+parseRetryAfterMicros :: C.ByteString -> IO (Maybe Int)
+parseRetryAfterMicros bs =
+  case readMaybe (C.unpack bs) of
+    Just (seconds :: Int)
+      | seconds > 0 -> pure $ Just (seconds * 1_000_000)
+    _ -> do
+      let dateStr = C.unpack bs
+      case parseTimeM True defaultTimeLocale rfc822DateFormat dateStr of
+        Just targetTime -> do
+          now <- getCurrentTime
+          let diffSecs = diffUTCTime targetTime now
+              micros = ceiling (diffSecs * 1_000_000) :: Int
+          pure $ if micros > 0 then Just micros else Nothing
+        Nothing ->
+          case parseTimeM True defaultTimeLocale "%a, %d %b %Y %H:%M:%S GMT" dateStr of
+            Just targetTime -> do
+              now <- getCurrentTime
+              let diffSecs = diffUTCTime targetTime now
+                  micros = ceiling (diffSecs * 1_000_000) :: Int
+              pure $ if micros > 0 then Just micros else Nothing
+            Nothing -> pure Nothing

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
@@ -27,7 +27,6 @@ import qualified Data.Vector as V
 import Data.Word (Word64)
 import Lens.Micro ((&), (.~))
 import Network.HTTP.Client
-import qualified Network.HTTP.Client as HTTPClient
 import Network.HTTP.Simple (httpBS)
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
@@ -121,15 +120,8 @@ otlpLogRecordExporter conf = liftIO $ do
                 threadDelay (retryDelay `shiftL` backoffCount)
                 sendReq req (backoffCount + 1)
       case eResp of
-        Left err@(HttpExceptionRequest req' e)
-          | HTTPClient.host req' == "localhost"
-          , HTTPClient.port req' == 4317 || HTTPClient.port req' == 4318
-          , ConnectionFailure _ <- e ->
-              pure $ Failure Nothing
-          | otherwise ->
-              if isRetryableException e
-                then exponentialBackoff
-                else pure $ Failure $ Just $ SomeException err
+        Left err@(HttpExceptionRequest _req' e)
+          | isRetryableException e -> exponentialBackoff
         Left err -> pure $ Failure $ Just $ SomeException err
         Right resp ->
           if isRetryableStatusCode (responseStatus resp)
@@ -252,7 +244,7 @@ severityToProto = \case
   Fatal2 -> PL.SEVERITY_NUMBER_FATAL2
   Fatal3 -> PL.SEVERITY_NUMBER_FATAL3
   Fatal4 -> PL.SEVERITY_NUMBER_FATAL4
-  Unknown n -> fromMaybe PL.SEVERITY_NUMBER_UNSPECIFIED (ProtoLens.maybeToEnum n)
+  Unknown _ -> PL.SEVERITY_NUMBER_UNSPECIFIED
 
 
 logAttributesToProto :: LogAttributes -> V.Vector KeyValue
@@ -291,7 +283,7 @@ materializedResourceToProto r =
        & RF.vec'attributes
          .~ attrsToProto attrs
        & RF.droppedAttributesCount
-         .~ fromIntegral (A.getCount attrs)
+         .~ fromIntegral (A.getDropped attrs)
 
 
 instrumentationLibraryToProto :: InstrumentationLibrary -> Common.InstrumentationScope
@@ -300,7 +292,7 @@ instrumentationLibraryToProto InstrumentationLibrary {..} =
     & CF.name .~ libraryName
     & CF.version .~ libraryVersion
     & CF.vec'attributes .~ attrsToProto libraryAttributes
-    & CF.droppedAttributesCount .~ fromIntegral (A.getCount libraryAttributes)
+    & CF.droppedAttributesCount .~ fromIntegral (A.getDropped libraryAttributes)
 
 
 attrsToProto :: A.Attributes -> V.Vector KeyValue
@@ -351,7 +343,7 @@ httpLogsBaseHeaders :: OTLPExporterConfig -> Request -> RequestHeaders
 httpLogsBaseHeaders conf req =
   concat
     [ [(hContentType, httpProtobufMimeType)]
-    , [(hAcceptEncoding, httpProtobufMimeType)]
+    , [(hAccept, httpProtobufMimeType)]
     , fromMaybe [] (otlpHeaders conf)
     , requestHeaders req
     ]

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
@@ -120,7 +120,7 @@ otlpLogRecordExporter conf = liftIO $ do
                 threadDelay (retryDelay `shiftL` backoffCount)
                 sendReq req (backoffCount + 1)
       case eResp of
-        Left err@(HttpExceptionRequest _req' e)
+        Left (HttpExceptionRequest _req' e)
           | isRetryableException e -> exponentialBackoff
         Left err -> pure $ Failure $ Just $ SomeException err
         Right resp ->

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Metric.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Metric.hs
@@ -32,7 +32,6 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
 import Lens.Micro ((&), (.~))
 import Network.HTTP.Client
-import qualified Network.HTTP.Client as HTTPClient
 import Network.HTTP.Simple (httpBS)
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
@@ -142,15 +141,8 @@ otlpMetricExporter conf = liftIO $ do
                 threadDelay (retryDelay `shiftL` backoffCount)
                 sendReq req (backoffCount + 1)
       case eResp of
-        Left err@(HttpExceptionRequest req' e)
-          | HTTPClient.host req' == "localhost"
-          , HTTPClient.port req' == 4317 || HTTPClient.port req' == 4318
-          , ConnectionFailure _ <- e ->
-              pure $ Failure Nothing
-          | otherwise ->
-              if isRetryableException e
-                then exponentialBackoff
-                else pure $ Failure $ Just $ SomeException err
+        Left err@(HttpExceptionRequest _req' e)
+          | isRetryableException e -> exponentialBackoff
         Left err -> pure $ Failure $ Just $ SomeException err
         Right resp ->
           if isRetryableStatusCode (responseStatus resp)
@@ -189,7 +181,7 @@ httpMetricsBaseHeaders :: OTLPExporterConfig -> Request -> RequestHeaders
 httpMetricsBaseHeaders conf req =
   concat
     [ [(hContentType, httpProtobufMimeType)]
-    , [(hAcceptEncoding, httpProtobufMimeType)]
+    , [(hAccept, httpProtobufMimeType)]
     , fromMaybe [] (otlpHeaders conf)
     , fromMaybe [] (otlpMetricsHeaders conf)
     , requestHeaders req
@@ -234,7 +226,7 @@ materializedResourceToProto r =
        & Rf.vec'attributes
          .~ attributesToProto attrs
        & Rf.droppedAttributesCount
-         .~ fromIntegral (getCount attrs)
+         .~ fromIntegral (getDropped attrs)
 
 
 scopeMetricsExportToProto :: ScopeMetricsExport -> PM.ScopeMetrics
@@ -258,7 +250,7 @@ instrumentationLibraryToProto InstrumentationLibrary {..} =
     & Common_Fields.vec'attributes
       .~ attributesToProto libraryAttributes
     & Common_Fields.droppedAttributesCount
-      .~ fromIntegral (getCount libraryAttributes)
+      .~ fromIntegral (getDropped libraryAttributes)
 
 
 temporalityToProto :: AggregationTemporality -> PM.AggregationTemporality

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -43,6 +43,9 @@ module OpenTelemetry.Exporter.OTLP.Span (
   -- * Default local endpoints
   otlpExporterHttpEndpoint,
   otlpExporterGRpcEndpoint,
+
+  -- * Protobuf conversion (testing)
+  immutableSpansToProtobuf,
 ) where
 
 import Codec.Compression.GZip
@@ -50,14 +53,14 @@ import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeAsyncException (..), SomeException (..), fromException, throwIO, try)
 import Control.Monad.IO.Class
-import Data.Bits (shiftL)
+import Data.Bits (shiftL, (.|.))
 import qualified Data.ByteString.Char8 as C
 import qualified Data.ByteString.Lazy as L
 import qualified Data.CaseInsensitive as CI
 import Data.Char (toLower)
-import Data.IORef (readIORef)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as H
+import Data.IORef (readIORef)
 import Data.Maybe
 import Data.ProtoLens.Encoding
 import Data.ProtoLens.Message
@@ -66,9 +69,9 @@ import qualified Data.Text.Encoding as T
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import qualified Data.Vector as Vector
+import qualified Data.Word
 import Lens.Micro
 import Network.HTTP.Client
-import qualified Network.HTTP.Client as HTTPClient
 import Network.HTTP.Simple (httpBS)
 import Network.HTTP.Types.Header
 import Network.HTTP.Types.Status
@@ -143,9 +146,9 @@ loadExporterEnvironmentVariables = liftIO $ do
     <*> lookupEnv "OTEL_EXPORTER_OTLP_CERTIFICATE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE"
     <*> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"
-    <*> (fmap decodeHeaders <$> lookupEnv "OTEL_EXPORTER_OTLP_HEADERS")
-    <*> (fmap decodeHeaders <$> lookupEnv "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
-    <*> (fmap decodeHeaders <$> lookupEnv "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
+    <*> (traverse decodeHeaders =<< lookupEnv "OTEL_EXPORTER_OTLP_HEADERS")
+    <*> (traverse decodeHeaders =<< lookupEnv "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+    <*> (traverse decodeHeaders =<< lookupEnv "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
     <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_COMPRESSION")
     <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
     <*> (traverse readCompressionFormat =<< lookupEnv "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
@@ -157,9 +160,11 @@ loadExporterEnvironmentVariables = liftIO $ do
     <*> (traverse readProtocol =<< lookupEnv "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
   where
     decodeHeaders hsString = case Baggage.decodeBaggageHeader $ C.pack hsString of
-      Left _ -> mempty
+      Left err -> do
+        putWarningLn $ "Warning: failed to parse OTEL_EXPORTER_OTLP_HEADERS: " <> show err
+        pure mempty
       Right baggageFmt ->
-        (\(k, v) -> (CI.mk $ Baggage.tokenValue k, T.encodeUtf8 $ Baggage.value v)) <$> H.toList (Baggage.values baggageFmt)
+        pure $ (\(k, v) -> (CI.mk $ Baggage.tokenValue k, T.encodeUtf8 $ Baggage.value v)) <$> H.toList (Baggage.values baggageFmt)
 
 
 {- |
@@ -326,17 +331,9 @@ httpOtlpExporter conf = do
                 sendReq req (backoffCount + 1)
 
       case eResp of
-        Left err@(HttpExceptionRequest req' e)
-          | HTTPClient.host req' == "localhost"
-          , HTTPClient.port req' == 4317 || HTTPClient.port req' == 4318
-          , ConnectionFailure _someExn <- e ->
-              do
-                pure $ Failure Nothing
-          | otherwise ->
-              if isRetryableException e
-                then exponentialBackoff
-                else pure $ Failure $ Just $ SomeException err
-        Left err -> do
+        Left err@(HttpExceptionRequest _req' e)
+          | isRetryableException e -> exponentialBackoff
+        Left err ->
           pure $ Failure $ Just $ SomeException err
         Right resp ->
           if isRetryableStatusCode (responseStatus resp)
@@ -351,9 +348,7 @@ httpOtlpExporter conf = do
                     sendReq req (backoffCount + 1)
             else
               if statusCode (responseStatus resp) >= 300
-                then do
-                  print resp
-                  pure $ Failure Nothing
+                then pure $ Failure Nothing
                 else pure Success
 
 
@@ -377,9 +372,8 @@ Internal helper.
 Get the HTTP host from the `OTLPExporterConfig`.
 -}
 httpHost :: OTLPExporterConfig -> String
-httpHost conf = fromMaybe defaultHost $ otlpEndpoint conf
+httpHost conf = fromMaybe defaultHost $ otlpTracesEndpoint conf <|> otlpEndpoint conf
   where
-    -- TODO shouldn't this be http://localhost:4317 ?
     defaultHost = "http://localhost:4318"
 
 
@@ -417,7 +411,7 @@ httpBaseHeaders :: OTLPExporterConfig -> Request -> [(HeaderName, C.ByteString)]
 httpBaseHeaders conf req =
   concat
     [ [(hContentType, httpProtobufMimeType)]
-    , [(hAcceptEncoding, httpProtobufMimeType)]
+    , [(hAccept, httpProtobufMimeType)]
     , fromMaybe [] (otlpHeaders conf)
     , fromMaybe [] (otlpTracesHeaders conf)
     , requestHeaders req
@@ -508,6 +502,8 @@ makeSpan completedSpan = do
         .~ spanIdBytes (OT.spanId $ OT.spanContext completedSpan)
       & Trace_Fields.traceState
         .~ T.decodeUtf8 (encodeTraceStateFull $ OT.traceState $ OT.spanContext completedSpan)
+      & Trace_Fields.flags
+        .~ fromIntegral (OT.traceFlagsValue $ OT.traceFlags $ OT.spanContext completedSpan)
       & Trace_Fields.name
         .~ OT.hotName hot
       & Trace_Fields.kind
@@ -525,7 +521,7 @@ makeSpan completedSpan = do
       & Trace_Fields.vec'attributes
         .~ attributesToProto (OT.hotAttributes hot)
       & Trace_Fields.droppedAttributesCount
-        .~ fromIntegral (getCount $ OT.hotAttributes hot)
+        .~ fromIntegral (getDropped $ OT.hotAttributes hot)
       & Trace_Fields.vec'events
         .~ fmap makeEvent (appendOnlyBoundedCollectionValues $ OT.hotEvents hot)
       & Trace_Fields.droppedEventsCount
@@ -568,7 +564,7 @@ makeEvent e =
     & Trace_Fields.vec'attributes
       .~ attributesToProto (OT.eventAttributes e)
     & Trace_Fields.droppedAttributesCount
-      .~ fromIntegral (getCount $ OT.eventAttributes e)
+      .~ fromIntegral (getDropped $ OT.eventAttributes e)
 
 
 {- |
@@ -579,21 +575,35 @@ makeLink :: OT.Link -> Span'Link
 makeLink l =
   defMessage
     & Trace_Fields.traceId
-      .~ traceIdBytes (OT.traceId $ OT.frozenLinkContext l)
+      .~ traceIdBytes (OT.traceId ctx)
     & Trace_Fields.spanId
-      .~ spanIdBytes (OT.spanId $ OT.frozenLinkContext l)
+      .~ spanIdBytes (OT.spanId ctx)
     & Trace_Fields.traceState
-      .~ T.decodeUtf8 (encodeTraceStateFull $ OT.traceState $ OT.frozenLinkContext l)
+      .~ T.decodeUtf8 (encodeTraceStateFull $ OT.traceState ctx)
+    & Trace_Fields.flags
+      .~ linkFlags ctx
     & Trace_Fields.vec'attributes
       .~ attributesToProto (OT.frozenLinkAttributes l)
     & Trace_Fields.droppedAttributesCount
-      .~ fromIntegral (getCount $ OT.frozenLinkAttributes l)
+      .~ fromIntegral (getDropped $ OT.frozenLinkAttributes l)
+  where
+    ctx = OT.frozenLinkContext l
 
 
 {- |
 Internal helper.
 Translate a collection of `Attributes` to a vector of OTLP `KeyValue` pairs.
 -}
+
+-- | OTLP link flags: bits 0-7 = W3C trace flags, bit 8 = HAS_IS_REMOTE, bit 9 = IS_REMOTE.
+linkFlags :: OT.SpanContext -> Data.Word.Word32
+linkFlags ctx =
+  let w8flags = fromIntegral (OT.traceFlagsValue $ OT.traceFlags ctx) :: Data.Word.Word32
+      hasIsRemote = 1 `shiftL` 8
+      isRemoteBit = if OT.isRemote ctx then 1 `shiftL` 9 else 0
+  in w8flags .|. hasIsRemote .|. isRemoteBit
+
+
 attributesToProto :: Attributes -> Vector KeyValue
 attributesToProto =
   V.fromList

--- a/exporters/prometheus/hs-opentelemetry-exporter-prometheus.cabal
+++ b/exporters/prometheus/hs-opentelemetry-exporter-prometheus.cabal
@@ -28,19 +28,26 @@ source-repository head
 library
   exposed-modules:
       OpenTelemetry.Exporter.Prometheus
+      OpenTelemetry.Exporter.Prometheus.PushGateway
+      OpenTelemetry.Exporter.Prometheus.WAI
   other-modules:
       Paths_hs_opentelemetry_exporter_prometheus
   hs-source-dirs:
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <5
+      async
+    , base >=4.7 && <5
     , bytestring
     , containers
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
+    , http-client
+    , http-types
     , text
     , unordered-containers
     , vector
+    , wai
+    , warp
   default-language: Haskell2010
 
 test-suite hs-opentelemetry-exporter-prometheus-test
@@ -53,9 +60,14 @@ test-suite hs-opentelemetry-exporter-prometheus-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
-    , hs-opentelemetry-exporter-prometheus
+    , bytestring
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-prometheus ==0.1.*
+    , hs-opentelemetry-semantic-conventions ==1.40.*
     , hspec
+    , http-types
     , text
     , vector
+    , wai
+    , wai-extra
   default-language: Haskell2010

--- a/exporters/prometheus/package.yaml
+++ b/exporters/prometheus/package.yaml
@@ -22,12 +22,17 @@ library:
   ghc-options: -Wall
   source-dirs: src
   dependencies:
+  - async
   - bytestring
   - containers
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
+  - http-client
+  - http-types
   - text
   - unordered-containers
   - vector
+  - wai
+  - warp
 
 tests:
   hs-opentelemetry-exporter-prometheus-test:
@@ -38,8 +43,13 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-api ^>= 0.3
-    - hs-opentelemetry-exporter-prometheus
+    - hs-opentelemetry-api ^>= 0.4
+    - hs-opentelemetry-exporter-prometheus == 0.1.*
+    - hs-opentelemetry-semantic-conventions ^>= 1.40
     - hspec
     - text
     - vector
+    - wai
+    - wai-extra
+    - http-types
+    - bytestring

--- a/exporters/prometheus/src/OpenTelemetry/Exporter/Prometheus/PushGateway.hs
+++ b/exporters/prometheus/src/OpenTelemetry/Exporter/Prometheus/PushGateway.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- | Prometheus PushGateway support.
+
+Periodically pushes metrics to a
+<https://github.com/prometheus/pushgateway Prometheus PushGateway>
+in text exposition format.
+
+@
+mgr <- newManager defaultManagerSettings
+(provider, env) <- createMeterProvider ...
+handle <- startPushGateway
+  PushGatewayConfig
+    { pushGatewayEndpoint = "http://pushgateway:9091"
+    , pushGatewayJob      = "my-service"
+    , pushGatewayIntervalSeconds = 15
+    }
+  mgr
+  (collectResourceMetrics env)
+@
+-}
+module OpenTelemetry.Exporter.Prometheus.PushGateway (
+  PushGatewayConfig (..),
+  pushMetricsOnce,
+  startPushGateway,
+) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async)
+import Control.Exception (SomeException, try)
+import Control.Monad (forever, void)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Vector (Vector)
+import Network.HTTP.Client (
+  Manager,
+  Request (..),
+  RequestBody (..),
+  httpNoBody,
+  parseRequest,
+ )
+import OpenTelemetry.Exporter.Metric (ResourceMetricsExport)
+import OpenTelemetry.Exporter.Prometheus (renderPrometheusText)
+
+
+data PushGatewayConfig = PushGatewayConfig
+  { pushGatewayEndpoint :: Text
+  -- ^ Base URL of the PushGateway, e.g. @\"http:\/\/pushgateway:9091\"@
+  , pushGatewayJob :: Text
+  -- ^ Value for the @job@ grouping key
+  , pushGatewayIntervalSeconds :: Int
+  -- ^ Seconds between pushes
+  }
+
+
+{- | Push the current metrics snapshot once.
+
+Uses HTTP PUT to @\/metrics\/job\/<job>@ which replaces all metrics
+for the given job.
+-}
+pushMetricsOnce :: PushGatewayConfig -> Manager -> IO (Vector ResourceMetricsExport) -> IO ()
+pushMetricsOnce config mgr collect = do
+  metrics <- collect
+  let body = LBS.fromStrict (TE.encodeUtf8 (renderPrometheusText metrics))
+      url =
+        T.unpack (pushGatewayEndpoint config)
+          <> "/metrics/job/"
+          <> T.unpack (pushGatewayJob config)
+  baseReq <- parseRequest url
+  let req =
+        baseReq
+          { method = "PUT"
+          , requestBody = RequestBodyLBS body
+          , requestHeaders = [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")]
+          }
+  void $ httpNoBody req mgr
+
+
+{- | Start a background thread that periodically pushes metrics.
+
+Returns an 'Async' handle. Errors during individual pushes are silently
+swallowed to avoid crashing the application; the next push will retry.
+-}
+startPushGateway :: PushGatewayConfig -> Manager -> IO (Vector ResourceMetricsExport) -> IO (Async ())
+startPushGateway config mgr collect = async $ forever $ do
+  _ <- try @SomeException $ pushMetricsOnce config mgr collect
+  threadDelay (pushGatewayIntervalSeconds config * 1000000)

--- a/exporters/prometheus/src/OpenTelemetry/Exporter/Prometheus/WAI.hs
+++ b/exporters/prometheus/src/OpenTelemetry/Exporter/Prometheus/WAI.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Prometheus metrics serving via WAI.
+
+Provides a WAI 'Middleware' and standalone 'Application' for serving
+OpenTelemetry metrics in Prometheus text exposition format.
+
+== Avoiding trace noise
+
+The 'prometheusMiddleware' short-circuits @\/metrics@ requests before they
+reach any inner middleware. Compose it __outside__ the OTel WAI tracing
+middleware so scrape requests never generate spans:
+
+@
+app <- prometheusMiddleware collect (otelMiddleware innerApp)
+@
+
+== Standalone server (spec-conformant)
+
+'startPrometheusServer' reads @OTEL_EXPORTER_PROMETHEUS_HOST@ (default
+@0.0.0.0@) and @OTEL_EXPORTER_PROMETHEUS_PORT@ (default @9464@) and runs
+a Warp server that serves the @\/metrics@ endpoint. No OTel instrumentation
+is applied to this server.
+-}
+module OpenTelemetry.Exporter.Prometheus.WAI (
+  -- * WAI integration
+  prometheusApplication,
+  prometheusMiddleware,
+  prometheusMiddleware',
+
+  -- * Standalone server
+  startPrometheusServer,
+  startPrometheusServerAsync,
+
+  -- * Configuration
+  PrometheusExporterConfig (..),
+  defaultPrometheusExporterConfig,
+) where
+
+import Control.Concurrent.Async (Async, async)
+import qualified Data.ByteString.Lazy as LBS
+import Data.String (fromString)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+import Data.Vector (Vector)
+import Network.HTTP.Types (status200)
+import Network.Wai (Application, Middleware, pathInfo, responseLBS)
+import qualified Network.Wai.Handler.Warp as Warp
+import OpenTelemetry.Exporter.Metric (ResourceMetricsExport)
+import OpenTelemetry.Exporter.Prometheus (renderPrometheusText)
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
+
+
+data PrometheusExporterConfig = PrometheusExporterConfig
+  { prometheusMetricsPath :: [Text]
+  -- ^ URL path segments to serve metrics at. Default: @[\"metrics\"]@
+  }
+
+
+defaultPrometheusExporterConfig :: PrometheusExporterConfig
+defaultPrometheusExporterConfig =
+  PrometheusExporterConfig
+    { prometheusMetricsPath = ["metrics"]
+    }
+
+
+{- | WAI 'Application' that always responds with Prometheus metrics.
+
+Every request path returns @200@ with the current metrics snapshot. Use
+this with 'Warp.runSettings' for a dedicated metrics server, or compose
+into a larger application with a router.
+-}
+prometheusApplication :: IO (Vector ResourceMetricsExport) -> Application
+prometheusApplication collect _request respond = do
+  metrics <- collect
+  let body = LBS.fromStrict (TE.encodeUtf8 (renderPrometheusText metrics))
+  respond $
+    responseLBS
+      status200
+      [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")]
+      body
+
+
+{- | WAI 'Middleware' that intercepts @\/metrics@ and serves Prometheus text.
+
+Requests whose 'pathInfo' matches the configured metrics path are handled
+immediately; all other requests pass through to the inner application.
+Place this __outside__ any OTel tracing middleware to avoid generating
+spans for Prometheus scrape requests.
+-}
+prometheusMiddleware :: IO (Vector ResourceMetricsExport) -> Middleware
+prometheusMiddleware = prometheusMiddleware' defaultPrometheusExporterConfig
+
+
+-- | Like 'prometheusMiddleware' with a custom 'PrometheusExporterConfig'.
+prometheusMiddleware' :: PrometheusExporterConfig -> IO (Vector ResourceMetricsExport) -> Middleware
+prometheusMiddleware' config collect inner request respond
+  | pathInfo request == prometheusMetricsPath config =
+      prometheusApplication collect request respond
+  | otherwise =
+      inner request respond
+
+
+{- | Start a standalone Prometheus HTTP server (blocking).
+
+Reads environment variables per the OpenTelemetry specification:
+
+* @OTEL_EXPORTER_PROMETHEUS_HOST@ — bind address (default @0.0.0.0@)
+* @OTEL_EXPORTER_PROMETHEUS_PORT@ — listen port (default @9464@)
+
+The server responds to every path with the metrics snapshot. No
+OpenTelemetry instrumentation is applied to this server.
+-}
+startPrometheusServer :: IO (Vector ResourceMetricsExport) -> IO ()
+startPrometheusServer collect = do
+  host <- maybe "0.0.0.0" id <$> lookupEnv "OTEL_EXPORTER_PROMETHEUS_HOST"
+  port <- maybe 9464 id . (>>= readMaybe) <$> lookupEnv "OTEL_EXPORTER_PROMETHEUS_PORT"
+  let settings =
+        Warp.setPort port $
+          Warp.setHost (fromString host) $
+            Warp.defaultSettings
+  Warp.runSettings settings (prometheusApplication collect)
+
+
+-- | Like 'startPrometheusServer' but runs in a background thread.
+startPrometheusServerAsync :: IO (Vector ResourceMetricsExport) -> IO (Async ())
+startPrometheusServerAsync collect = async (startPrometheusServer collect)

--- a/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
+++ b/instrumentation/cloudflare/hs-opentelemetry-instrumentation-cloudflare.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , case-insensitive
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-instrumentation-wai
     , text
     , unordered-containers

--- a/instrumentation/cloudflare/package.yaml
+++ b/instrumentation/cloudflare/package.yaml
@@ -25,7 +25,7 @@ library:
   source-dirs: src
   dependencies:
   - case-insensitive
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hs-opentelemetry-instrumentation-wai
   - text
   - unordered-containers

--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -34,6 +34,6 @@ library
   build-depends:
       base >=4.7 && <5
     , conduit
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , text
   default-language: Haskell2010

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -27,7 +27,7 @@ library:
   dependencies:
   - conduit
   - text
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
 
 # Test suite not yet implemented
 _tests:

--- a/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
+++ b/instrumentation/hspec/hs-opentelemetry-instrumentation-hspec.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,7 +32,7 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hspec-core >=2.9.4
     , mtl
     , text

--- a/instrumentation/hspec/package.yaml
+++ b/instrumentation/hspec/package.yaml
@@ -25,7 +25,7 @@ library:
   # ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hspec-core >= 2.9.4
   - text
   - mtl

--- a/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
+++ b/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,7 +39,7 @@ library
     , bytestring
     , case-insensitive
     , conduit
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-instrumentation-conduit >=0.0.1 && <0.2
     , http-client
     , http-conduit

--- a/instrumentation/http-client/package.yaml
+++ b/instrumentation/http-client/package.yaml
@@ -29,7 +29,7 @@ library:
   - bytestring
   - case-insensitive
   - conduit
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hs-opentelemetry-instrumentation-conduit >= 0.0.1 && < 0.2
   - http-client
   - http-conduit

--- a/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
+++ b/instrumentation/persistent/hs-opentelemetry-instrumentation-persistent.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , clock
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , mtl
     , persistent >=2.13.3
     , resourcet

--- a/instrumentation/persistent/package.yaml
+++ b/instrumentation/persistent/package.yaml
@@ -25,7 +25,7 @@ library:
   # ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - persistent >= 2.13.3
   - text
   - vault

--- a/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
+++ b/instrumentation/postgresql-simple/hs-opentelemetry-instrumentation-postgresql-simple.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , iproute
     , postgresql-libpq
     , postgresql-simple

--- a/instrumentation/postgresql-simple/package.yaml
+++ b/instrumentation/postgresql-simple/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - iproute
   - postgresql-simple
   - postgresql-libpq

--- a/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
+++ b/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -35,7 +35,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , http-types
     , iproute
     , network

--- a/instrumentation/wai/package.yaml
+++ b/instrumentation/wai/package.yaml
@@ -27,7 +27,7 @@ library:
   dependencies:
   - http-types
   - wai
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - vault
   - text
   - network

--- a/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
+++ b/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -35,7 +35,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-instrumentation-wai >=0.0.1 && <0.2
     , microlens
     , template-haskell

--- a/instrumentation/yesod/package.yaml
+++ b/instrumentation/yesod/package.yaml
@@ -25,7 +25,7 @@ library:
   ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hs-opentelemetry-instrumentation-wai >= 0.0.1 && < 0.2
   - microlens
   - template-haskell

--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -13,9 +13,6 @@ in rec {
   inherit pkgs;
 
   skipPackages = [
-    "hs-opentelemetry-exporter-handle"
-    "hs-opentelemetry-exporter-in-memory"
-    "hs-opentelemetry-exporter-otlp"
     "hs-opentelemetry-sdk"
     "hs-opentelemetry-instrumentation-cloudflare"
     "hs-opentelemetry-instrumentation-conduit"

--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -12,26 +12,7 @@
 in rec {
   inherit pkgs;
 
-  skipPackages = [
-    "hs-opentelemetry-sdk"
-    "hs-opentelemetry-instrumentation-cloudflare"
-    "hs-opentelemetry-instrumentation-conduit"
-    "hs-opentelemetry-instrumentation-ghc-metrics"
-    "hs-opentelemetry-instrumentation-hspec"
-    "hs-opentelemetry-instrumentation-http-client"
-    "hs-opentelemetry-instrumentation-hw-kafka-client"
-    "hs-opentelemetry-instrumentation-persistent"
-    "hs-opentelemetry-instrumentation-persistent-mysql"
-    "hs-opentelemetry-instrumentation-postgresql-simple"
-    "hs-opentelemetry-instrumentation-yesod"
-    "hs-opentelemetry-instrumentation-wai"
-    "hs-opentelemetry-instrumentation-tasty"
-    "hs-opentelemetry-utils-exceptions"
-    "hs-opentelemetry-vendor-honeycomb"
-    "hspec-example"
-    "hw-kafka-client-example"
-    "yesod-minimal"
-  ];
+  skipPackages = [];
 
   localPackages = {
     hs-opentelemetry-api = ../api;
@@ -47,17 +28,11 @@ in rec {
     hs-opentelemetry-propagator-jaeger = ../propagators/jaeger;
     hs-opentelemetry-propagator-xray = ../propagators/xray;
     hs-opentelemetry-propagator-w3c = ../propagators/w3c;
-    hs-opentelemetry-instrumentation-amazonka = ../instrumentation/amazonka;
     hs-opentelemetry-instrumentation-cloudflare = ../instrumentation/cloudflare;
-    hs-opentelemetry-instrumentation-co-log = ../instrumentation/co-log;
     hs-opentelemetry-instrumentation-conduit = ../instrumentation/conduit;
-    hs-opentelemetry-instrumentation-ghc-metrics = ../instrumentation/ghc-metrics;
-    hs-opentelemetry-instrumentation-gogol = ../instrumentation/gogol;
     hs-opentelemetry-instrumentation-hspec = ../instrumentation/hspec;
     hs-opentelemetry-instrumentation-http-client = ../instrumentation/http-client;
     hs-opentelemetry-instrumentation-hw-kafka-client = ../instrumentation/hw-kafka-client;
-    hs-opentelemetry-instrumentation-katip = ../instrumentation/katip;
-    hs-opentelemetry-instrumentation-monad-logger = ../instrumentation/monad-logger;
     hs-opentelemetry-instrumentation-persistent = ../instrumentation/persistent;
     hs-opentelemetry-instrumentation-persistent-mysql = ../instrumentation/persistent-mysql;
     hs-opentelemetry-instrumentation-postgresql-simple = ../instrumentation/postgresql-simple;
@@ -69,7 +44,6 @@ in rec {
 
     hspec-example = ../examples/hspec;
     hw-kafka-client-example = ../examples/hw-kafka-client-example;
-    otlp-demo = ../examples/otlp-demo;
     yesod-minimal = ../examples/yesod-minimal;
   };
 

--- a/propagators/b3/src/OpenTelemetry/Propagator/B3/Internal.hs
+++ b/propagators/b3/src/OpenTelemetry/Propagator/B3/Internal.hs
@@ -213,7 +213,7 @@ parseB3Single bs = do
                   guardByte bs afterSamp 0x2d -- '-'
                   let !parentStart = afterSamp + 1
                       !parentEnd = parentStart + 16
-                  if parentEnd > len
+                  if parentEnd /= len
                     then Nothing
                     else do
                       !psid <- either (const Nothing) Just (baseEncodedToSpanId Base16 (BS.take 16 (BS.drop parentStart bs)))

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -89,7 +89,7 @@ library
     , clock
     , containers
     , hashable
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-exporter-handle >=0.0.1 && <0.1
     , hs-opentelemetry-exporter-otlp ==0.1.*
     , hs-opentelemetry-propagator-b3 >=0.0.1 && <0.1

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -67,7 +67,7 @@ library:
   - vector
   - vector-builder
   # These are "distribution" packages
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hs-opentelemetry-propagator-w3c ^>= 0.1.0
   - hs-opentelemetry-exporter-handle ^>= 0.0.1
   - hs-opentelemetry-exporter-otlp ^>= 0.1

--- a/sdk/src/OpenTelemetry/Trace.hs
+++ b/sdk/src/OpenTelemetry/Trace.hs
@@ -323,7 +323,7 @@ requestHeadersToTextMap =
   textMapFromList . map (\(name, val) -> (decodeUtf8 (CI.original name), decodeUtf8 val))
 
 
-knownPropagators :: [(T.Text, Propagator Context RequestHeaders RequestHeaders)]
+knownPropagators :: [(T.Text, TextMapPropagator)]
 knownPropagators =
   [ ("tracecontext", w3cTraceContextPropagator)
   , ("baggage", w3cBaggagePropagator)
@@ -334,8 +334,8 @@ knownPropagators =
   ]
 
 
--- TODO, actually implement a registry systme
-readRegisteredPropagators :: IO [(T.Text, Propagator Context RequestHeaders RequestHeaders)]
+-- TODO, actually implement a registry system
+readRegisteredPropagators :: IO [(T.Text, TextMapPropagator)]
 readRegisteredPropagators = pure knownPropagators
 
 
@@ -417,7 +417,7 @@ detectPropagators = do
           propagatorsAndRegistryEntry = map (\k -> maybe (Left k) Right $ lookup k registeredPropagators) envPropagators
           (_notFound, propagators) = partitionEithers propagatorsAndRegistryEntry
       -- TODO log warn notFound
-      pure . headerPropagatorToTextMap $ mconcat propagators
+      pure $ mconcat propagators
 
 
 knownSamplers :: [(T.Text, Maybe T.Text -> Maybe Sampler)]

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -5,6 +5,10 @@ packages:
 - api
 - otlp
 - semantic-conventions
+- exporters/handle
+- exporters/in-memory
+- exporters/otlp
+- exporters/prometheus
 - propagators/b3
 - propagators/jaeger
 - propagators/xray

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -15,17 +15,11 @@ packages:
 - propagators/xray
 - propagators/datadog
 - propagators/w3c
-# amazonka excluded: amazonka-sso/sts-2.0 fail with GHC 9.10+ DuplicateRecordFields errors
 - instrumentation/cloudflare
-- instrumentation/co-log
 - instrumentation/conduit
-- instrumentation/ghc-metrics
-- instrumentation/gogol
 - instrumentation/hspec
 - instrumentation/http-client
 - instrumentation/hw-kafka-client
-- instrumentation/katip
-- instrumentation/monad-logger
 - instrumentation/persistent
 - instrumentation/persistent-mysql
 - instrumentation/postgresql-simple
@@ -33,7 +27,6 @@ packages:
 - instrumentation/wai
 - instrumentation/yesod
 - examples/hspec
-- examples/otlp-demo
 - examples/yesod-minimal
 - examples/hw-kafka-client-example
 

--- a/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
+++ b/utils/exceptions/hs-opentelemetry-utils-exceptions.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
       base >=4.7 && <5
     , exceptions
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-sdk ==0.1.*
     , text
   default-language: Haskell2010

--- a/utils/exceptions/package.yaml
+++ b/utils/exceptions/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
   - hs-opentelemetry-sdk ^>= 0.1
   - text
   - exceptions


### PR DESCRIPTION
Part of the hs-opentelemetry v0.4 stack. Stacked on #254.

See PR #219 for the base of this stack.

Made with [Cursor](https://cursor.com)