### PR TITLE
feat(instrumentation): update conduit for API 0.4

### DIFF
--- a/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
+++ b/instrumentation/conduit/hs-opentelemetry-instrumentation-conduit.cabal
@@ -1,12 +1,14 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:               hs-opentelemetry-instrumentation-conduit
 version:            0.1.0.2
+synopsis:           OpenTelemetry instrumentation for Conduit streaming pipelines
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/conduit#readme>
+category:           OpenTelemetry, Conduit, Streaming
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
 bug-reports:        https://github.com/iand675/hs-opentelemetry/issues
 author:             Ian Duncan, Jade Lovelace
@@ -34,6 +36,28 @@ library
   build-depends:
       base >=4.7 && <5
     , conduit
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
     , text
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-conduit-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_conduit
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , conduit
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-conduit ==0.1.*
+    , hs-opentelemetry-sdk ==0.1.*
+    , hspec
+    , resourcet
+    , text
+    , vector
   default-language: Haskell2010

--- a/instrumentation/conduit/package.yaml
+++ b/instrumentation/conduit/package.yaml
@@ -10,8 +10,8 @@ extra-source-files:
 - ChangeLog.md
 
 # Metadata used when publishing your package
-# synopsis:            Short description of your package
-# category:            Web
+synopsis: OpenTelemetry instrumentation for Conduit streaming pipelines
+category: OpenTelemetry, Conduit, Streaming
 
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
@@ -27,10 +27,10 @@ library:
   dependencies:
   - conduit
   - text
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-instrumentation-conduit-test:
     main:                Spec.hs
     source-dirs:         test
@@ -39,4 +39,12 @@ _tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-instrumentation-conduit
+    - hs-opentelemetry-instrumentation-conduit >= 0.1 && < 0.2
+    - hs-opentelemetry-api == 0.4.*
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - conduit
+    - hspec
+    - text
+    - resourcet
+    - vector

--- a/instrumentation/conduit/src/OpenTelemetry/Instrumentation/Conduit.hs
+++ b/instrumentation/conduit/src/OpenTelemetry/Instrumentation/Conduit.hs
@@ -1,13 +1,44 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+{- |
+Module      : OpenTelemetry.Instrumentation.Conduit
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Trace conduit pipeline stages as spans
+Stability   : experimental
+
+= Overview
+
+Wraps individual conduit pipeline stages in trace spans so you can see
+how time is spent across your streaming pipeline. Use 'inSpan' to run a
+sub-pipeline under a span; exceptions are recorded on the span and rethrown.
+
+= Quick example
+
+@
+import Conduit
+import Data.ByteString (ByteString)
+import OpenTelemetry.Instrumentation.Conduit (inSpan)
+import OpenTelemetry.Trace.Core (defaultSpanArguments)
+
+myPipeline :: Tracer -> ConduitT ByteString Void IO ()
+myPipeline tracer =
+  sourceFile "input.csv"
+    .| inSpan tracer "parse" defaultSpanArguments (\_ -> mapC parseRow)
+    .| inSpan tracer "transform" defaultSpanArguments (\_ -> mapC transformRow)
+    .| sinkFile "output.json"
+@
+-}
 module OpenTelemetry.Instrumentation.Conduit where
 
 import Conduit
 import Control.Exception (SomeException, throwIO)
 import Data.Text (Text)
 import GHC.Stack (HasCallStack)
+import OpenTelemetry.Attributes.Key (unkey)
 import OpenTelemetry.Context.ThreadLocal
+import qualified OpenTelemetry.SemanticConventions as SC
 import OpenTelemetry.Trace.Core hiding (getTracer)
 
 
@@ -26,5 +57,5 @@ inSpan t n args f = do
     $ \span_ -> do
       catchC (f span_) $ \e -> do
         liftIO $ do
-          recordException span_ [("exception.escaped", toAttribute True)] Nothing (e :: SomeException)
+          recordException span_ [(unkey SC.exception_escaped, toAttribute True)] Nothing (e :: SomeException)
           throwIO e

--- a/instrumentation/conduit/test/Spec.hs
+++ b/instrumentation/conduit/test/Spec.hs
@@ -1,3 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import Conduit
+import Control.Exception (SomeException, throwIO, try)
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef
+import qualified Data.Vector as V
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryListExporter)
+import OpenTelemetry.Instrumentation.Conduit (inSpan)
+import OpenTelemetry.Trace.Core (Event (..))
+import OpenTelemetry.Trace.Core hiding (inSpan)
+import OpenTelemetry.Util (appendOnlyBoundedCollectionValues)
+import System.IO.Error (userError)
+import Test.Hspec
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = hspec spec
+
+
+withTracer :: (Tracer -> IO a) -> IO ([ImmutableSpan], a)
+withTracer action = do
+  (processor, ref) <- inMemoryListExporter
+  tp <- createTracerProvider [processor] emptyTracerProviderOptions
+  let tracer = makeTracer tp "test-conduit" tracerOptions
+  result <- action tracer
+  _ <- shutdownTracerProvider tp Nothing
+  spans <- readIORef ref
+  pure (spans, result)
+
+
+firstSpan :: [ImmutableSpan] -> IO ImmutableSpan
+firstSpan (s : _) = pure s
+firstSpan [] = expectationFailure "No spans recorded" >> pure (error "unreachable")
+
+
+spec :: Spec
+spec = describe "Conduit instrumentation" $ do
+  it "creates a span wrapping a conduit pipeline" $ do
+    (spans, result) <- withTracer $ \t ->
+      runConduitRes $
+        inSpan t "process-items" defaultSpanArguments $ \_s ->
+          yieldMany [1 :: Int, 2, 3] .| sinkList
+    result `shouldBe` [1, 2, 3]
+    s <- firstSpan spans
+    hot <- readIORef (spanHot s)
+    hotName hot `shouldBe` "process-items"
+
+  it "records exception on conduit failure" $ do
+    (spans, result) <- withTracer $ \t -> do
+      r <- try $
+        runConduitRes $
+          inSpan t "failing-conduit" defaultSpanArguments $ \_s ->
+            yieldMany [1 :: Int, 2, 3] .| mapMC (\_ -> liftIO $ throwIO $ userError "conduit-boom") .| sinkList
+      pure (r :: Either SomeException [Int])
+    case result of
+      Left _ -> pure ()
+      Right _ -> expectationFailure "expected exception"
+    s <- firstSpan spans
+    hot <- readIORef (spanHot s)
+    let events = V.toList $ appendOnlyBoundedCollectionValues $ hotEvents hot
+    any (\e -> eventName e == "exception") events `shouldBe` True


### PR DESCRIPTION
Update `hs-opentelemetry-instrumentation-conduit` for the API 0.4 interface.

## Changes
- Update span/trace APIs to match new API 0.4 signatures
- Update `.cabal` and `package.yaml` dependency bounds

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-conduit` passes
- [ ] Depends on #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)