### PR TITLE
feat(instrumentation): update hw-kafka-client instrumentation for API 0.4

### DIFF
--- a/instrumentation/hw-kafka-client/hs-opentelemetry-instrumentation-hw-kafka-client.cabal
+++ b/instrumentation/hw-kafka-client/hs-opentelemetry-instrumentation-hw-kafka-client.cabal
@@ -6,10 +6,18 @@ license:         BSD-3-Clause
 license-file:    LICENSE
 author:          Alberto Fanton
 maintainer:      alberto.fanton@protonmail.com
+copyright:       2024 Ian Duncan, Mercury Technologies
+homepage:        https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:     https://github.com/iand675/hs-opentelemetry/issues
+category:        OpenTelemetry, Telemetry, Kafka
 build-type:      Simple
 extra-doc-files: CHANGELOG.md
 
 -- extra-source-files:
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
 
 common warnings
   ghc-options: -Wall
@@ -25,12 +33,28 @@ library
     , containers
     , text
     , bytestring
-    , hs-opentelemetry-api
-    , hs-opentelemetry-semantic-conventions
+    , hs-opentelemetry-api == 0.4.*
+    , hs-opentelemetry-semantic-conventions >= 1.40 && < 2
     , hw-kafka-client
     , unliftio-core
-    , case-insensitive
-    , http-types
 
   hs-source-dirs:   src
   default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-hw-kafka-client-test
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   test
+  default-language: Haskell2010
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base                  >=4.7 && <5
+    , hs-opentelemetry-instrumentation-hw-kafka-client == 0.1.*
+    , hs-opentelemetry-api == 0.4.*
+    , hspec
+    , text
+    , bytestring
+    , hw-kafka-client
+    , containers
+    , unordered-containers

--- a/instrumentation/hw-kafka-client/src/OpenTelemetry/Instrumentation/Kafka.hs
+++ b/instrumentation/hw-kafka-client/src/OpenTelemetry/Instrumentation/Kafka.hs
@@ -17,21 +17,26 @@ module OpenTelemetry.Instrumentation.Kafka (
 
   -- * Consumer
   pollMessage,
+
+  -- * Attribute builders (exported for testing)
+  producerAttributes,
+  consumerAttributes,
 ) where
 
-import Control.Monad (void)
-import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.IO.Unlift (MonadUnliftIO)
-import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
-import qualified Data.CaseInsensitive as CI
+import qualified Data.ByteString as BS
+import Data.Int (Int64)
 import qualified Data.Map as M
 import Data.String (IsString)
+import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8')
+import qualified Data.Text.Encoding as TE
 import GHC.Stack.Types (HasCallStack)
 import Kafka.Consumer (
   ConsumerProperties (cpProps),
-  ConsumerRecord (crHeaders, crKey, crOffset, crPartition, crTopic),
+  ConsumerRecord (crHeaders, crKey, crOffset, crPartition, crTopic, crValue),
   KafkaConsumer,
   Offset (unOffset),
  )
