### PR TITLE
feat(instrumentation): update katip, co-log, and monad-logger logging bridges for API 0.4

### DIFF
--- a/instrumentation/co-log/ChangeLog.md
+++ b/instrumentation/co-log/ChangeLog.md
@@ -1,0 +1,11 @@
+# Changelog for hs-opentelemetry-instrumentation-co-log
+
+## 0.1.0.0
+
+- Initial release.
+- Provides `otelLogAction` for co-log's standard `Message` type and
+  `otelLogActionWith` for arbitrary message types.
+- Severity mapping: `Debug`→`Debug`, `Info`→`Info`, `Warning`→`Warn`,
+  `Error`→`Error`.
+- Call-stack source location emitted as `code.filepath`, `code.function.name`,
+  and `code.lineno` attributes.

--- a/instrumentation/co-log/hs-opentelemetry-instrumentation-co-log.cabal
+++ b/instrumentation/co-log/hs-opentelemetry-instrumentation-co-log.cabal
@@ -1,0 +1,57 @@
+cabal-version: 1.12
+name:               hs-opentelemetry-instrumentation-co-log
+version:            0.1.0.0
+synopsis:           Bridge co-log to OpenTelemetry Logs
+description:
+  Provides LogAction values that forward co-log messages to the
+  OpenTelemetry Logs pipeline with automatic trace correlation.
+  Supports both the standard co-log Message type and arbitrary
+  custom message types via a conversion function.
+category:           OpenTelemetry, Logging
+homepage:           https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
+author:             Ian Duncan
+maintainer:         ian@iankduncan.com
+copyright:          2024-2026 Ian Duncan, Mercury Technologies
+license:            BSD3
+license-file:       LICENSE
+build-type:         Simple
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Instrumentation.CoLog
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , co-log >=0.6 && <0.7
+    , co-log-core >=0.3 && <0.4
+    , hs-opentelemetry-api >=0.4 && <0.5
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-co-log-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , co-log >=0.6 && <0.7
+    , co-log-core >=0.3 && <0.4
+    , hs-opentelemetry-api >=0.4 && <0.5
+    , hs-opentelemetry-exporter-in-memory >=0.0 && <0.1
+    , hs-opentelemetry-instrumentation-co-log
+    , hs-opentelemetry-sdk >=0.1 && <0.2
+    , hspec
+    , text
+    , vector
+  default-language: Haskell2010

