### PR TITLE
feat(instrumentation): update wai, http-client, and conduit for API 0.4

### DIFF
--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -1,12 +1,14 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-conduit
 version:            0.1.0.2
+synopsis:           OpenTelemetry instrumentation for Conduit streaming pipelines
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/conduit#readme>
+category:           OpenTelemetry, Conduit, Streaming
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
 author:             Ian Duncan, Jade Lovelace
@@ -34,6 +36,28 @@ library
   build-depends:
       base >=4.7 && <5
     , conduit
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
     , text
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-conduit-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_conduit
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , conduit
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-conduit ==0.1.*
+    , hs-opentelemetry-sdk ==0.1.*
+    , hspec
+    , resourcet
+    , text
+    , vector
   default-language: Haskell2010

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -10,8 +10,8 @@ extra-source-files:
 - ChangeLog.md
 
 # Metadata used when publishing your package
-# synopsis:            Short description of your package
-# category:            Web
+synopsis: OpenTelemetry instrumentation for Conduit streaming pipelines
+category: OpenTelemetry, Conduit, Streaming
 
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
@@ -27,10 +27,10 @@ library:
   dependencies:
   - conduit
   - text
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-instrumentation-conduit-test:
     main:                Spec.hs
     source-dirs:         test
@@ -39,4 +39,12 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-instrumentation-conduit
+    - hs-opentelemetry-instrumentation-conduit >= 0.1 && < 0.2
+    - hs-opentelemetry-api == 0.4.*
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - conduit
+    - hspec
+    - text
+    - resourcet
+    - vector

--- a/instrumentation/conduit/src/OpenTelemetry/Instrumentation/Conduit.hs
+++ b/instrumentation/conduit/src/OpenTelemetry/Instrumentation/Conduit.hs
@@ -1,13 +1,44 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+{- |
+Module      : OpenTelemetry.Instrumentation.Conduit
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Trace conduit pipeline stages as spans
+Stability   : experimental
+
+= Overview
+
+Wraps individual conduit pipeline stages in trace spans so you can see
+how time is spent across your streaming pipeline. Use 'inSpan' to run a
+sub-pipeline under a span; exceptions are recorded on the span and rethrown.
+
+= Quick example
+
+@
+import Conduit
+import Data.ByteString (ByteString)
+import OpenTelemetry.Instrumentation.Conduit (inSpan)
+import OpenTelemetry.Trace.Core (defaultSpanArguments)
+
+myPipeline :: Tracer -> ConduitT ByteString Void IO ()
+myPipeline tracer =
+  sourceFile "input.csv"
+    .| inSpan tracer "parse" defaultSpanArguments (\_ -> mapC parseRow)
+    .| inSpan tracer "transform" defaultSpanArguments (\_ -> mapC transformRow)
+    .| sinkFile "output.json"
+@
+-}
 module OpenTelemetry.Instrumentation.Conduit where
 
 import Conduit
 import Control.Exception (SomeException, throwIO)
 import Data.Text (Text)
 import GHC.Stack (HasCallStack)
+import OpenTelemetry.Attributes.Key (unkey)
 import OpenTelemetry.Context.ThreadLocal
+import qualified OpenTelemetry.SemanticConventions as SC
 import OpenTelemetry.Trace.Core hiding (getTracer)
 
 
@@ -26,5 +57,5 @@ inSpan t n args f = do
     $ \span_ -> do
       catchC (f span_) $ \e -> do
         liftIO $ do
-          recordException span_ [("exception.escaped", toAttribute True)] Nothing (e :: SomeException)
+          recordException span_ [(unkey SC.exception_escaped, toAttribute True)] Nothing (e :: SomeException)
           throwIO e

--- a/instrumentation/conduit/test/Spec.hs
+++ b/instrumentation/conduit/test/Spec.hs
@@ -1,3 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import Conduit
+import Control.Exception (SomeException, throwIO, try)
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef
+import qualified Data.Vector as V
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryListExporter)
+import OpenTelemetry.Instrumentation.Conduit (inSpan)
+import OpenTelemetry.Trace.Core (Event (..))
+import OpenTelemetry.Trace.Core hiding (inSpan)
+import OpenTelemetry.Util (appendOnlyBoundedCollectionValues)
+import System.IO.Error (userError)
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec spec
+
+
+withTracer :: (Tracer -> IO a) -> IO ([ImmutableSpan], a)
+withTracer action = do
+  (processor, ref) <- inMemoryListExporter
+  tp <- createTracerProvider [processor] emptyTracerProviderOptions
+  let tracer = makeTracer tp "test-conduit" tracerOptions
+  result <- action tracer
+  _ <- shutdownTracerProvider tp Nothing
+  spans <- readIORef ref
+  pure (spans, result)
+
+
+firstSpan :: [ImmutableSpan] -> IO ImmutableSpan
+firstSpan (s : _) = pure s
+firstSpan [] = expectationFailure "No spans recorded" >> pure (error "unreachable")
+
+
+spec :: Spec
+spec = describe "Conduit instrumentation" $ do
+  it "creates a span wrapping a conduit pipeline" $ do
+    (spans, result) <- withTracer $ \t ->
+      runConduitRes $
+        inSpan t "process-items" defaultSpanArguments $ \_s ->
+          yieldMany [1 :: Int, 2, 3] .| sinkList
+    result `shouldBe` [1, 2, 3]
+    s <- firstSpan spans
+    hot <- readIORef (spanHot s)
+    hotName hot `shouldBe` "process-items"
+
+  it "records exception on conduit failure" $ do
+    (spans, result) <- withTracer $ \t -> do
+      r <- try $
+        runConduitRes $
+          inSpan t "failing-conduit" defaultSpanArguments $ \_s ->
+            yieldMany [1 :: Int, 2, 3] .| mapMC (\_ -> liftIO $ throwIO $ userError "conduit-boom") .| sinkList
+      pure (r :: Either SomeException [Int])
+    case result of
+      Left _ -> pure ()
+      Right _ -> expectationFailure "expected exception"
+    s <- firstSpan spans
+    hot <- readIORef (spanHot s)
+    let events = V.toList $ appendOnlyBoundedCollectionValues $ hotEvents hot
+    any (\e -> eventName e == "exception") events `shouldBe` True