@@ -40,7 +45,7 @@ import Kafka.Producer (
   KafkaError,
   KafkaProducer,
   ProducePartition (SpecifiedPartition, UnassignedPartition),
-  ProducerRecord (prHeaders, prKey, prPartition, prTopic),
+  ProducerRecord (prHeaders, prKey, prPartition, prTopic, prValue),
  )
 import qualified Kafka.Producer as KP
 import Kafka.Types (
@@ -51,31 +56,40 @@ import Kafka.Types (
   headersFromList,
   headersToList,
  )
-import Network.HTTP.Types (RequestHeaders)
+import OpenTelemetry.Attributes.Key (unkey)
 import OpenTelemetry.Attributes.Map (AttributeMap, insertAttributeByKey)
 import qualified OpenTelemetry.Context as Context
 import OpenTelemetry.Context.ThreadLocal (attachContext, getContext)
-import OpenTelemetry.Propagator (extract, inject)
+import OpenTelemetry.Propagator (TextMap, emptyTextMap, extract, getGlobalTextMapPropagator, inject, textMapFromList, textMapToList)
 import OpenTelemetry.SemanticConventions (
+  error_type,
+  messaging_client_id,
+  messaging_consumer_group_name,
   messaging_destination_name,
   messaging_kafka_consumer_group,
   messaging_kafka_destination_partition,
   messaging_kafka_message_key,
   messaging_kafka_message_offset,
+  messaging_message_body_size,
   messaging_operation,
+  messaging_operation_name,
+  messaging_operation_type,
+  messaging_system,
  )
 import OpenTelemetry.Trace.Core (
   SpanArguments (kind),
   SpanKind (Consumer, Producer),
+  SpanStatus (Error),
   Tracer,
+  addAttribute,
   addAttributesToSpanArguments,
   callerAttributes,
   defaultSpanArguments,
   detectInstrumentationLibrary,
   getGlobalTracerProvider,
-  getTracerProviderPropagators,
   inSpan'',
   makeTracer,
+  setStatus,
   toAttribute,
   tracerOptions,
  )
@@ -100,12 +114,16 @@ rightToMaybe (Right b) = Just b
 rightToMaybe _ = Nothing
 
 
--- | Span attributes with caller information and kafka specifics
 producerAttributes :: HasCallStack => ProducerRecord -> AttributeMap
 producerAttributes record =
   let
+    addSystem =
+      insertAttributeByKey messaging_system (toAttribute ("kafka" :: T.Text))
     addOperationName =
       insertAttributeByKey messaging_operation producerOperationName
+        . insertAttributeByKey messaging_operation_name (toAttribute (producerOperationName :: T.Text))
+    addOperationType =
+      insertAttributeByKey messaging_operation_type (toAttribute ("send" :: T.Text))
     addDestination =
       insertAttributeByKey messaging_destination_name $ toAttribute . unTopicName . prTopic $ record
     addPartition =
@@ -120,8 +138,12 @@ producerAttributes record =
           insertAttributeByKey messaging_kafka_message_key $ toAttribute key
         Nothing ->
           id
+    addBodySize =
+      case prValue record of
+        Just v -> insertAttributeByKey messaging_message_body_size (toAttribute (fromIntegral (BS.length v) :: Int64))
+        Nothing -> id
   in
-    (addOperationName . addDestination . addPartition . addKey)
+    (addSystem . addOperationName . addOperationType . addDestination . addPartition . addKey . addBodySize)
       callerAttributes
 
 
@@ -130,7 +152,6 @@ consumerSpanArgs :: SpanArguments
 consumerSpanArgs = defaultSpanArguments {kind = Consumer}
 
 
--- | Span attributes for consumer with caller information and kafka specifics
 consumerAttributes
   :: HasCallStack
   => ConsumerProperties
@@ -138,14 +159,24 @@ consumerAttributes
   -> AttributeMap
 consumerAttributes consumerProperties record =
   let
+    addSystem =
+      insertAttributeByKey messaging_system (toAttribute ("kafka" :: T.Text))
     addOperationName =
       insertAttributeByKey messaging_operation consumerOperationName
+        . insertAttributeByKey messaging_operation_name (toAttribute (consumerOperationName :: T.Text))
+    addOperationType =
+      insertAttributeByKey messaging_operation_type (toAttribute ("process" :: T.Text))
     addDestination =
       insertAttributeByKey messaging_destination_name $ toAttribute . unTopicName . crTopic $ record
     addConsumerGroup =
-      -- NOTE: unfortunately, hw-kafka-client does not expose an API to get the consumer, this a flaky workaround
       case M.lookup "group.id" $ cpProps consumerProperties of
-        Just groupId -> insertAttributeByKey messaging_kafka_consumer_group $ toAttribute groupId
+        Just groupId ->
+          insertAttributeByKey messaging_kafka_consumer_group (toAttribute groupId)
+            . insertAttributeByKey messaging_consumer_group_name (toAttribute groupId)
+        Nothing -> id
+    addClientId =
+      case M.lookup "client.id" $ cpProps consumerProperties of
+        Just cid -> insertAttributeByKey messaging_client_id (toAttribute cid)
         Nothing -> id
     addPartition =
       insertAttributeByKey messaging_kafka_destination_partition $ toAttribute . unPartitionId . crPartition $ record
@@ -157,8 +188,22 @@ consumerAttributes consumerProperties record =
           insertAttributeByKey messaging_kafka_message_key $ toAttribute key
         Nothing ->
           id
+    addBodySize =
+      case crValue record of
+        Just v -> insertAttributeByKey messaging_message_body_size (toAttribute (fromIntegral (BS.length v) :: Int64))
+        Nothing -> id
   in
-    (addOperationName . addDestination . addConsumerGroup . addPartition . addOffset . addKey)
+    ( addSystem
+        . addOperationName
+        . addOperationType
+        . addDestination
+        . addConsumerGroup
+        . addClientId
+        . addPartition
+        . addOffset
+        . addKey
+        . addBodySize
+    )
       callerAttributes
 
 
@@ -169,14 +214,12 @@ rdkafkaTracer = do
   return $ makeTracer provider $detectInstrumentationLibrary tracerOptions
 
 
--- | Convert Kafka headers to HTTP headers format
-kafkaHeadersToHttpHeaders :: Headers -> RequestHeaders
-kafkaHeadersToHttpHeaders = map (first CI.mk) . headersToList
+kafkaHeadersToTextMap :: Headers -> TextMap
+kafkaHeadersToTextMap = textMapFromList . map (\(k, v) -> (TE.decodeUtf8 k, TE.decodeUtf8 v)) . headersToList
 
 
--- | Convert HTTP headers to Kafka headers format
-httpHeadersToKafkaHeaders :: RequestHeaders -> Headers
-httpHeadersToKafkaHeaders = headersFromList . map (first CI.foldedCase)
+textMapToKafkaHeaders :: TextMap -> Headers
+textMapToKafkaHeaders = headersFromList . map (\(k, v) -> (TE.encodeUtf8 k, TE.encodeUtf8 v)) . textMapToList
 
 
 {- | Produce a message to Kafka with OpenTelemetry instrumentation.
@@ -202,11 +245,18 @@ produceMessage producer record =
       tracer <- rdkafkaTracer
       ctxt <- getContext
       inSpan'' tracer spanName spanArguments $ \newSpan -> do
-        propagator <- getTracerProviderPropagators <$> getGlobalTracerProvider
-        extraHeaders <- inject propagator (Context.insertSpan newSpan ctxt) []
-        let newKafkaHeaders = headers <> httpHeadersToKafkaHeaders extraHeaders
+        propagator <- liftIO getGlobalTextMapPropagator
+        extraTm <- inject propagator (Context.insertSpan newSpan ctxt) emptyTextMap
+        let newKafkaHeaders = headers <> textMapToKafkaHeaders extraTm
         let newKafkaRecord = record {prHeaders = newKafkaHeaders}
-        KP.produceMessage producer newKafkaRecord
+        result <- KP.produceMessage producer newKafkaRecord
+        case result of
+          Just err -> do
+            let errText = T.pack $ show err
+            addAttribute newSpan (unkey error_type) errText
+            setStatus newSpan (Error errText)
+          Nothing -> pure ()
+        pure result
 
 
 {- | Poll for a single message from Kafka with OpenTelemetry instrumentation.
@@ -235,8 +285,8 @@ pollMessage consumerProperties consumer timeout =
           do
             tracer <- rdkafkaTracer
             ctxt <- getContext
-            propagator <- getTracerProviderPropagators <$> getGlobalTracerProvider
-            ctx <- extract propagator (kafkaHeadersToHttpHeaders $ crHeaders cr) ctxt
-            void $ attachContext ctx
+            propagator <- liftIO getGlobalTextMapPropagator
+            ctx <- extract propagator (kafkaHeadersToTextMap $ crHeaders cr) ctxt
+            _ <- attachContext ctx
             inSpan'' tracer spanName (addAttributesToSpanArguments attributes consumerSpanArgs) $ \_span -> do
               return $ Right cr

--- a/instrumentation/hw-kafka-client/src/OpenTelemetry/Instrumentation/Kafka.hs
+++ b/instrumentation/hw-kafka-client/src/OpenTelemetry/Instrumentation/Kafka.hs
@@ -119,9 +119,6 @@ producerAttributes record =
   let
     addSystem =
       insertAttributeByKey messaging_system (toAttribute ("kafka" :: T.Text))
-    addOperationName =
-      insertAttributeByKey messaging_operation producerOperationName
-        . insertAttributeByKey messaging_operation_name (toAttribute (producerOperationName :: T.Text))
     addOperationType =
       insertAttributeByKey messaging_operation_type (toAttribute ("send" :: T.Text))
     addDestination =
@@ -143,7 +140,7 @@ producerAttributes record =
         Just v -> insertAttributeByKey messaging_message_body_size (toAttribute (fromIntegral (BS.length v) :: Int64))
         Nothing -> id
   in
-    (addSystem . addOperationName . addOperationType . addDestination . addPartition . addKey . addBodySize)
+    (addSystem . addOperationType . addDestination . addPartition . addKey . addBodySize)
       callerAttributes
 
 
@@ -161,9 +158,6 @@ consumerAttributes consumerProperties record =
   let
     addSystem =
       insertAttributeByKey messaging_system (toAttribute ("kafka" :: T.Text))
-    addOperationName =
-      insertAttributeByKey messaging_operation consumerOperationName
-        . insertAttributeByKey messaging_operation_name (toAttribute (consumerOperationName :: T.Text))
     addOperationType =
       insertAttributeByKey messaging_operation_type (toAttribute ("process" :: T.Text))
     addDestination =
@@ -194,7 +188,6 @@ consumerAttributes consumerProperties record =
         Nothing -> id
   in
     ( addSystem
-        . addOperationName
         . addOperationType
         . addDestination
         . addConsumerGroup

--- a/instrumentation/hw-kafka-client/test/Spec.hs
+++ b/instrumentation/hw-kafka-client/test/Spec.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import qualified Data.ByteString as BS
+import qualified Data.HashMap.Strict as H
+import Kafka.Consumer (ConsumerRecord (..), Offset (..), Timestamp (..))
+import Kafka.Consumer.ConsumerProperties (ConsumerProperties, clientId, groupId)
+import Kafka.Consumer.Types (ConsumerGroupId (..))
+import Kafka.Producer (ProducePartition (..), ProducerRecord (..))
+import Kafka.Types (ClientId (..), PartitionId (..), TopicName (..), headersFromList)
+import OpenTelemetry.Attributes.Attribute (Attribute (..), PrimitiveAttribute (..))
+import OpenTelemetry.Instrumentation.Kafka (consumerAttributes, producerAttributes)
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec spec
+
+
+testProducerRecord :: ProducerRecord
+testProducerRecord =
+  ProducerRecord
+    { prTopic = TopicName "orders"
+    , prPartition = SpecifiedPartition 3
+    , prKey = Just "order-123"
+    , prValue = Just "payload-data"
+    , prHeaders = headersFromList []
+    }
+
+
+testConsumerRecord :: ConsumerRecord (Maybe BS.ByteString) (Maybe BS.ByteString)
+testConsumerRecord =
+  ConsumerRecord
+    { crTopic = TopicName "events"
+    , crPartition = PartitionId 1
+    , crOffset = Offset 42
+    , crTimestamp = NoTimestamp
+    , crHeaders = headersFromList []
+    , crKey = Just "event-key"
+    , crValue = Just "event-body-data"
+    }
+
+
+testConsumerProps :: ConsumerProperties
+testConsumerProps =
+  groupId (ConsumerGroupId "my-consumer-group")
+    <> clientId (ClientId "my-client")
+
+
+spec :: Spec
+spec = do
+  describe "producerAttributes" $ do
+    let attrs = producerAttributes testProducerRecord
+
+    it "sets messaging.system to kafka" $
+      H.lookup "messaging.system" attrs `shouldBe` Just (AttributeValue (TextAttribute "kafka"))
+
+    it "sets messaging.operation to send" $
+      H.lookup "messaging.operation" attrs `shouldBe` Just (AttributeValue (TextAttribute "send"))
+
+    it "sets messaging.operation.name to send" $
+      H.lookup "messaging.operation.name" attrs `shouldBe` Just (AttributeValue (TextAttribute "send"))
+
+    it "sets messaging.operation.type to send" $
+      H.lookup "messaging.operation.type" attrs `shouldBe` Just (AttributeValue (TextAttribute "send"))
+
+    it "sets messaging.destination.name to topic" $
+      H.lookup "messaging.destination.name" attrs `shouldBe` Just (AttributeValue (TextAttribute "orders"))
+
+    it "sets messaging.kafka.destination.partition" $
+      H.lookup "messaging.kafka.destination.partition" attrs `shouldSatisfy` (/= Nothing)
+
+    it "sets messaging.kafka.message.key" $
+      H.lookup "messaging.kafka.message.key" attrs `shouldBe` Just (AttributeValue (TextAttribute "order-123"))
+
+    it "sets messaging.message.body.size for non-empty value" $
+      H.lookup "messaging.message.body.size" attrs `shouldBe` Just (AttributeValue (IntAttribute 12))
+
+    it "does not set body size when value is Nothing" $ do
+      let noValueRecord = testProducerRecord {prValue = Nothing}
+          noValueAttrs = producerAttributes noValueRecord
+      H.lookup "messaging.message.body.size" noValueAttrs `shouldBe` Nothing
+
+  describe "consumerAttributes" $ do
+    let attrs = consumerAttributes testConsumerProps testConsumerRecord
+
+    it "sets messaging.system to kafka" $
+      H.lookup "messaging.system" attrs `shouldBe` Just (AttributeValue (TextAttribute "kafka"))
+
+    it "sets messaging.operation to process" $
+      H.lookup "messaging.operation" attrs `shouldBe` Just (AttributeValue (TextAttribute "process"))
+
+    it "sets messaging.operation.name to process" $
+      H.lookup "messaging.operation.name" attrs `shouldBe` Just (AttributeValue (TextAttribute "process"))
+
+    it "sets messaging.operation.type to process" $
+      H.lookup "messaging.operation.type" attrs `shouldBe` Just (AttributeValue (TextAttribute "process"))
+
+    it "sets messaging.destination.name to topic" $
+      H.lookup "messaging.destination.name" attrs `shouldBe` Just (AttributeValue (TextAttribute "events"))
+
+    it "sets messaging.consumer.group.name from consumer properties" $
+      H.lookup "messaging.consumer.group.name" attrs `shouldBe` Just (AttributeValue (TextAttribute "my-consumer-group"))
+
+    it "sets messaging.client.id from consumer properties" $
+      H.lookup "messaging.client.id" attrs `shouldBe` Just (AttributeValue (TextAttribute "my-client"))
+
+    it "sets messaging.kafka.message.offset" $
+      H.lookup "messaging.kafka.message.offset" attrs `shouldSatisfy` (/= Nothing)
+
+    it "sets messaging.message.body.size for non-empty value" $
+      H.lookup "messaging.message.body.size" attrs `shouldBe` Just (AttributeValue (IntAttribute 15))
+
+    it "sets messaging.kafka.message.key" $
+      H.lookup "messaging.kafka.message.key" attrs `shouldBe` Just (AttributeValue (TextAttribute "event-key"))


### PR DESCRIPTION
Update `hs-opentelemetry-instrumentation-hw-kafka` for the API 0.4 interface.

## Changes
- Update trace/attribute APIs for API 0.4
- Update `.cabal` dependency bounds
- Requires GHC 9.6+ (uses hw-kafka-client headers API from LTS 22+)

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-hw-kafka` passes
- [ ] Depends on #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)