--- a/instrumentation/co-log/src/OpenTelemetry/Instrumentation/CoLog.hs
+++ b/instrumentation/co-log/src/OpenTelemetry/Instrumentation/CoLog.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : OpenTelemetry.Instrumentation.CoLog
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Bridge co-log to OpenTelemetry Logs
+Stability   : experimental
+
+Provides 'LogAction' values that forward co-log messages to the
+OpenTelemetry Logs pipeline.
+
+* 'otelLogAction' for co-log's standard 'Message' type (from @co-log@),
+  which carries severity, call stack, and text.
+
+* 'otelLogActionWith' for arbitrary message types — supply your own
+  conversion function.
+
+Trace correlation is automatic: log records emitted inside an
+'OpenTelemetry.Trace.Core.inSpan' block carry the active trace\/span IDs.
+
+= Usage with co-log's @Message@
+
+@
+import Colog (logInfo)
+import Colog.Core (LogAction)
+import OpenTelemetry.Log.Core
+import OpenTelemetry.Instrumentation.CoLog
+
+main :: IO ()
+main = do
+  lp <- getGlobalLoggerProvider
+  let logger = makeLogger lp (instrumentationLibrary \"my-app\" \"1.0.0\")
+      action = otelLogAction logger
+  -- use action with your co-log setup
+@
+
+= Usage with a custom message type
+
+@
+myBridge :: Logger -> LogAction IO Text
+myBridge logger = otelLogActionWith logger $ \\txt ->
+  emptyLogRecordArguments
+    { severityNumber = Just Info
+    , body = toValue txt
+    }
+@
+
+@since 0.1.0.0
+-}
+module OpenTelemetry.Instrumentation.CoLog (
+  otelLogAction,
+  otelLogActionWith,
+  coLogSeverity,
+) where
+
+import Colog.Core (LogAction (..))
+import Colog.Core.Severity (Severity (..))
+import qualified Colog.Core.Severity as CS
+import Colog.Message (Message, Msg (..))
+import Control.Monad (void)
+import qualified Data.HashMap.Strict as H
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Stack (CallStack, getCallStack, srcLocFile, srcLocModule, srcLocStartLine)
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Internal.Common.Types (AnyValue (..), ToValue (..))
+import OpenTelemetry.Internal.Log.Types (
+  LogRecordArguments (..),
+  SeverityNumber (..),
+  emptyLogRecordArguments,
+ )
+import OpenTelemetry.Log.Core (Logger, emitLogRecord)
+import qualified OpenTelemetry.SemanticConventions as SC
+
+
+{- | A 'LogAction' for co-log's standard 'Message' type that forwards
+to the OTel Logs pipeline.
+
+@since 0.1.0.0
+-}
+otelLogAction :: Logger -> LogAction IO Message
+otelLogAction logger = LogAction $ \msg -> do
+  let (sevNum, sevText) = coLogSeverity (msgSeverity msg)
+      attrs = callStackAttributes (msgStack msg)
+      args =
+        emptyLogRecordArguments
+          { severityText = Just sevText
+          , severityNumber = Just sevNum
+          , body = toValue (msgText msg)
+          , attributes = attrs
+          }
+  void $ emitLogRecord logger args
+
+
+{- | A generic 'LogAction' for arbitrary message types. Supply a function
+that converts your message to 'LogRecordArguments'.
+
+@since 0.1.0.0
+-}
+otelLogActionWith :: Logger -> (msg -> LogRecordArguments) -> LogAction IO msg
+otelLogActionWith logger toArgs = LogAction $ \msg ->
+  void $ emitLogRecord logger (toArgs msg)
+
+
+{- | Map co-log 'Severity' to OTel 'SeverityNumber' and short text.
+
+@since 0.1.0.0
+-}
+coLogSeverity :: Severity -> (SeverityNumber, Text)
+coLogSeverity CS.Debug = (OpenTelemetry.Internal.Log.Types.Debug, "DEBUG")
+coLogSeverity CS.Info = (OpenTelemetry.Internal.Log.Types.Info, "INFO")
+coLogSeverity CS.Warning = (Warn, "WARN")
+coLogSeverity CS.Error = (OpenTelemetry.Internal.Log.Types.Error, "ERROR")
+
+
+callStackAttributes :: CallStack -> H.HashMap Text AnyValue
+callStackAttributes cs = case getCallStack cs of
+  [] -> H.empty
+  ((_, loc) : _) ->
+    H.fromList
+      [ (unkey SC.code_filepath, toValue (T.pack (srcLocFile loc)))
+      , (unkey SC.code_function_name, toValue (T.pack (srcLocModule loc)))
+      , (unkey SC.code_lineno, IntValue (fromIntegral (srcLocStartLine loc)))
+      ]

--- a/instrumentation/co-log/test/Spec.hs
+++ b/instrumentation/co-log/test/Spec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Colog.Core (LogAction (..), (<&))
+import Colog.Core.Severity (Severity (..))
+import qualified Colog.Core.Severity as CS
+import Colog.Message (Message, Msg (..))
+import Data.IORef (readIORef)
+import qualified Data.Text as T
+import GHC.Stack (emptyCallStack)
+import OpenTelemetry.Exporter.InMemory.LogRecord (getExportedLogRecords, inMemoryLogRecordExporter)
+import OpenTelemetry.Instrumentation.CoLog (coLogSeverity, otelLogAction, otelLogActionWith)
+import OpenTelemetry.Internal.Common.Types (AnyValue (..), ToValue (..))
+import OpenTelemetry.Internal.Log.Types
+import OpenTelemetry.Log.Core
+import OpenTelemetry.Processor.Simple.LogRecord (SimpleLogRecordProcessorConfig (..), simpleLogRecordProcessor)
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec spec
+
+
+spec :: Spec
+spec = describe "co-log bridge" $ do
+  describe "coLogSeverity" $ do
+    it "maps Debug to Debug" $
+      fst (coLogSeverity CS.Debug) `shouldBe` OpenTelemetry.Internal.Log.Types.Debug
+    it "maps Info to Info" $
+      fst (coLogSeverity CS.Info) `shouldBe` OpenTelemetry.Internal.Log.Types.Info
+    it "maps Warning to Warn" $
+      fst (coLogSeverity CS.Warning) `shouldBe` Warn
+    it "maps Error to Error" $
+      fst (coLogSeverity CS.Error) `shouldBe` OpenTelemetry.Internal.Log.Types.Error
+
+  describe "otelLogAction" $ do
+    it "emits log records to the OTel pipeline" $ do
+      (exporter, ref) <- inMemoryLogRecordExporter
+      proc <- simpleLogRecordProcessor (SimpleLogRecordProcessorConfig exporter 30000000)
+      lp <- createLoggerProvider [proc] emptyLoggerProviderOptions
+      let logger = makeLogger lp (instrumentationLibrary "test-co-log" "0.0.0")
+          action = otelLogAction logger
+          msg = Msg CS.Info emptyCallStack "hello from co-log"
+      action <& msg
+      _ <- forceFlushLoggerProvider lp Nothing
+      records <- getExportedLogRecords ref
+      length records `shouldBe` 1
+      let r = head records
+      ilr <- readLogRecord r
+      toBaseMaybe (logRecordSeverityNumber ilr) `shouldBe` Just OpenTelemetry.Internal.Log.Types.Info
+      logRecordBody ilr `shouldBe` TextValue "hello from co-log"
+
+  describe "otelLogActionWith" $ do
+    it "converts custom messages via the supplied function" $ do
+      (exporter, ref) <- inMemoryLogRecordExporter
+      proc <- simpleLogRecordProcessor (SimpleLogRecordProcessorConfig exporter 30000000)
+      lp <- createLoggerProvider [proc] emptyLoggerProviderOptions
+      let logger = makeLogger lp (instrumentationLibrary "test-co-log" "0.0.0")
+          action = otelLogActionWith logger $ \txt ->
+            emptyLogRecordArguments
+              { severityNumber = Just Warn
+              , body = toValue (txt :: T.Text)
+              }
+      action <& "custom message"
+      _ <- forceFlushLoggerProvider lp Nothing
+      records <- getExportedLogRecords ref
+      length records `shouldBe` 1
+      ilr <- readLogRecord (head records)
+      toBaseMaybe (logRecordSeverityNumber ilr) `shouldBe` Just Warn
+      logRecordBody ilr `shouldBe` TextValue "custom message"

