### PR TITLE
feat(instrumentation): add gogol (Google Cloud) instrumentation for API 0.4

### DIFF
--- a/instrumentation/gogol/Setup.hs
+++ b/instrumentation/gogol/Setup.hs
@@ -1,0 +1,4 @@
+import Distribution.Simple
+
+
+main = defaultMain

--- a/instrumentation/gogol/hs-opentelemetry-instrumentation-gogol.cabal
+++ b/instrumentation/gogol/hs-opentelemetry-instrumentation-gogol.cabal
@@ -1,0 +1,66 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           hs-opentelemetry-instrumentation-gogol
+version:        0.1.0.0
+synopsis:       OpenTelemetry instrumentation for the Gogol Google Cloud SDK
+description:    Tracing wrappers for Gogol Google Cloud SDK calls. Creates spans per Google API call with RPC semantic convention attributes.
+category:       OpenTelemetry, Telemetry, Monitoring, Observability, Google Cloud
+homepage:       https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
+author:         Ian Duncan, Jade Lovelace
+maintainer:     ian@iankduncan.com
+copyright:      2024 Ian Duncan, Mercury Technologies
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Instrumentation.Gogol
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_gogol
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , exceptions
+    , gogol-core ==1.0.*
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , http-types
+    , resourcet
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-gogol-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_gogol
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , gogol-core
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-gogol ==0.1.*
+    , hs-opentelemetry-sdk ==0.1.*
+    , hspec
+    , text
+  default-language: Haskell2010

--- a/instrumentation/gogol/package.yaml
+++ b/instrumentation/gogol/package.yaml
@@ -1,0 +1,48 @@
+_common/lib: !include "../../package-common.yaml"
+
+name:                hs-opentelemetry-instrumentation-gogol
+version:             0.1.0.0
+
+<<: *preface
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+synopsis:            OpenTelemetry instrumentation for the Gogol Google Cloud SDK
+category:            OpenTelemetry, Telemetry, Monitoring, Observability, Google Cloud
+description:         Tracing wrappers for Gogol Google Cloud SDK calls. Creates spans per Google API call with RPC semantic convention attributes.
+
+dependencies:
+- base >= 4.7 && < 5
+
+library:
+  ghc-options: -Wall
+  source-dirs: src
+  dependencies:
+  - exceptions
+  - gogol-core ^>= 1.0
+  - bytestring
+  - hs-opentelemetry-api >= 0.3 && < 0.5
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
+  - http-types
+  - resourcet
+  - text
+  - unordered-containers
+
+tests:
+  hs-opentelemetry-instrumentation-gogol-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-gogol == 0.1.*
+    - hs-opentelemetry-api >= 0.3 && < 0.5
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - gogol-core
+    - hspec
+    - text

