### PR TITLE
feat(instrumentation): update tasty instrumentation for API 0.4

### DIFF
--- a/instrumentation/tasty/ChangeLog.md
+++ b/instrumentation/tasty/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for hs-opentelemetry-instrumentation-tasty
 
+## Unreleased
+
+- Update to `hs-opentelemetry-api` 0.4.
+- Internal: `result.description` attribute key is now a typed `AttributeKey` constant.
+  Attribute name is unchanged.
+
 ## 0.1.0.1
 
 - Relax `hs-opentelemetry-api` bounds to support 0.3.x

--- a/instrumentation/tasty/hs-opentelemetry-instrumentation-tasty.cabal
+++ b/instrumentation/tasty/hs-opentelemetry-instrumentation-tasty.cabal
@@ -1,6 +1,8 @@
 cabal-version: 2.0
 name:          hs-opentelemetry-instrumentation-tasty
-version:       0.1.0.1
+version:       0.1.0.0
+synopsis:      OpenTelemetry instrumentation for the Tasty test framework
+category:      OpenTelemetry, Testing
 
 description:        Please see the README on GitHub at <https://github.com/iand675/hs-opentelemetry/tree/main/instrumentation/tasty#readme>
 homepage:           https://github.com/iand675/hs-opentelemetry#readme
@@ -23,7 +25,8 @@ library
   default-language: Haskell2010
   build-depends:
     base >=4.7 && <5
-    , hs-opentelemetry-api ^>=0.3
+    , hs-opentelemetry-api ^>= 0.4
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
     , tagged ^>= 0.8
     , tasty ^>= 1.5
     , text
@@ -39,9 +42,9 @@ test-suite tests
     async
     , base
     , containers
-    , hs-opentelemetry-api
+    , hs-opentelemetry-api == 0.4.*
     , hs-opentelemetry-instrumentation-tasty
-    , hs-opentelemetry-sdk
+    , hs-opentelemetry-sdk == 0.1.*
     , tasty
     , tasty-hunit
     , text

--- a/instrumentation/tasty/src/OpenTelemetry/Instrumentation/Tasty.hs
+++ b/instrumentation/tasty/src/OpenTelemetry/Instrumentation/Tasty.hs
@@ -6,18 +6,32 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+{- |
+Module      : OpenTelemetry.Instrumentation.Tasty
+Description : OpenTelemetry instrumentation for the Tasty test framework.
+Stability   : experimental
+
+Wraps test trees to emit spans for each test.
+-}
 module OpenTelemetry.Instrumentation.Tasty (instrumentTestTree, instrumentTestTreeWithTracer) where
 
 import Control.Exception (bracket)
 import Data.Tagged (Tagged, retag)
+import Data.Text (Text)
 import Data.Text qualified as T
+import OpenTelemetry.Attributes.Key (AttributeKey (..), unkey)
 import OpenTelemetry.Context (insertSpan, lookupSpan, removeSpan)
 import OpenTelemetry.Context.ThreadLocal (adjustContext, getContext)
 import OpenTelemetry.Trace.Core (Span, SpanStatus (Error, Ok), Tracer, addAttribute, createSpan, defaultSpanArguments, detectInstrumentationLibrary, endSpan, getGlobalTracerProvider, inSpan, makeTracer, setStatus, tracerOptions)
 import Test.Tasty (TestTree, withResource)
 import Test.Tasty.Options (OptionDescription)
 import Test.Tasty.Providers (IsTest (run, testOptions))
-import Test.Tasty.Runners (Outcome (Failure, Success), ResourceSpec (ResourceSpec), Result (Result, resultDescription, resultOutcome), TestTree (After, AskOptions, PlusTestOptions, SingleTest, TestGroup, WithResource))
+import Test.Tasty.Runners (FailureReason (..), Outcome (Failure, Success), ResourceSpec (ResourceSpec), Result (Result, resultDescription, resultOutcome), TestTree (After, AskOptions, PlusTestOptions, SingleTest, TestGroup, WithResource))
+
+
+-- | @result.description@ – human-readable description of the test result (custom attribute).
+resultDescriptionKey :: AttributeKey Text
+resultDescriptionKey = AttributeKey "result.description"
 
 
 {- | A test case with a wrapper function that can do some IO around the
@@ -35,12 +49,12 @@ instance IsTest t => IsTest (WrappedTest t) where
       res@Result {resultOutcome, resultDescription} <- run opts innerTest progress
       case mspan of
         Just s -> do
-          addAttribute s "result.description" (T.pack resultDescription)
+          addAttribute s (unkey resultDescriptionKey) (T.pack resultDescription)
           case resultOutcome of
             Success -> do
-              setStatus s $ Ok
+              setStatus s Ok
             Failure reason -> do
-              setStatus s $ Error $ T.pack $ show reason
+              setStatus s $ Error $ failureReasonText reason
         Nothing -> pure ()
 
       pure res
@@ -129,6 +143,14 @@ withParentSpan parentSpan act =
       pure (lookupSpan ctx, ctx)
     teardown (originalParentSpan, _ctx) = do
       adjustContext $ \ctx -> maybe (removeSpan ctx) (`insertSpan` ctx) originalParentSpan
+
+
+failureReasonText :: FailureReason -> T.Text
+failureReasonText = \case
+  TestFailed -> "TestFailed"
+  TestThrewException e -> T.pack $ "TestThrewException: " <> show e
+  TestTimedOut n -> T.pack $ "TestTimedOut: " <> show n
+  TestDepFailed -> "TestDepFailed"
 
 {- Note [Test parallelism]
 Tasty runs tests in parallel by default, and we don't want to disturb that.


### PR DESCRIPTION
Update `hs-opentelemetry-instrumentation-tasty` for the API 0.4 interface.

## Changes
- Update trace APIs for API 0.4
- Update `.cabal` dependency bounds

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-tasty` passes
- [ ] Depends on #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)