--- a/instrumentation/katip/ChangeLog.md
+++ b/instrumentation/katip/ChangeLog.md
@@ -1,0 +1,11 @@
+# Changelog for hs-opentelemetry-instrumentation-katip
+
+## 0.1.0.0
+
+- Initial release.
+- Provides a Katip `Scribe` that forwards log items to the OpenTelemetry Logs pipeline.
+- Severity mapping: `DebugS`→`Debug`, `InfoS`→`Info`, `WarningS`→`Warn`,
+  `ErrorS`→`Error`, `CriticalS`/`AlertS`/`EmergencyS`→`Fatal` variants.
+- Structured Katip payloads serialised as `log.payload.*` attributes.
+- Standard OTel attributes emitted: `thread.id`, `server.address`, `process.pid`,
+  `code.filepath`, `code.function.name`, `code.lineno`, `katip.namespace`.

--- a/instrumentation/katip/hs-opentelemetry-instrumentation-katip.cabal
+++ b/instrumentation/katip/hs-opentelemetry-instrumentation-katip.cabal
@@ -1,0 +1,57 @@
+cabal-version: 1.12
+name:               hs-opentelemetry-instrumentation-katip
+version:            0.1.0.0
+synopsis:           Bridge Katip structured logging to OpenTelemetry Logs
+description:
+  Provides a Katip Scribe that forwards structured log items to the
+  OpenTelemetry Logs pipeline with automatic trace correlation. Katip's
+  rich structured payloads (namespaces, JSON context, source locations)
+  are preserved as OTel log record attributes.
+category:           OpenTelemetry, Logging
+homepage:           https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
+author:             Ian Duncan
+maintainer:         ian@iankduncan.com
+copyright:          2024-2026 Ian Duncan, Mercury Technologies
+license:            BSD3
+license-file:       LICENSE
+build-type:         Simple
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Instrumentation.Katip
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , hs-opentelemetry-api >=0.4 && <0.5
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , katip >=0.8 && <0.9
+    , template-haskell
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-katip-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api >=0.4 && <0.5
+    , hs-opentelemetry-exporter-in-memory >=0.0 && <0.1
+    , hs-opentelemetry-instrumentation-katip
+    , hs-opentelemetry-sdk >=0.1 && <0.2
+    , hspec
+    , katip >=0.8 && <0.9
+    , text
+    , vector
+  default-language: Haskell2010

