### PR TITLE
feat(instrumentation): add amazonka (AWS) instrumentation for API 0.4

### DIFF
--- a/instrumentation/amazonka/Setup.hs
+++ b/instrumentation/amazonka/Setup.hs
@@ -1,0 +1,4 @@
+import Distribution.Simple
+
+
+main = defaultMain

--- a/instrumentation/amazonka/hs-opentelemetry-instrumentation-amazonka.cabal
+++ b/instrumentation/amazonka/hs-opentelemetry-instrumentation-amazonka.cabal
@@ -1,0 +1,69 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           hs-opentelemetry-instrumentation-amazonka
+version:        0.1.0.0
+synopsis:       OpenTelemetry instrumentation for the Amazonka AWS SDK
+description:    Automatic tracing for Amazonka AWS SDK calls via the hooks API. Creates spans per AWS API call with semantic convention attributes (rpc.system, rpc.service, rpc.method, aws.request_id, etc.).
+category:       OpenTelemetry, Telemetry, Monitoring, Observability, AWS
+homepage:       https://github.com/iand675/hs-opentelemetry#readme
+bug-reports:    https://github.com/iand675/hs-opentelemetry/issues
+author:         Ian Duncan, Jade Lovelace
+maintainer:     ian@iankduncan.com
+copyright:      2024 Ian Duncan, Mercury Technologies
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry
+
+library
+  exposed-modules:
+      OpenTelemetry.Instrumentation.Amazonka
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_amazonka
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      amazonka ==2.0.*
+    , amazonka-core ==2.0.*
+    , base >=4.7 && <5
+    , bytestring
+    , case-insensitive
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , http-client
+    , http-types
+    , text
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-amazonka-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_hs_opentelemetry_instrumentation_amazonka
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      amazonka
+    , amazonka-core
+    , base >=4.7 && <5
+    , hs-opentelemetry-api >=0.3 && <0.5
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-amazonka
+    , hs-opentelemetry-sdk ==0.1.*
+    , hspec
+    , text
+    , unordered-containers
+  default-language: Haskell2010

--- a/instrumentation/amazonka/package.yaml
+++ b/instrumentation/amazonka/package.yaml
@@ -1,0 +1,51 @@
+_common/lib: !include "../../package-common.yaml"
+
+name:                hs-opentelemetry-instrumentation-amazonka
+version:             0.1.0.0
+
+<<: *preface
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+synopsis:            OpenTelemetry instrumentation for the Amazonka AWS SDK
+category:            OpenTelemetry, Telemetry, Monitoring, Observability, AWS
+description:         Automatic tracing for Amazonka AWS SDK calls via the hooks API. Creates spans per AWS API call with semantic convention attributes (rpc.system, rpc.service, rpc.method, aws.request_id, etc.).
+
+dependencies:
+- base >= 4.7 && < 5
+
+library:
+  ghc-options: -Wall
+  source-dirs: src
+  dependencies:
+  - amazonka ^>= 2.0
+  - amazonka-core ^>= 2.0
+  - bytestring
+  - case-insensitive
+  - hs-opentelemetry-api >= 0.3 && < 0.5
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
+  - http-client
+  - http-types
+  - text
+  - unordered-containers
+
+tests:
+  hs-opentelemetry-instrumentation-amazonka-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - hs-opentelemetry-instrumentation-amazonka
+    - hs-opentelemetry-api >= 0.3 && < 0.5
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - amazonka
+    - amazonka-core
+    - hspec
+    - text
+    - unordered-containers

--- a/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
+++ b/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
@@ -163,11 +163,12 @@ tracingResponse
   => Hook_ (AWS.Request a, AWS.ClientResponse (AWS.AWSResponse a))
   -> Hook_ (AWS.Request a, AWS.ClientResponse (AWS.AWSResponse a))
 tracingResponse baseHook env arg = do
+  result <- baseHook env arg
   ctx <- getContext
   case lookupSpan ctx of
     Just span -> endSpan span Nothing
     Nothing -> pure ()
-  baseHook env arg
+  pure result
 
 
 tracingError