--- a/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
+++ b/instrumentation/http-client/hs-opentelemetry-instrumentation-http-client.cabal
@@ -1,12 +1,14 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-http-client
 version:            0.1.0.2
+synopsis:           OpenTelemetry instrumentation for http-client
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/http-client#readme>
+category:           OpenTelemetry, Telemetry, HTTP, Web
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
 author:             Ian Duncan, Jade Lovelace
@@ -26,6 +28,7 @@ source-repository head
 library
   exposed-modules:
       OpenTelemetry.Instrumentation.HttpClient
+      OpenTelemetry.Instrumentation.HttpClient.Metrics
       OpenTelemetry.Instrumentation.HttpClient.Raw
       OpenTelemetry.Instrumentation.HttpClient.Simple
   other-modules:
@@ -39,12 +42,35 @@ library
     , bytestring
     , case-insensitive
     , conduit
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-instrumentation-conduit >=0.0.1 && <0.2
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
     , http-client
     , http-conduit
     , http-types
     , text
     , unliftio
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-http-client-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_http_client
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-http-client ==0.1.*
+    , hs-opentelemetry-sdk ==0.1.*
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , hspec
+    , http-client
+    , http-types
+    , text
     , unordered-containers
   default-language: Haskell2010

--- a/instrumentation/http-client/package.yaml
+++ b/instrumentation/http-client/package.yaml
@@ -10,8 +10,8 @@ extra-source-files:
 - ChangeLog.md
 
 # Metadata used when publishing your package
-# synopsis:            Short description of your package
-# category:            Web
+synopsis: OpenTelemetry instrumentation for http-client
+category: OpenTelemetry, Telemetry, HTTP, Web
 
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
@@ -29,7 +29,8 @@ library:
   - bytestring
   - case-insensitive
   - conduit
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
   - hs-opentelemetry-instrumentation-conduit >= 0.0.1 && < 0.2
   - http-client
   - http-conduit
@@ -38,8 +39,7 @@ library:
   - unliftio
   - unordered-containers
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-instrumentation-http-client-test:
     main:                Spec.hs
     source-dirs:         test
@@ -48,4 +48,13 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-instrumentation-http-client
+    - hs-opentelemetry-instrumentation-http-client >= 0.1 && < 0.2
+    - hs-opentelemetry-api == 0.4.*
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
+    - hspec
+    - text
+    - http-client
+    - http-types
+    - unordered-containers