--- a/instrumentation/katip/src/OpenTelemetry/Instrumentation/Katip.hs
+++ b/instrumentation/katip/src/OpenTelemetry/Instrumentation/Katip.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module      : OpenTelemetry.Instrumentation.Katip
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Bridge Katip structured logging to OpenTelemetry Logs
+Stability   : experimental
+
+Provides a Katip 'K.Scribe' that forwards structured log items to the
+OpenTelemetry Logs pipeline. Because Katip items carry rich structured data
+(JSON payloads, namespaces, thread IDs, source locations), the bridge
+preserves all of it as OTel log record attributes.
+
+* __Trace correlation is automatic__: log records emitted inside an
+  'OpenTelemetry.Trace.Core.inSpan' block carry the active trace\/span IDs.
+
+* __Structured payloads preserved__: the 'K.LogItem' payload is serialized
+  to JSON and stored under @log.payload.*@ attributes.
+
+* __Severity mapping__: Katip 'K.Severity' maps naturally to OTel severity
+  (DebugS→Debug, InfoS→Info, WarningS→Warn, ErrorS→Error,
+  CriticalS→Fatal, etc.).
+
+= Usage
+
+@
+import qualified Katip as K
+import OpenTelemetry.Log.Core
+import OpenTelemetry.Instrumentation.Katip
+
+main :: IO ()
+main = do
+  lp <- getGlobalLoggerProvider
+  let logger = makeLogger lp (instrumentationLibrary \"my-app\" \"1.0.0\")
+  scribe <- makeOTelScribe logger (K.permitItem K.InfoS) K.V2
+  le <- K.registerScribe \"otel\" scribe K.defaultScribeSettings =<< K.initLogEnv \"MyApp\" \"production\"
+  K.runKatipContextT le () \"main\" $ do
+    K.logTM K.InfoS \"Hello from Katip via OTel!\"
+@
+
+@since 0.1.0.0
+-}
+module OpenTelemetry.Instrumentation.Katip (
+  makeOTelScribe,
+  katipSeverity,
+) where
+
+import Control.Monad (void)
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.HashMap.Strict as H
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TLB
+import qualified Katip as K
+import qualified Katip.Core as KC
+import Language.Haskell.TH.Syntax (Loc (..))
+import OpenTelemetry.Attributes.Key (AttributeKey (..), unkey)
+import OpenTelemetry.Internal.Common.Types (AnyValue (..), ToValue (..))
+import OpenTelemetry.Internal.Log.Types (
+  LogRecordArguments (..),
+  SeverityNumber (..),
+  emptyLogRecordArguments,
+ )
+import OpenTelemetry.Log.Core (Logger, emitLogRecord)
+import qualified OpenTelemetry.SemanticConventions as SC
+
+
+{- | Create a Katip 'K.Scribe' that forwards log items to OTel.
+
+@minSev@ is the minimum severity to forward (e.g. @K.InfoS@).
+@verb@ controls how much of the 'K.LogItem' payload is serialized
+into attributes.
+
+@since 0.1.0.0
+-}
+makeOTelScribe
+  :: Logger
+  -> K.Severity
+  -> K.Verbosity
+  -> IO K.Scribe
+makeOTelScribe logger minSev verb =
+  pure $
+    K.Scribe
+      { K.liPush = \item -> do
+          permitted <- K.permitItem minSev item
+          if permitted
+            then emitItem logger verb item
+            else pure ()
+      , K.scribeFinalizer = pure ()
+      , K.scribePermitItem = K.permitItem minSev
+      }
+
+
+emitItem :: (K.LogItem a) => Logger -> K.Verbosity -> K.Item a -> IO ()
+emitItem logger verb item = do
+  let bodyText = TL.toStrict (TLB.toLazyText (KC.unLogStr (KC._itemMessage item)))
+      (sevNum, sevText) = katipSeverity (KC._itemSeverity item)
+      attrs = itemAttributes verb item
+      args =
+        emptyLogRecordArguments
+          { severityText = Just sevText
+          , severityNumber = Just sevNum
+          , body = toValue bodyText
+          , attributes = attrs
+          }
+  void $ emitLogRecord logger args
+
+
+{- | Map Katip 'K.Severity' to OTel 'SeverityNumber' and short text.
+
+@since 0.1.0.0
+-}
+katipSeverity :: K.Severity -> (SeverityNumber, Text)
+katipSeverity K.DebugS = (Debug, "DEBUG")
+katipSeverity K.InfoS = (Info, "INFO")
+katipSeverity K.NoticeS = (Info2, "NOTICE")
+katipSeverity K.WarningS = (Warn, "WARN")
+katipSeverity K.ErrorS = (Error, "ERROR")
+katipSeverity K.CriticalS = (Fatal, "CRITICAL")
+katipSeverity K.AlertS = (Fatal2, "ALERT")
+katipSeverity K.EmergencyS = (Fatal4, "EMERGENCY")
+
+
+-- | @katip.namespace@ – dot-joined Katip namespace segments (custom attribute).
+katipNamespaceKey :: AttributeKey Text
+katipNamespaceKey = AttributeKey "katip.namespace"
+
+
+itemAttributes :: (K.LogItem a) => K.Verbosity -> K.Item a -> H.HashMap Text AnyValue
+itemAttributes verb item =
+  let KC.Namespace ns = KC._itemNamespace item
+      base =
+        H.fromList $
+          concat
+            [ [(unkey katipNamespaceKey, toValue (T.intercalate "." ns))]
+            , [(unkey SC.thread_id, toValue (KC.getThreadIdText (KC._itemThread item)))]
+            , [(unkey SC.server_address, toValue (T.pack (KC._itemHost item)))]
+            , [(unkey SC.process_pid, toValue (T.pack (show (KC._itemProcess item))))]
+            , maybe [] locAttrs (KC._itemLoc item)
+            ]
+      payloadAttrs = aesonToAttributes (K.itemJson verb item)
+  in H.union base payloadAttrs
+  where
+    locAttrs loc =
+      [ (unkey SC.code_filepath, toValue (T.pack (loc_filename loc)))
+      , (unkey SC.code_function_name, toValue (T.pack (loc_package loc) <> ":" <> T.pack (loc_module loc)))
+      , (unkey SC.code_lineno, IntValue (fromIntegral (fst (loc_start loc))))
+      ]
+
+
+aesonToAttributes :: Value -> H.HashMap Text AnyValue
+aesonToAttributes (Object obj) =
+  H.fromList (map (\(k, v) -> ("log.payload." <> Key.toText k, aesonToAnyValue v)) (KM.toList obj))
+aesonToAttributes _ = H.empty
+
+
+aesonToAnyValue :: Value -> AnyValue
+aesonToAnyValue (String t) = TextValue t
+aesonToAnyValue (Number n) = DoubleValue (realToFrac n)
+aesonToAnyValue (Bool b) = BoolValue b
+aesonToAnyValue Null = NullValue
+aesonToAnyValue (Array arr) = ArrayValue (map aesonToAnyValue (foldr (:) [] arr))
+aesonToAnyValue (Object obj) =
+  HashMapValue (H.fromList (map (\(k, v) -> (Key.toText k, aesonToAnyValue v)) (KM.toList obj)))