--- a/instrumentation/gogol/src/OpenTelemetry/Instrumentation/Gogol.hs
+++ b/instrumentation/gogol/src/OpenTelemetry/Instrumentation/Gogol.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{- |
+Module      :  OpenTelemetry.Instrumentation.Gogol
+Copyright   :  (c) Ian Duncan, 2024
+License     :  BSD-3
+Description :  OpenTelemetry instrumentation for the Gogol Google Cloud SDK
+Maintainer  :  Ian Duncan
+Stability   :  experimental
+Portability :  non-portable (GHC extensions)
+
+Tracing wrappers for Gogol Google Cloud API calls. Unlike Amazonka, Gogol
+does not have a hooks API, so instrumentation is provided as wrapper
+functions that take the underlying @send@ as a parameter.
+
+@
+import Gogol
+import OpenTelemetry.Instrumentation.Gogol ('tracedSend')
+
+-- Instead of: send req
+-- Write:
+result <- runGoogle env $ 'tracedSend' tracer send req
+@
+
+Each call produces a span named @\"ServiceId.Operation\"@ (e.g.,
+@\"storage.ObjectsGet\"@, @\"compute.InstancesList\"@) with standard RPC
+attributes.
+
+@since 0.1.0.0
+-}
+module OpenTelemetry.Instrumentation.Gogol (
+  tracedSend,
+  tracedSendEither,
+) where
+
+import Control.Exception (SomeException)
+import Control.Monad.Catch (MonadCatch, catch, throwM)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Resource (MonadResource)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Typeable (Proxy (..), Typeable, tyConName, typeRep, typeRepTyCon)
+import qualified Gogol.Types as G
+import qualified Network.HTTP.Types.Status as HTTP
+import OpenTelemetry.Attributes (toAttribute)
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Context (insertSpan)
+import OpenTelemetry.Context.ThreadLocal (getAndAdjustContext, getContext)
+import qualified OpenTelemetry.SemanticConventions as SC
+import OpenTelemetry.Trace.Core (
+  Span,
+  SpanArguments (..),
+  SpanKind (Client),
+  SpanStatus (..),
+  Tracer,
+  addAttributes,
+  createSpanWithoutCallStack,
+  defaultSpanArguments,
+  endSpan,
+  setStatus,
+ )
+
+
+{- | Traced version of Gogol's @send@. Creates a client span for each
+Google API call with RPC semantic convention attributes.
+
+The span is named @\"ServiceId.TypeName\"@ — e.g., @\"storage.ObjectsGet\"@.
+
+@since 0.1.0.0
+-}
+tracedSend
+  :: forall a m
+   . (MonadResource m, MonadIO m, MonadCatch m, G.GoogleRequest a, Typeable a)
+  => Tracer
+  -> (a -> m (G.Rs a))
+  -> a
+  -> m (G.Rs a)
+tracedSend tracer sendFn req = do
+  s <- liftIO $ startSpan tracer req
+  result <-
+    sendFn req `catch` \(e :: SomeException) -> do
+      liftIO $ do
+        let errText = T.pack (show e)
+        addAttributes s $ HM.fromList [(unkey SC.error_type, toAttribute errText)]
+        setStatus s (Error errText)
+        endSpan s Nothing
+      throwM e
+  liftIO $ endSpan s Nothing
+  pure result
+
+
+{- | Traced version of Gogol's @sendEither@. Preserves the 'Either'
+result, recording errors on the span without throwing.
+
+@since 0.1.0.0
+-}
+tracedSendEither
+  :: forall a m
+   . (MonadResource m, MonadIO m, MonadCatch m, G.GoogleRequest a, Typeable a)
+  => Tracer
+  -> (a -> m (Either G.Error (G.Rs a)))
+  -> a
+  -> m (Either G.Error (G.Rs a))
+tracedSendEither tracer sendFn req = do
+  s <- liftIO $ startSpan tracer req
+  result <- sendFn req
+  liftIO $ case result of
+    Right _ -> endSpan s Nothing
+    Left err -> do
+      recordError s err
+      endSpan s Nothing
+  pure result
+
+
+startSpan
+  :: forall a
+   . (G.GoogleRequest a, Typeable a)
+  => Tracer
+  -> a
+  -> IO Span
+startSpan tracer req = do
+  let client = G.requestClient req
+      svc = G._cliService client
+      G.ServiceId svcId = G._svcId svc
+      opName = T.pack $ tyConName $ typeRepTyCon $ typeRep (Proxy @a)
+      spanName = svcId <> "." <> opName
+      host = TE.decodeUtf8 (G._svcHost svc)
+
+  ctx <- getContext
+  s <-
+    createSpanWithoutCallStack tracer ctx spanName $
+      defaultSpanArguments
+        { kind = Client
+        , attributes =
+            HM.fromList
+              [ (unkey SC.rpc_system, toAttribute ("gcp-api" :: T.Text))
+              , (unkey SC.rpc_service, toAttribute svcId)
+              , (unkey SC.rpc_method, toAttribute opName)
+              , (unkey SC.server_address, toAttribute host)
+              , (unkey SC.cloud_provider, toAttribute ("gcp" :: T.Text))
+              ]
+        }
+
+  _ <- getAndAdjustContext (insertSpan s)
+  pure s
+
+
+recordError :: Span -> G.Error -> IO ()
+recordError s err = do
+  let errDesc = describeError err
+      statusAttr sc = [(unkey SC.http_response_statusCode, toAttribute (HTTP.statusCode sc))]
+      attrs = case err of
+        G.ServiceError svcErr -> statusAttr (G._serviceStatus svcErr)
+        G.SerializeError serr -> statusAttr (G._serializeStatus serr)
+        G.TransportError _ -> []
+  addAttributes s $ HM.fromList $ (unkey SC.error_type, toAttribute errDesc) : attrs
+  setStatus s (Error errDesc)
+
+
+describeError :: G.Error -> T.Text
+describeError (G.TransportError _) = "transport_error"
+describeError (G.SerializeError serr) = T.pack (G._serializeMessage serr)
+describeError (G.ServiceError svcErr) =
+  "http_" <> T.pack (show (HTTP.statusCode (G._serviceStatus svcErr)))

--- a/instrumentation/gogol/test/Spec.hs
+++ b/instrumentation/gogol/test/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+


### PR DESCRIPTION
Add `hs-opentelemetry-instrumentation-gogol` — trace instrumentation for Google Cloud API calls via the `gogol` library.

## Changes
- New package for GCP instrumentation
- Update `.cabal` and `package.yaml` dependency bounds for API 0.4
- Requires GHC 9.10+ (gogol-core only available in LTS 24+ / nightly)

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-gogol` passes (GHC 9.10+)
- [ ] Depends on #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)