--- a/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
+++ b/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- |
+Module      :  OpenTelemetry.Instrumentation.Amazonka
+Copyright   :  (c) Ian Duncan, 2024
+License     :  BSD-3
+Description :  OpenTelemetry instrumentation for the Amazonka AWS SDK
+Maintainer  :  Ian Duncan
+Stability   :  experimental
+Portability :  non-portable (GHC extensions)
+
+Provides automatic tracing for all AWS API calls made through the Amazonka
+SDK. Installs hooks on an Amazonka 'Env' that create OTel spans per
+@send@\/@sendEither@ call, following the
+<https://opentelemetry.io/docs/specs/semconv/cloud-providers/aws-sdk/ OTel AWS SDK semantic conventions>.
+
+@
+import Amazonka
+import OpenTelemetry.Instrumentation.Amazonka ('instrumentEnv')
+
+main :: IO ()
+main = 'OpenTelemetry.Trace.withTracerProvider' $ \\tp -> do
+  let tracer = 'OpenTelemetry.Trace.Core.makeTracer' tp "my-app" 'OpenTelemetry.Trace.Core.tracerOptions'
+  env <- newEnv discover
+  let tracedEnv = 'instrumentEnv' tracer env
+  runResourceT $ send tracedEnv someRequest
+@
+
+Each @send@ call produces a span named @\"Service.Operation\"@ (e.g.,
+@\"S3.GetObject\"@, @\"DynamoDB.PutItem\"@) with standard RPC and AWS
+attributes.
+
+@since 0.1.0.0
+-}
+module OpenTelemetry.Instrumentation.Amazonka (
+  instrumentEnv,
+  instrumentHooks,
+) where
+
+import Amazonka.Env (Env, Env' (..))
+import Amazonka.Env.Hooks (Finality (..), Hook, Hook_, Hooks (..))
+import qualified Amazonka.Types as AWS
+import Control.Applicative ((<|>))
+import Control.Exception (onException)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Typeable (Proxy (..), Typeable, tyConName, typeRep, typeRepTyCon)
+import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Types.Status as HTTP
+import OpenTelemetry.Attributes (toAttribute)
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Context (insertSpan, lookupSpan)
+import OpenTelemetry.Context.ThreadLocal (getAndAdjustContext, getContext)
+import qualified OpenTelemetry.SemanticConventions as SC
+import OpenTelemetry.Trace.Core (
+  Span,
+  SpanArguments (..),
+  SpanKind (Client),
+  SpanStatus (Error),
+  Tracer,
+  addAttributes,
+  createSpanWithoutCallStack,
+  defaultSpanArguments,
+  endSpan,
+  setStatus,
+ )
+import Prelude hiding (error)
+
+
+{- | Add OpenTelemetry tracing hooks to an Amazonka 'Env'.
+
+All subsequent @send@ and @sendEither@ calls through the returned 'Env'
+will automatically create spans with AWS SDK semantic convention attributes.
+
+The tracing hooks compose with any existing hooks on the 'Env' — they do
+not replace them.
+
+@since 0.1.0.0
+-}
+instrumentEnv :: Tracer -> Env -> Env
+instrumentEnv tracer env =
+  env {hooks = instrumentHooks tracer (hooks env)}
+
+
+{- | Install tracing hooks on an Amazonka 'Hooks' value.
+
+Lower-level than 'instrumentEnv' — use this if you need fine-grained
+control over hook composition.
+
+@since 0.1.0.0
+-}
+instrumentHooks :: Tracer -> Hooks -> Hooks
+instrumentHooks tracer baseHooks =
+  baseHooks
+    { configuredRequest = tracingConfiguredRequest tracer (configuredRequest baseHooks)
+    , clientResponse = tracingClientResponse (clientResponse baseHooks)
+    , response = tracingResponse (response baseHooks)
+    , error = tracingError (error baseHooks)
+    }
+
+
+tracingConfiguredRequest
+  :: forall a
+   . (AWS.AWSRequest a, Typeable a)
+  => Tracer
+  -> Hook (AWS.Request a)
+  -> Hook (AWS.Request a)
+tracingConfiguredRequest tracer baseHook env req = do
+  let svcAbbrev = TE.decodeUtf8 $ AWS.toBS (AWS.abbrev (AWS.service req))
+      opName = T.pack $ tyConName $ typeRepTyCon $ typeRep (Proxy @a)
+      spanName = svcAbbrev <> "." <> opName
+      region = AWS.fromRegion (Amazonka.Env.region env)
+      endpoint_ = AWS.endpoint (AWS.service req) (Amazonka.Env.region env)
+      host = TE.decodeUtf8 (AWS.host endpoint_)
+
+  ctx <- getContext
+  span <-
+    createSpanWithoutCallStack tracer ctx spanName $
+      defaultSpanArguments
+        { kind = Client
+        , attributes =
+            HM.fromList
+              [ (unkey SC.rpc_system, toAttribute ("aws-api" :: T.Text))
+              , (unkey SC.rpc_service, toAttribute svcAbbrev)
+              , (unkey SC.rpc_method, toAttribute opName)
+              , (unkey SC.cloud_region, toAttribute region)
+              , (unkey SC.server_address, toAttribute host)
+              ]
+        }
+
+  _ <- getAndAdjustContext (insertSpan span)
+  baseHook env req `onException` endSpan span Nothing
+
+
+tracingClientResponse
+  :: forall a
+   . (AWS.AWSRequest a, Typeable a)
+  => Hook_ (AWS.Request a, AWS.ClientResponse ())
+  -> Hook_ (AWS.Request a, AWS.ClientResponse ())
+tracingClientResponse baseHook env arg@(_req, resp) = do
+  ctx <- getContext
+  case lookupSpan ctx of
+    Just span -> do
+      let sc = HTTP.statusCode (HTTP.responseStatus resp)
+          mReqId = requestIdFromHeaders (HTTP.responseHeaders resp)
+          attrs =
+            HM.fromList $
+              (unkey SC.http_response_statusCode, toAttribute sc)
+                : case mReqId of
+                  Just reqId -> [(unkey SC.aws_requestId, toAttribute reqId)]
+                  Nothing -> []
+      addAttributes span attrs
+    Nothing -> pure ()
+  baseHook env arg
+
+
+tracingResponse
+  :: forall a
+   . (AWS.AWSRequest a, Typeable a)
+  => Hook_ (AWS.Request a, AWS.ClientResponse (AWS.AWSResponse a))
+  -> Hook_ (AWS.Request a, AWS.ClientResponse (AWS.AWSResponse a))
+tracingResponse baseHook env arg = do
+  ctx <- getContext
+  case lookupSpan ctx of
+    Just span -> endSpan span Nothing
+    Nothing -> pure ()
+  baseHook env arg
+
+
+tracingError
+  :: forall a
+   . (AWS.AWSRequest a, Typeable a)
+  => Hook_ (Finality, AWS.Request a, AWS.Error)
+  -> Hook_ (Finality, AWS.Request a, AWS.Error)
+tracingError baseHook env arg@(finality, _req, err) = do
+  case finality of
+    Final -> do
+      ctx <- getContext
+      case lookupSpan ctx of
+        Just span -> do
+          let errDesc = describeError err
+              attrs =
+                HM.fromList $
+                  (unkey SC.error_type, toAttribute errDesc)
+                    : case extractServiceRequestId err of
+                      Just reqId -> [(unkey SC.aws_requestId, toAttribute reqId)]
+                      Nothing -> []
+          addAttributes span attrs
+          setStatus span (Error errDesc)
+          endSpan span Nothing
+        Nothing -> pure ()
+    NotFinal -> pure ()
+  baseHook env arg
+
+
+requestIdFromHeaders :: [HTTP.Header] -> Maybe T.Text
+requestIdFromHeaders headers =
+  fmap TE.decodeUtf8 (lookup "x-amzn-requestid" headers)
+    <|> fmap TE.decodeUtf8 (lookup "x-amzn-request-id" headers)
+    <|> fmap TE.decodeUtf8 (lookup "x-amz-request-id" headers)
+
+
+extractServiceRequestId :: AWS.Error -> Maybe T.Text
+extractServiceRequestId (AWS.ServiceError svcErr) =
+  AWS.fromRequestId <$> AWS.requestId svcErr
+extractServiceRequestId _ = Nothing
+
+
+describeError :: AWS.Error -> T.Text
+describeError (AWS.TransportError _) = "transport_error"
+describeError (AWS.SerializeError serr) =
+  T.pack (AWS.message (serr :: AWS.SerializeError))
+describeError (AWS.ServiceError svcErr) =
+  let AWS.ErrorCode code = AWS.code svcErr
+  in code

--- a/instrumentation/amazonka/test/Spec.hs
+++ b/instrumentation/amazonka/test/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+


### PR DESCRIPTION
Add `hs-opentelemetry-instrumentation-amazonka` — trace instrumentation for AWS API calls via the `amazonka` library.

## Changes
- New package for AWS instrumentation
- Update `.cabal` and `package.yaml` dependency bounds for API 0.4
- Requires GHC ≤ 9.8 (amazonka 2.0 requires `base < 4.19`; excluded from GHC 9.10+)

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-amazonka` passes (GHC 9.4–9.8)
- [ ] Depends on #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)