--- a/instrumentation/katip/test/Spec.hs
+++ b/instrumentation/katip/test/Spec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main where
+
+import Data.IORef (readIORef)
+import qualified Data.Text as T
+import Katip
+import OpenTelemetry.Exporter.InMemory.LogRecord (getExportedLogRecords, inMemoryLogRecordExporter)
+import OpenTelemetry.Instrumentation.Katip (katipSeverity, makeOTelScribe)
+import OpenTelemetry.Internal.Log.Types
+import OpenTelemetry.Log.Core
+import OpenTelemetry.Processor.Simple.LogRecord (SimpleLogRecordProcessorConfig (..), simpleLogRecordProcessor)
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec spec
+
+
+spec :: Spec
+spec = describe "Katip bridge" $ do
+  describe "katipSeverity" $ do
+    it "maps DebugS to Debug" $
+      fst (katipSeverity DebugS) `shouldBe` Debug
+    it "maps InfoS to Info" $
+      fst (katipSeverity InfoS) `shouldBe` Info
+    it "maps WarningS to Warn" $
+      fst (katipSeverity WarningS) `shouldBe` Warn
+    it "maps ErrorS to Error" $
+      fst (katipSeverity ErrorS) `shouldBe` Error
+    it "maps CriticalS to Fatal" $
+      fst (katipSeverity CriticalS) `shouldBe` Fatal
+
+  describe "makeOTelScribe" $ do
+    it "emits log records to the OTel pipeline" $ do
+      (exporter, ref) <- inMemoryLogRecordExporter
+      proc <- simpleLogRecordProcessor (SimpleLogRecordProcessorConfig exporter 30000000)
+      lp <- createLoggerProvider [proc] emptyLoggerProviderOptions
+      let otelLogger = makeLogger lp (instrumentationLibrary "test-katip" "0.0.0")
+      scribe <- makeOTelScribe otelLogger InfoS V2
+      le <- registerScribe "otel" scribe defaultScribeSettings =<< initLogEnv "TestApp" "test"
+      runKatipContextT le () "main" $
+        $(logTM) InfoS "hello from katip"
+      closeScribes le
+      _ <- forceFlushLoggerProvider lp Nothing
+      records <- getExportedLogRecords ref
+      length records `shouldBe` 1
+      let r = head records
+      ilr <- readLogRecord r
+      toBaseMaybe (logRecordSeverityNumber ilr) `shouldBe` Just Info
+      toBaseMaybe (logRecordSeverityText ilr) `shouldBe` Just "INFO"
+
+    it "filters by severity" $ do
+      (exporter, ref) <- inMemoryLogRecordExporter
+      proc <- simpleLogRecordProcessor (SimpleLogRecordProcessorConfig exporter 30000000)
+      lp <- createLoggerProvider [proc] emptyLoggerProviderOptions
+      let otelLogger = makeLogger lp (instrumentationLibrary "test-katip" "0.0.0")
+      scribe <- makeOTelScribe otelLogger WarningS V2
+      le <- registerScribe "otel" scribe defaultScribeSettings =<< initLogEnv "TestApp" "test"
+      runKatipContextT le () "main" $ do
+        $(logTM) DebugS "debug"
+        $(logTM) InfoS "info"
+        $(logTM) WarningS "warning"
+        $(logTM) ErrorS "error"
+      closeScribes le
+      _ <- forceFlushLoggerProvider lp Nothing
+      records <- reverse <$> getExportedLogRecords ref
+      length records `shouldBe` 2
+      sevs <- mapM (\r -> logRecordSeverityNumber <$> readLogRecord r) records
+      map toBaseMaybe sevs `shouldBe` [Just Warn, Just Error]