--- a/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient.hs
+++ b/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient.hs
@@ -1,24 +1,81 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{- | Offer a few options for HTTP instrumentation
+{- |
+Module      : OpenTelemetry.Instrumentation.HttpClient
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Automatic tracing for http-client requests
+Stability   : experimental
 
-- Add attributes via 'Request' and 'Response' to an existing span (Best)
-- Use internals to instrument a particular callsite using modifyRequest, modifyResponse (Next best)
-- Provide a middleware to pull from the thread-local state (okay)
-- Modify the global manager to pull from the thread-local state (least good, can't be helped sometimes)
+= Overview
 
-[New HTTP semantic conventions have been declared stable.](https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#migration-plan) Opt-in by setting the environment variable OTEL_SEMCONV_STABILITY_OPT_IN to
-- "http" - to use the stable conventions
-- "http/dup" - to emit both the old and the stable conventions
-Otherwise, the old conventions will be used. The stable conventions will replace the old conventions in the next major release of this library.
+Instruments outbound HTTP requests made with the @http-client@ library.
+Creates a @Client@ span for each request and injects trace context into
+request headers so downstream services can continue the trace.
+
+= Quick example
+
+The usual approach is to build a 'Manager' with traced settings once; spans
+use the tracer from 'OpenTelemetry.Instrumentation.HttpClient.Raw.httpTracerProvider'
+(typically the global tracer provider):
+
+@
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import OpenTelemetry.Instrumentation.HttpClient
+  ( httpLbs
+  , httpClientInstrumentationConfig
+  , newTracedManager
+  )
+
+main :: IO ()
+main = do
+  manager <- newTracedManager httpClientInstrumentationConfig tlsManagerSettings
+  response <- httpLbs request manager
+  ...
+@
+
+For custom manager settings, apply 'OpenTelemetry.Instrumentation.HttpClient.Raw.instrumentManagerSettings'
+before @newManager@. You can also use 'tracedHttpRequest' or the prime-suffixed
+variants (e.g. 'httpLbs'') for per-call configuration; see the export list below.
+
+= What gets traced
+
+Each outbound request creates a @Client@ span with:
+
+* Span name: @METHOD host@ (e.g. @GET api.example.com@)
+* @http.request.method@, @url.full@, @server.address@, @server.port@
+* @http.response.status_code@, @http.response.body.size@
+* Trace context injected into request headers via the global propagator
+
+[HTTP semantic conventions migration:](https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#migration-plan)
+opt in via @OTEL_SEMCONV_STABILITY_OPT_IN@ (@http@, @http/dup@, or default legacy).
 -}
 module OpenTelemetry.Instrumentation.HttpClient (
+  -- * Manager-level instrumentation (recommended)
+  instrumentManagerSettings,
+  newTracedManager,
+  httpClientPropagateHeaders,
+
+  -- * Per-request combinator
+  tracedHttpRequest,
+
+  -- * Drop-in replacements (zero-config)
   withResponse,
   httpLbs,
   httpNoBody,
   responseOpen,
+
+  -- * Drop-in replacements (with config)
+  withResponse',
+  httpLbs',
+  httpNoBody',
+  responseOpen',
+
+  -- * Configuration
   httpClientInstrumentationConfig,
   HttpClientInstrumentationConfig (..),
+
+  -- * Re-exports
   module X,
 ) where
 
@@ -31,9 +88,13 @@ import OpenTelemetry.Context.ThreadLocal
 import OpenTelemetry.Instrumentation.HttpClient.Raw (
   HttpClientInstrumentationConfig (..),
   httpClientInstrumentationConfig,
+  httpClientPropagateHeaders,
   httpTracerProvider,
+  instrumentManagerSettings,
   instrumentRequest,
   instrumentResponse,
+  newTracedManager,
+  tracedHttpRequest,
  )
 import OpenTelemetry.Trace.Core (
   SpanArguments (kind),
@@ -50,34 +111,70 @@ spanArgs :: SpanArguments
 spanArgs = defaultSpanArguments {kind = Client}
 
 
-{- | Instrumented variant of @Network.HTTP.Client.withResponse@
+{- | 'withResponse' with default instrumentation config.
 
- Perform a @Request@ using a connection acquired from the given @Manager@,
- and then provide the @Response@ to the given function. This function is
- fully exception safe, guaranteeing that the response will be closed when the
- inner function exits. It is defined as:
-
- > withResponse req man f = bracket (responseOpen req man) responseClose f
-
- It is recommended that you use this function in place of explicit calls to
- 'responseOpen' and 'responseClose'.
-
- You will need to use functions such as 'brRead' to consume the response
- body.
+@since 0.2.0.0
 -}
 withResponse
+  :: (MonadUnliftIO m, HasCallStack)
+  => Client.Request
+  -> Client.Manager
+  -> (Client.Response Client.BodyReader -> m a)
+  -> m a
+withResponse = withResponse' mempty
+
+
+{- | 'httpLbs' with default instrumentation config.
+
+@since 0.2.0.0
+-}
+httpLbs
+  :: (MonadUnliftIO m, HasCallStack)
+  => Client.Request
+  -> Client.Manager
+  -> m (Client.Response L.ByteString)
+httpLbs = httpLbs' mempty
+
+
+{- | 'httpNoBody' with default instrumentation config.
+
+@since 0.2.0.0
+-}
+httpNoBody
+  :: (MonadUnliftIO m, HasCallStack)
+  => Client.Request
+  -> Client.Manager
+  -> m (Client.Response ())
+httpNoBody = httpNoBody' mempty
+
+
+{- | 'responseOpen' with default instrumentation config.
+
+@since 0.2.0.0
+-}
+responseOpen
+  :: (MonadUnliftIO m, HasCallStack)
+  => Client.Request
+  -> Client.Manager
+  -> m (Client.Response Client.BodyReader)
+responseOpen = responseOpen' mempty
+
+
+{- | Instrumented 'Client.withResponse' with explicit config.
+
+@since 0.2.0.0
+-}
+withResponse'
   :: (MonadUnliftIO m, HasCallStack)
   => HttpClientInstrumentationConfig
   -> Client.Request
   -> Client.Manager
   -> (Client.Response Client.BodyReader -> m a)
   -> m a
-withResponse httpConf req man f = do
+withResponse' httpConf req man f = do
   tracer <- httpTracerProvider
   inSpan'' tracer "withResponse" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_wrSpan -> do
     ctxt <- getContext
-    -- TODO would like to capture the req/resp time specifically
-    -- inSpan "http.request" (defaultSpanArguments { startingKind = Client }) $ \httpReqSpan -> do
     req' <- instrumentRequest httpConf ctxt req
     runInIO <- askRunInIO
     liftIO $ Client.withResponse req' man $ \resp -> do
@@ -85,14 +182,17 @@ withResponse httpConf req man f = do
       runInIO $ f resp
 
 
-{- | A convenience wrapper around 'withResponse' which reads in the entire
- response body and immediately closes the connection. Note that this function
- performs fully strict I\/O, and only uses a lazy ByteString in its response
- for memory efficiency. If you are anticipating a large response body, you
- are encouraged to use 'withResponse' and 'brRead' instead.
+{- | Instrumented 'Client.httpLbs' with explicit config.
+
+@since 0.2.0.0
 -}
-httpLbs :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> m (Client.Response L.ByteString)
-httpLbs httpConf req man = do
+httpLbs'
+  :: (MonadUnliftIO m, HasCallStack)
+  => HttpClientInstrumentationConfig
+  -> Client.Request
+  -> Client.Manager
+  -> m (Client.Response L.ByteString)
+httpLbs' httpConf req man = do
   tracer <- httpTracerProvider
   inSpan'' tracer "httpLbs" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_ -> do
     ctxt <- getContext
@@ -102,11 +202,17 @@ httpLbs httpConf req man = do
     pure resp
 
 
-{- | A convenient wrapper around 'withResponse' which ignores the response
- body. This is useful, for example, when performing a HEAD request.
+{- | Instrumented 'Client.httpNoBody' with explicit config.
+
+@since 0.2.0.0
 -}
-httpNoBody :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> m (Client.Response ())
-httpNoBody httpConf req man = do
+httpNoBody'
+  :: (MonadUnliftIO m, HasCallStack)
+  => HttpClientInstrumentationConfig
+  -> Client.Request
+  -> Client.Manager
+  -> m (Client.Response ())
+httpNoBody' httpConf req man = do
   tracer <- httpTracerProvider
   inSpan'' tracer "httpNoBody" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_ -> do
     ctxt <- getContext
@@ -116,36 +222,17 @@ httpNoBody httpConf req man = do
     pure resp
 
 
-{- | The most low-level function for initiating an HTTP request.
+{- | Instrumented 'Client.responseOpen' with explicit config.
 
- The first argument to this function gives a full specification
- on the request: the host to connect to, whether to use SSL,
- headers, etc. Please see 'Request' for full details.  The
- second argument specifies which 'Manager' should be used.
-
- This function then returns a 'Response' with a
- 'BodyReader'.  The 'Response' contains the status code
- and headers that were sent back to us, and the
- 'BodyReader' contains the body of the request.  Note
- that this 'BodyReader' allows you to have fully
- interleaved IO actions during your HTTP download, making it
- possible to download very large responses in constant memory.
-
- An important note: the response body returned by this function represents a
- live HTTP connection. As such, if you do not use the response body, an open
- socket will be retained indefinitely. You must be certain to call
- 'responseClose' on this response to free up resources.
-
- This function automatically performs any necessary redirects, as specified
- by the 'redirectCount' setting.
-
- When implementing a (reverse) proxy using this function or relating
- functions, it's wise to remove Transfer-Encoding:, Content-Length:,
- Content-Encoding: and Accept-Encoding: from request and response
- headers to be relayed.
+@since 0.2.0.0
 -}
-responseOpen :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Client.Request -> Client.Manager -> m (Client.Response Client.BodyReader)
-responseOpen httpConf req man = do
+responseOpen'
+  :: (MonadUnliftIO m, HasCallStack)
+  => HttpClientInstrumentationConfig
+  -> Client.Request
+  -> Client.Manager
+  -> m (Client.Response Client.BodyReader)
+responseOpen' httpConf req man = do
   tracer <- httpTracerProvider
   inSpan'' tracer "responseOpen" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_ -> do
     ctxt <- getContext

--- a/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient/Metrics.hs
+++ b/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient/Metrics.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module      :  OpenTelemetry.Instrumentation.HttpClient.Metrics
+Copyright   :  (c) Ian Duncan, 2026
+License     :  BSD-3
+Description :  HTTP client metrics per the OpenTelemetry stable HTTP semantic conventions.
+Stability   :  experimental
+
+Recorded instruments:
+
+* @http.client.request.duration@  — 'Histogram' (seconds)
+* @http.client.active_requests@   — 'UpDownCounter'
+
+Attributes: @http.request.method@, @http.response.status_code@, @server.address@,
+@server.port@.
+
+Usage:
+
+@
+meter <- getMeter provider (instrumentationLibrary "hs-opentelemetry-http-client" "0.1.0")
+metrics <- newHttpClientMetrics meter
+-- wrap individual requests:
+resp <- withHttpClientMetrics metrics request (httpLbs request manager)
+@
+-}
+module OpenTelemetry.Instrumentation.HttpClient.Metrics (
+  HttpClientMetrics (..),
+  newHttpClientMetrics,
+  withHttpClientMetrics,
+) where
+
+import Control.Exception (SomeException, catch, throwIO)
+import Data.Int (Int64)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import GHC.Clock (getMonotonicTimeNSec)
+import Network.HTTP.Client (Request (..), Response (..))
+import Network.HTTP.Types (statusCode)
+import OpenTelemetry.Attributes (Attributes, addAttribute, defaultAttributeLimits, emptyAttributes)
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Metric.Core (
+  AdvisoryParameters (..),
+  Counter (..),
+  Histogram (..),
+  Meter (..),
+  UpDownCounter (..),
+  defaultAdvisoryParameters,
+ )
+import qualified OpenTelemetry.SemanticConventions as SC
+
+
+data HttpClientMetrics = HttpClientMetrics
+  { httpClientDuration :: !Histogram
+  , httpClientActiveRequests :: !(UpDownCounter Int64)
+  , httpClientRequestCount :: !(Counter Int64)
+  }
+
+
+newHttpClientMetrics :: Meter -> IO HttpClientMetrics
+newHttpClientMetrics m = do
+  dur <-
+    meterCreateHistogram
+      m
+      "http.client.request.duration"
+      (Just "s")
+      (Just "Duration of outbound HTTP requests")
+      defaultAdvisoryParameters
+        { advisoryExplicitBucketBoundaries =
+            Just [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+        }
+  active <-
+    meterCreateUpDownCounterInt64
+      m
+      "http.client.active_requests"
+      (Just "{request}")
+      (Just "Number of active outbound HTTP requests")
+      defaultAdvisoryParameters
+  cnt <-
+    meterCreateCounterInt64
+      m
+      "http.client.request.count"
+      (Just "{request}")
+      (Just "Total number of outbound HTTP requests")
+      defaultAdvisoryParameters
+  pure
+    HttpClientMetrics
+      { httpClientDuration = dur
+      , httpClientActiveRequests = active
+      , httpClientRequestCount = cnt
+      }
+
+
+{- | Wrap an HTTP request action to record metrics.
+
+@
+resp <- withHttpClientMetrics metrics req (httpLbs req manager)
+@
+-}
+withHttpClientMetrics :: HttpClientMetrics -> Request -> IO (Response body) -> IO (Response body)
+withHttpClientMetrics hcm req action = do
+  let reqAttrs = requestAttributes req
+  upDownCounterAdd (httpClientActiveRequests hcm) 1 reqAttrs
+  startNs <- getMonotonicTimeNSec
+  result <-
+    (Right <$> action)
+      `catch` (\(e :: SomeException) -> pure (Left e))
+  endNs <- getMonotonicTimeNSec
+  upDownCounterAdd (httpClientActiveRequests hcm) (-1) reqAttrs
+  let durationSec = fromIntegral (endNs - startNs) / 1000000000 :: Double
+  case result of
+    Right resp -> do
+      let sc = statusCode (responseStatus resp)
+          respAttrs = addAttribute defaultAttributeLimits reqAttrs (unkey SC.http_response_statusCode) sc
+      histogramRecord (httpClientDuration hcm) durationSec respAttrs
+      counterAdd (httpClientRequestCount hcm) 1 respAttrs
+      pure resp
+    Left ex -> do
+      let errAttrs = addAttribute defaultAttributeLimits reqAttrs (unkey SC.error_type) (T.pack (show (typeOf ex)))
+      histogramRecord (httpClientDuration hcm) durationSec errAttrs
+      counterAdd (httpClientRequestCount hcm) 1 errAttrs
+      throwIO ex
+  where
+    typeOf :: SomeException -> String
+    typeOf e = case words (show e) of
+      (w : _) -> w
+      [] -> "unknown"
+
+
+requestAttributes :: Request -> Attributes
+requestAttributes req =
+  let a1 = addAttribute defaultAttributeLimits emptyAttributes (unkey SC.http_request_method) (T.decodeUtf8 (method req))
+      a2 = addAttribute defaultAttributeLimits a1 (unkey SC.server_address) (T.decodeUtf8 (host req))
+      a3 = addAttribute defaultAttributeLimits a2 (unkey SC.server_port) (port req)
+  in a3

--- a/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient/Raw.hs
+++ b/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient/Raw.hs
@@ -432,7 +432,6 @@ instrumentResponse
 instrumentResponse conf ctxt resp = do
   propagator <- liftIO getGlobalTextMapPropagator
   ctxt' <- extractFromHeaders propagator (responseHeaders resp) ctxt
-  _ <- attachContext ctxt'
   forM_ (lookupSpan ctxt') $ \s ->
     instrumentResponseOnSpan conf s resp
 

--- a/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient/Simple.hs
+++ b/instrumentation/http-client/src/OpenTelemetry/Instrumentation/HttpClient/Simple.hs
@@ -1,7 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
+{- | OpenTelemetry instrumentation for @http-conduit@ \/ @Network.HTTP.Simple@.
+
+Provides drop-in replacements for the @http-conduit@ convenience functions.
+Zero-config versions use default settings; primed variants accept
+'HttpClientInstrumentationConfig'.
+
+For Manager-level instrumentation (recommended for most applications), see
+"OpenTelemetry.Instrumentation.HttpClient".
+-}
 module OpenTelemetry.Instrumentation.HttpClient.Simple (
+  -- * Zero-config drop-in replacements
   httpBS,
   httpLBS,
   httpNoBody,
@@ -10,8 +20,22 @@ module OpenTelemetry.Instrumentation.HttpClient.Simple (
   httpSink,
   httpSource,
   withResponse,
+
+  -- * Explicit-config variants
+  httpBS',
+  httpLBS',
+  httpNoBody',
+  httpJSON',
+  httpJSONEither',
+  httpSink',
+  httpSource',
+  withResponse',
+
+  -- * Configuration
   httpClientInstrumentationConfig,
   HttpClientInstrumentationConfig (..),
+
+  -- * Re-exports
   module X,
 ) where
 
@@ -34,8 +58,44 @@ spanArgs :: SpanArguments
 spanArgs = defaultSpanArguments {kind = Client}
 
 
-httpBS :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response B.ByteString)
-httpBS httpConf req = do
+-- Zero-config versions
+
+httpBS :: (MonadUnliftIO m, HasCallStack) => Simple.Request -> m (Simple.Response B.ByteString)
+httpBS = httpBS' mempty
+
+
+httpLBS :: (MonadUnliftIO m, HasCallStack) => Simple.Request -> m (Simple.Response L.ByteString)
+httpLBS = httpLBS' mempty
+
+
+httpNoBody :: (MonadUnliftIO m, HasCallStack) => Simple.Request -> m (Simple.Response ())
+httpNoBody = httpNoBody' mempty
+
+
+httpJSON :: (MonadUnliftIO m, FromJSON a, HasCallStack) => Simple.Request -> m (Simple.Response a)
+httpJSON = httpJSON' mempty
+
+
+httpJSONEither :: (FromJSON a, MonadUnliftIO m, HasCallStack) => Simple.Request -> m (Simple.Response (Either Simple.JSONException a))
+httpJSONEither = httpJSONEither' mempty
+
+
+httpSink :: (MonadUnliftIO m, HasCallStack) => Simple.Request -> (Simple.Response () -> ConduitM B.ByteString Void m a) -> m a
+httpSink = httpSink' mempty
+
+
+httpSource :: (MonadUnliftIO m, MonadResource m, HasCallStack) => Simple.Request -> (Simple.Response (ConduitM i B.ByteString m ()) -> ConduitM i o m r) -> ConduitM i o m r
+httpSource = httpSource' mempty
+
+
+withResponse :: (MonadUnliftIO m, HasCallStack) => Simple.Request -> (Simple.Response (ConduitM i B.ByteString m ()) -> m a) -> m a
+withResponse = withResponse' mempty
+
+
+-- Explicit-config variants
+
+httpBS' :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response B.ByteString)
+httpBS' httpConf req = do
   tracer <- httpTracerProvider
   inSpan' tracer "httpBS" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext
@@ -45,8 +105,8 @@ httpBS httpConf req = do
     pure resp
 
 
-httpLBS :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response L.ByteString)
-httpLBS httpConf req = do
+httpLBS' :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response L.ByteString)
+httpLBS' httpConf req = do
   tracer <- httpTracerProvider
   inSpan' tracer "httpLBS" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext
@@ -56,8 +116,8 @@ httpLBS httpConf req = do
     pure resp
 
 
-httpNoBody :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response ())
-httpNoBody httpConf req = do
+httpNoBody' :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response ())
+httpNoBody' httpConf req = do
   tracer <- httpTracerProvider
   inSpan' tracer "httpNoBody" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext
@@ -67,8 +127,8 @@ httpNoBody httpConf req = do
     pure resp
 
 
-httpJSON :: (MonadUnliftIO m, FromJSON a, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response a)
-httpJSON httpConf req = do
+httpJSON' :: (MonadUnliftIO m, FromJSON a, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response a)
+httpJSON' httpConf req = do
   tracer <- httpTracerProvider
   inSpan' tracer "httpJSON" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext
@@ -78,8 +138,8 @@ httpJSON httpConf req = do
     pure resp
 
 
-httpJSONEither :: (FromJSON a, MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response (Either Simple.JSONException a))
-httpJSONEither httpConf req = do
+httpJSONEither' :: (FromJSON a, MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> m (Simple.Response (Either Simple.JSONException a))
+httpJSONEither' httpConf req = do
   tracer <- httpTracerProvider
   inSpan' tracer "httpJSONEither" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext
@@ -89,8 +149,8 @@ httpJSONEither httpConf req = do
     pure resp
 
 
-httpSink :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> (Simple.Response () -> ConduitM B.ByteString Void m a) -> m a
-httpSink httpConf req f = do
+httpSink' :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> (Simple.Response () -> ConduitM B.ByteString Void m a) -> m a
+httpSink' httpConf req f = do
   tracer <- httpTracerProvider
   inSpan' tracer "httpSink" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext
@@ -100,8 +160,8 @@ httpSink httpConf req f = do
       f resp
 
 
-httpSource :: (MonadUnliftIO m, MonadResource m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> (Simple.Response (ConduitM i B.ByteString m ()) -> ConduitM i o m r) -> ConduitM i o m r
-httpSource httpConf req f = do
+httpSource' :: (MonadUnliftIO m, MonadResource m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> (Simple.Response (ConduitM i B.ByteString m ()) -> ConduitM i o m r) -> ConduitM i o m r
+httpSource' httpConf req f = do
   tracer <- httpTracerProvider
   Conduit.inSpan tracer "httpSource" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- lift getContext
@@ -111,8 +171,8 @@ httpSource httpConf req f = do
       f resp
 
 
-withResponse :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> (Simple.Response (ConduitM i B.ByteString m ()) -> m a) -> m a
-withResponse httpConf req f = do
+withResponse' :: (MonadUnliftIO m, HasCallStack) => HttpClientInstrumentationConfig -> Simple.Request -> (Simple.Response (ConduitM i B.ByteString m ()) -> m a) -> m a
+withResponse' httpConf req f = do
   tracer <- httpTracerProvider
   inSpan' tracer "withResponse" (addAttributesToSpanArguments callerAttributes spanArgs) $ \_s -> do
     ctxt <- getContext

--- a/instrumentation/http-client/test/Spec.hs
+++ b/instrumentation/http-client/test/Spec.hs
@@ -1,3 +1,106 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Data.IORef
+import qualified Data.Text as T
+import Network.HTTP.Client (parseRequest)
+import OpenTelemetry.Attributes (lookupAttribute)
+import OpenTelemetry.Attributes.Attribute (Attribute (..), PrimitiveAttribute (..))
+import OpenTelemetry.Attributes.Key (unkey)
+import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryListExporter)
+import OpenTelemetry.Instrumentation.HttpClient.Raw
+import qualified OpenTelemetry.SemanticConventions as SC
+import OpenTelemetry.Trace.Core
+import System.Environment (setEnv)
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = do
+  setEnv "OTEL_SEMCONV_STABILITY_OPT_IN" "http"
+  hspec spec
+
+
+withTestSpan :: T.Text -> (Context.Context -> Span -> IO a) -> IO (ImmutableSpan, a)
+withTestSpan name action = do
+  (processor, ref) <- inMemoryListExporter
+  tp <- createTracerProvider [processor] emptyTracerProviderOptions
+  setGlobalTracerProvider tp
+  let tracer = makeTracer tp "test" tracerOptions
+  s <- createSpan tracer Context.empty name (defaultSpanArguments {kind = Client})
+  let ctx = Context.insertSpan s Context.empty
+  result <- action ctx s
+  endSpan s Nothing
+  _ <- shutdownTracerProvider tp Nothing
+  spans <- readIORef ref
+  case spans of
+    (clientSpan : _) -> pure (clientSpan, result)
+    [] -> error "No spans recorded"
+
+
+spec :: Spec
+spec = describe "HTTP client instrumentation" $ do
+  describe "instrumentRequest" $ do
+    it "sets span name to HTTP method (low cardinality)" $ do
+      req <- parseRequest "http://example.com/users/123?q=test"
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest httpClientInstrumentationConfig ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      hotName hot `shouldBe` "GET"
+
+    it "uses requestName override when provided" $ do
+      req <- parseRequest "http://example.com/users/123"
+      let conf = httpClientInstrumentationConfig {requestName = Just "custom-op"}
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest conf ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      hotName hot `shouldBe` "custom-op"
+
+    it "sets http.request.method" $ do
+      req <- parseRequest "POST http://example.com/api/data"
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest httpClientInstrumentationConfig ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      lookupAttribute (hotAttributes hot) (unkey SC.http_request_method)
+        `shouldBe` Just (AttributeValue (TextAttribute "POST"))
+
+    it "sets url.path" $ do
+      req <- parseRequest "http://example.com/api/data"
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest httpClientInstrumentationConfig ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      lookupAttribute (hotAttributes hot) (unkey SC.url_path)
+        `shouldBe` Just (AttributeValue (TextAttribute "/api/data"))
+
+    it "sets server.address" $ do
+      req <- parseRequest "http://example.com/test"
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest httpClientInstrumentationConfig ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      lookupAttribute (hotAttributes hot) (unkey SC.server_address)
+        `shouldBe` Just (AttributeValue (TextAttribute "example.com"))
+
+    it "sets server.port" $ do
+      req <- parseRequest "http://example.com:8080/test"
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest httpClientInstrumentationConfig ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      lookupAttribute (hotAttributes hot) (unkey SC.server_port)
+        `shouldBe` Just (AttributeValue (IntAttribute 8080))
+
+    it "sets url.scheme to http" $ do
+      req <- parseRequest "http://example.com/test"
+      (clientSpan, _) <- withTestSpan "HTTP" $ \ctx _s -> do
+        _ <- instrumentRequest httpClientInstrumentationConfig ctx req
+        pure ()
+      hot <- readIORef (spanHot clientSpan)
+      lookupAttribute (hotAttributes hot) (unkey SC.url_scheme)
+        `shouldBe` Just (AttributeValue (TextAttribute "http"))

--- a/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
+++ b/instrumentation/wai/hs-opentelemetry-instrumentation-wai.cabal
@@ -28,6 +28,7 @@ source-repository head
 library
   exposed-modules:
       OpenTelemetry.Instrumentation.Wai
+      OpenTelemetry.Instrumentation.Wai.Metrics
   other-modules:
       Paths_hs_opentelemetry_instrumentation_wai
   hs-source-dirs:
@@ -35,9 +36,35 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , case-insensitive
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
     , http-types
     , iproute
+    , network
+    , text
+    , unordered-containers
+    , vault
+    , wai
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-wai-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_wai
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-wai ==0.1.*
+    , hs-opentelemetry-sdk ==0.1.*
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , hspec
+    , http-types
     , network
     , text
     , unordered-containers

--- a/instrumentation/wai/package.yaml
+++ b/instrumentation/wai/package.yaml
@@ -25,17 +25,18 @@ library:
   ghc-options: -Wall
   source-dirs: src
   dependencies:
+  - case-insensitive
   - http-types
   - wai
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
   - vault
   - text
   - network
   - iproute
   - unordered-containers
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-instrumentation-wai-test:
     main:                Spec.hs
     source-dirs:         test
@@ -44,4 +45,15 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-instrumentation-wai
+    - hs-opentelemetry-instrumentation-wai >= 0.1 && < 0.2
+    - hs-opentelemetry-api == 0.4.*
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
+    - hspec
+    - text
+    - wai
+    - http-types
+    - vault
+    - network
+    - unordered-containers

--- a/instrumentation/wai/src/OpenTelemetry/Instrumentation/Wai/Metrics.hs
+++ b/instrumentation/wai/src/OpenTelemetry/Instrumentation/Wai/Metrics.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      :  OpenTelemetry.Instrumentation.Wai.Metrics
+Copyright   :  (c) Ian Duncan, 2026
+License     :  BSD-3
+Description :  WAI middleware that records HTTP server metrics per the OpenTelemetry HTTP semantic conventions (stable, Nov 2023).
+Stability   :  experimental
+
+Recorded instruments:
+
+* @http.server.request.duration@  — 'Histogram' (seconds)
+* @http.server.active_requests@   — 'UpDownCounter'
+
+Attributes follow the stable HTTP semantic conventions:
+@http.request.method@, @http.response.status_code@, @url.scheme@,
+@network.protocol.version@, @http.route@ (if set on the span).
+
+Usage:
+
+@
+meter <- getMeter provider (instrumentationLibrary "hs-opentelemetry-wai" "0.1.0")
+metricsMiddleware <- newWaiMetricsMiddleware meter
+let app = metricsMiddleware (tracingMiddleware myApp)
+@
+-}
+module OpenTelemetry.Instrumentation.Wai.Metrics (
+  newWaiMetricsMiddleware,
+  WaiMetrics (..),
+  newWaiMetrics,
+) where
+
+import Control.Exception (finally)
+import Data.Int (Int64)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import GHC.Clock (getMonotonicTimeNSec)
+import Network.HTTP.Types (HttpVersion (..), statusCode)
+import Network.Wai (Middleware, Request (..), responseStatus)
+import OpenTelemetry.Attributes (Attributes, addAttribute, defaultAttributeLimits, emptyAttributes)
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Metric.Core (
+  AdvisoryParameters (..),
+  Counter (..),
+  Histogram (..),
+  Meter (..),
+  UpDownCounter (..),
+  defaultAdvisoryParameters,
+ )
+import qualified OpenTelemetry.SemanticConventions as SC
+
+
+data WaiMetrics = WaiMetrics
+  { waiDurationHistogram :: !Histogram
+  , waiActiveRequests :: !(UpDownCounter Int64)
+  , waiRequestCounter :: !(Counter Int64)
+  }
+
+
+{- | Allocate metric instruments on the given 'Meter'.
+Call once during application startup.
+-}
+newWaiMetrics :: Meter -> IO WaiMetrics
+newWaiMetrics m = do
+  dur <-
+    meterCreateHistogram
+      m
+      "http.server.request.duration"
+      (Just "s")
+      (Just "Duration of inbound HTTP requests")
+      defaultAdvisoryParameters
+        { advisoryExplicitBucketBoundaries =
+            Just [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+        }
+  active <-
+    meterCreateUpDownCounterInt64
+      m
+      "http.server.active_requests"
+      (Just "{request}")
+      (Just "Number of active HTTP server requests")
+      defaultAdvisoryParameters
+  reqCount <-
+    meterCreateCounterInt64
+      m
+      "http.server.request.count"
+      (Just "{request}")
+      (Just "Total number of HTTP server requests")
+      defaultAdvisoryParameters
+  pure
+    WaiMetrics
+      { waiDurationHistogram = dur
+      , waiActiveRequests = active
+      , waiRequestCounter = reqCount
+      }
+
+
+{- | Create a WAI 'Middleware' that records HTTP server metrics.
+
+Should be composed with tracing middleware so that @http.route@ can be
+extracted from the span attributes.
+-}
+newWaiMetricsMiddleware :: Meter -> IO Middleware
+newWaiMetricsMiddleware m = do
+  wm <- newWaiMetrics m
+  pure (metricsMiddleware wm)
+
+
+metricsMiddleware :: WaiMetrics -> Middleware
+metricsMiddleware wm app req sendResp = do
+  let methodAttr = addAttribute defaultAttributeLimits emptyAttributes (unkey SC.http_request_method) (T.decodeUtf8 (requestMethod req))
+      reqAttrs =
+        addAttribute defaultAttributeLimits methodAttr (unkey SC.url_scheme) $
+          if isSecure req then ("https" :: T.Text) else "http"
+  upDownCounterAdd (waiActiveRequests wm) 1 reqAttrs
+  startNs <- getMonotonicTimeNSec
+  app req $ \resp ->
+    flip finally (upDownCounterAdd (waiActiveRequests wm) (-1) reqAttrs) $ do
+      result <- sendResp resp
+      endNs <- getMonotonicTimeNSec
+      let sc = statusCode (responseStatus resp)
+          durationSec = fromIntegral (endNs - startNs) / 1000000000 :: Double
+          respAttrs = addResponseAttrs sc req reqAttrs
+      histogramRecord (waiDurationHistogram wm) durationSec respAttrs
+      counterAdd (waiRequestCounter wm) 1 respAttrs
+      pure result
+
+
+addResponseAttrs :: Int -> Request -> Attributes -> Attributes
+addResponseAttrs sc req attrs =
+  let a1 = addAttribute defaultAttributeLimits attrs (unkey SC.http_response_statusCode) sc
+      a2 =
+        addAttribute defaultAttributeLimits a1 (unkey SC.network_protocol_version) $
+          httpVersionToText (httpVersion req)
+  in a2
+
+
+httpVersionToText :: HttpVersion -> T.Text
+httpVersionToText (HttpVersion major minor)
+  | minor == 0 = T.pack (show major)
+  | otherwise = T.pack (show major <> "." <> show minor)

--- a/instrumentation/wai/test/Spec.hs
+++ b/instrumentation/wai/test/Spec.hs
@@ -1,3 +1,172 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Data.IORef
+import Data.Text (Text)
+import qualified Data.Vault.Lazy as Vault
+import Network.HTTP.Types
+import Network.Socket (SockAddr (..))
+import Network.Wai (defaultRequest, responseLBS)
+import Network.Wai.Internal (Request (..), ResponseReceived (..))
+import OpenTelemetry.Attributes (lookupAttribute)
+import OpenTelemetry.Attributes.Attribute (Attribute (..), PrimitiveAttribute (..))
+import OpenTelemetry.Attributes.Key (unkey)
+import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Context.ThreadLocal (getContext)
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryListExporter)
+import OpenTelemetry.Instrumentation.Wai (newOpenTelemetryWaiMiddleware')
+import qualified OpenTelemetry.SemanticConventions as SC
+import OpenTelemetry.Trace.Core
+import System.Environment (setEnv)
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = do
+  setEnv "OTEL_SEMCONV_STABILITY_OPT_IN" "http"
+  hspec spec
+
+
+mkRequest :: StdMethod -> [Header] -> Request
+mkRequest method_ headers =
+  defaultRequest
+    { requestMethod = renderStdMethod method_
+    , rawPathInfo = "/users/123"
+    , requestHeaders = headers
+    , remoteHost = SockAddrInet 12345 0x0100007f
+    , vault = Vault.empty
+    }
+
+
+withTestMiddleware :: (TracerProvider -> IO ResponseReceived) -> IO [ImmutableSpan]
+withTestMiddleware action = do
+  (processor, ref) <- inMemoryListExporter
+  tp <- createTracerProvider [processor] emptyTracerProviderOptions
+  _ <- action tp
+  _ <- shutdownTracerProvider tp Nothing
+  readIORef ref
+
+
+firstSpan :: [ImmutableSpan] -> ImmutableSpan
+firstSpan (s : _) = s
+firstSpan [] = error "No spans recorded"
+
+
+spec :: Spec
+spec = describe "WAI middleware" $ do
+  describe "span naming" $ do
+    it "initial span name is just the HTTP method (low cardinality)" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      hotName hot `shouldBe` "GET"
+
+    it "updates span name to {method} {route} when http.route is set" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = do
+              ctx <- getContext
+              case Context.lookupSpan ctx of
+                Just s -> addAttribute s (unkey SC.http_route) ("/users/:id" :: Text)
+                Nothing -> pure ()
+              respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      hotName hot `shouldBe` "GET /users/:id"
+
+  describe "error.type attribute" $ do
+    it "sets error.type on 5xx responses" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS internalServerError500 [] "err"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.error_type)
+        `shouldBe` Just (AttributeValue (TextAttribute "500"))
+
+    it "does not set error.type on 2xx responses" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.error_type)
+        `shouldBe` Nothing
+
+    it "does not set error.type on 4xx responses" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS notFound404 [] "nope"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.error_type)
+        `shouldBe` Nothing
+
+  describe "stable HTTP attributes (OTEL_SEMCONV_STABILITY_OPT_IN=http)" $ do
+    it "sets http.request.method" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest POST [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.http_request_method)
+        `shouldBe` Just (AttributeValue (TextAttribute "POST"))
+
+    it "sets url.path" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.url_path)
+        `shouldBe` Just (AttributeValue (TextAttribute "/users/123"))
+
+    it "sets server.address from Host header" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com:8080")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.server_address)
+        `shouldBe` Just (AttributeValue (TextAttribute "example.com"))
+
+    it "sets http.response.status_code" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.http_response_statusCode)
+        `shouldBe` Just (AttributeValue (IntAttribute 200))
+
+    it "sets url.scheme" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.url_scheme)
+        `shouldBe` Just (AttributeValue (TextAttribute "http"))
+
+    it "sets server.port default 80 for non-secure" $ do
+      spans <- withTestMiddleware $ \tp -> do
+        let mw = newOpenTelemetryWaiMiddleware' tp
+            app _req respond = respond $ responseLBS ok200 [] "ok"
+            req = mkRequest GET [("Host", "example.com")]
+        mw app req $ \_ -> pure ResponseReceived
+      hot <- readIORef (spanHot (firstSpan spans))
+      lookupAttribute (hotAttributes hot) (unkey SC.server_port)
+        `shouldBe` Just (AttributeValue (IntAttribute 80))


### PR DESCRIPTION
## Summary
- `wai`: add metrics middleware (request count + latency histograms); update traces for new API
- `http-client`: add `HttpClient/Metrics.hs` for outbound request metrics; update traces
- `conduit`: update for API 0.4 changes

Stacks on: #256 (SDK)

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-wai hs-opentelemetry-instrumentation-http-client hs-opentelemetry-instrumentation-conduit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)