--- a/instrumentation/monad-logger/ChangeLog.md
+++ b/instrumentation/monad-logger/ChangeLog.md
@@ -1,0 +1,12 @@
+# Changelog for hs-opentelemetry-instrumentation-monad-logger
+
+## 0.1.0.0
+
+- Initial release.
+- Provides `makeOTelLogCallback` for use with `runLoggingT`.
+- Severity mapping: `LevelDebug`→`Debug`, `LevelInfo`→`Info`, `LevelWarn`→`Warn`,
+  `LevelError`→`Error`, `LevelOther t`→`Info` (with original level name in
+  `severityText`).
+- Template Haskell source location emitted as `code.filepath`, `code.function.name`,
+  and `code.lineno` attributes.
+- Logger source tag emitted as `log.source` attribute when non-empty.

--- a/instrumentation/monad-logger/hs-opentelemetry-instrumentation-monad-logger.cabal
+++ b/instrumentation/monad-logger/hs-opentelemetry-instrumentation-monad-logger.cabal
@@ -1,0 +1,55 @@
+cabal-version: 1.12
+name:               hs-opentelemetry-instrumentation-monad-logger
+version:            0.1.0.0
+synopsis:           Bridge monad-logger to OpenTelemetry Logs
+description:
+  Provides a logging callback for @runLoggingT@ that forwards monad-logger
+  messages to the OpenTelemetry Logs pipeline with automatic trace
+  correlation and source location attributes.
+category:           OpenTelemetry, Logging
+homepage:           https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
+author:             Ian Duncan
+maintainer:         ian@iankduncan.com
+copyright:          2024-2026 Ian Duncan, Mercury Technologies
+license:            BSD3
+license-file:       LICENSE
+build-type:         Simple
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Instrumentation.MonadLogger
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , fast-logger
+    , hs-opentelemetry-api >=0.4 && <0.5
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , monad-logger >=0.3 && <0.4
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-monad-logger-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api >=0.4 && <0.5
+    , hs-opentelemetry-exporter-in-memory >=0.0 && <0.1
+    , hs-opentelemetry-instrumentation-monad-logger
+    , hs-opentelemetry-sdk >=0.1 && <0.2
+    , hspec
+    , monad-logger >=0.3 && <0.4
+    , text
+    , vector
+  default-language: Haskell2010

--- a/instrumentation/monad-logger/src/OpenTelemetry/Instrumentation/MonadLogger.hs
+++ b/instrumentation/monad-logger/src/OpenTelemetry/Instrumentation/MonadLogger.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : OpenTelemetry.Instrumentation.MonadLogger
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Bridge monad-logger to OpenTelemetry Logs
+Stability   : experimental
+
+Provides a logging callback compatible with @runLoggingT@ that forwards
+@monad-logger@ messages to the OpenTelemetry Logs pipeline. Log records
+are emitted via the OTel Logs Bridge API, which means:
+
+* __Trace correlation is automatic__: if a log statement executes inside
+  an 'OpenTelemetry.Trace.Core.inSpan' block, the emitted log record
+  carries the active trace\/span IDs with no extra code.
+
+* __Severity mapping__: 'LevelDebug' → 'Debug', 'LevelInfo' → 'Info',
+  'LevelWarn' → 'Warn', 'LevelError' → 'Error', 'LevelOther' → 'Info'
+  (with the original level name preserved in @severityText@).
+
+* __Source location__: The 'Loc' from Template Haskell logging macros
+  (e.g. @$logInfo@) is mapped to @code.filepath@, @code.function.name@,
+  and @code.lineno@ attributes.
+
+= Usage
+
+@
+import OpenTelemetry.Log.Core
+import OpenTelemetry.Instrumentation.MonadLogger
+
+main :: IO ()
+main = do
+  lp <- getGlobalLoggerProvider
+  let logger = makeLogger lp (instrumentationLibrary \"my-app\" \"1.0.0\")
+  runLoggingT myApp (makeOTelLogCallback logger)
+@
+
+Or with 'LoggingT' and the SDK's auto-initialized provider:
+
+@
+import OpenTelemetry.Trace (withTracerProvider)
+import OpenTelemetry.Log (getGlobalLoggerProvider)
+import OpenTelemetry.Instrumentation.MonadLogger
+
+main :: IO ()
+main = withTracerProvider $ \\_ -> do
+  lp <- getGlobalLoggerProvider
+  let logger = makeLogger lp (instrumentationLibrary \"my-app\" \"1.0.0\")
+  runLoggingT myApp (makeOTelLogCallback logger)
+@
+
+@since 0.1.0.0
+-}
+module OpenTelemetry.Instrumentation.MonadLogger (
+  makeOTelLogCallback,
+  monadLoggerSeverity,
+) where
+
+import Control.Monad (void)
+import Control.Monad.Logger (Loc (..), LogLevel (..), LogSource, LogStr)
+import qualified Data.HashMap.Strict as H
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import OpenTelemetry.Attributes.Key (AttributeKey (..), unkey)
+import OpenTelemetry.Internal.Common.Types (AnyValue (..), ToValue (..))
+import OpenTelemetry.Internal.Log.Types (
+  LogRecordArguments (..),
+  SeverityNumber (..),
+  emptyLogRecordArguments,
+ )
+import OpenTelemetry.Log.Core (Logger, emitLogRecord)
+import qualified OpenTelemetry.SemanticConventions as SC
+import System.Log.FastLogger (fromLogStr)
+
+
+{- | Create a logging callback for use with @runLoggingT@ that forwards
+all log messages to the OTel Logs pipeline via the given 'Logger'.
+
+The callback signature matches what 'Control.Monad.Logger.runLoggingT'
+expects: @Loc -> LogSource -> LogLevel -> LogStr -> IO ()@.
+
+@since 0.1.0.0
+-}
+makeOTelLogCallback :: Logger -> (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
+makeOTelLogCallback logger loc src level msg = do
+  let bodyText = TE.decodeUtf8 (fromLogStr msg)
+      (sevNum, sevText) = monadLoggerSeverity level
+      attrs = locAttributes loc <> sourceAttributes src
+      args =
+        emptyLogRecordArguments
+          { severityText = Just sevText
+          , severityNumber = Just sevNum
+          , body = toValue bodyText
+          , attributes = attrs
+          }
+  void $ emitLogRecord logger args
+
+
+{- | Map a monad-logger 'LogLevel' to an OTel 'SeverityNumber' and
+short text name.
+
+@since 0.1.0.0
+-}
+monadLoggerSeverity :: LogLevel -> (SeverityNumber, Text)
+monadLoggerSeverity LevelDebug = (Debug, "DEBUG")
+monadLoggerSeverity LevelInfo = (Info, "INFO")
+monadLoggerSeverity LevelWarn = (Warn, "WARN")
+monadLoggerSeverity LevelError = (Error, "ERROR")
+monadLoggerSeverity (LevelOther t) = (Info, t)
+
+
+-- | @log.source@ – monad-logger log source tag (custom attribute).
+logSourceKey :: AttributeKey Text
+logSourceKey = AttributeKey "log.source"
+
+
+locAttributes :: Loc -> H.HashMap Text AnyValue
+locAttributes loc =
+  H.fromList
+    [ (unkey SC.code_filepath, toValue (T.pack (loc_filename loc)))
+    , (unkey SC.code_function_name, toValue (T.pack (loc_module loc)))
+    , (unkey SC.code_lineno, IntValue (fromIntegral (fst (loc_start loc))))
+    ]
+
+
+sourceAttributes :: LogSource -> H.HashMap Text AnyValue
+sourceAttributes src
+  | T.null src = H.empty
+  | otherwise = H.singleton (unkey logSourceKey) (toValue src)

--- a/instrumentation/monad-logger/test/Spec.hs
+++ b/instrumentation/monad-logger/test/Spec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main where
+
+import Control.Monad.Logger (Loc (..), LogLevel (..), LogStr, logDebugN, logErrorN, logInfoN, logWarnN, runLoggingT, toLogStr)
+import Data.IORef (readIORef)
+import qualified Data.Text as T
+import OpenTelemetry.Exporter.InMemory.LogRecord (getExportedLogRecords, inMemoryLogRecordExporter)
+import OpenTelemetry.Instrumentation.MonadLogger (makeOTelLogCallback, monadLoggerSeverity)
+import OpenTelemetry.Internal.Log.Types
+import OpenTelemetry.Log.Core
+import OpenTelemetry.Processor.Simple.LogRecord (SimpleLogRecordProcessorConfig (..), simpleLogRecordProcessor)
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec spec
+
+
+spec :: Spec
+spec = describe "MonadLogger bridge" $ do
+  describe "monadLoggerSeverity" $ do
+    it "maps LevelDebug to Debug" $
+      fst (monadLoggerSeverity LevelDebug) `shouldBe` Debug
+    it "maps LevelInfo to Info" $
+      fst (monadLoggerSeverity LevelInfo) `shouldBe` Info
+    it "maps LevelWarn to Warn" $
+      fst (monadLoggerSeverity LevelWarn) `shouldBe` Warn
+    it "maps LevelError to Error" $
+      fst (monadLoggerSeverity LevelError) `shouldBe` Error
+    it "maps LevelOther to Info with custom text" $ do
+      let (sev, txt) = monadLoggerSeverity (LevelOther "TRACE")
+      sev `shouldBe` Info
+      txt `shouldBe` "TRACE"
+
+  describe "makeOTelLogCallback" $ do
+    it "emits log records to the OTel pipeline" $ do
+      (exporter, ref) <- inMemoryLogRecordExporter
+      proc <- simpleLogRecordProcessor (SimpleLogRecordProcessorConfig exporter 30000000)
+      lp <- createLoggerProvider [proc] emptyLoggerProviderOptions
+      let logger = makeLogger lp (instrumentationLibrary "test-monad-logger" "0.0.0")
+      runLoggingT (logInfoN "hello from monad-logger") (makeOTelLogCallback logger)
+      _ <- forceFlushLoggerProvider lp Nothing
+      records <- getExportedLogRecords ref
+      length records `shouldBe` 1
+      let r = head records
+      ilr <- readLogRecord r
+      toBaseMaybe (logRecordSeverityNumber ilr) `shouldBe` Just Info
+      toBaseMaybe (logRecordSeverityText ilr) `shouldBe` Just "INFO"
+      logRecordBody ilr `shouldBe` TextValue "hello from monad-logger"
+
+    it "preserves severity across multiple levels" $ do
+      (exporter, ref) <- inMemoryLogRecordExporter
+      proc <- simpleLogRecordProcessor (SimpleLogRecordProcessorConfig exporter 30000000)
+      lp <- createLoggerProvider [proc] emptyLoggerProviderOptions
+      let logger = makeLogger lp (instrumentationLibrary "test-monad-logger" "0.0.0")
+          cb = makeOTelLogCallback logger
+      runLoggingT (logDebugN "d" >> logInfoN "i" >> logWarnN "w" >> logErrorN "e") cb
+      _ <- forceFlushLoggerProvider lp Nothing
+      records <- reverse <$> getExportedLogRecords ref
+      length records `shouldBe` 4
+      sevs <- mapM (\r -> logRecordSeverityNumber <$> readLogRecord r) records
+      map toBaseMaybe sevs `shouldBe` [Just Debug, Just Info, Just Warn, Just Error]


### PR DESCRIPTION
## Summary
Updates all three logging bridge libraries to emit `LogRecord`s via the new OTel logs signal:
- `katip`: bridge Katip log items to OTel log records
- `co-log`: bridge co-log messages to OTel log records
- `monad-logger`: bridge MonadLogger messages to OTel log records

Stacks on: #256 (SDK)

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-katip hs-opentelemetry-instrumentation-co-log hs-opentelemetry-instrumentation-monad-logger` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)