### PR TITLE
feat(instrumentation): update yesod instrumentation for API 0.4

### DIFF
--- a/instrumentation/yesod/ChangeLog.md
+++ b/instrumentation/yesod/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Breaking: `http.framework` attribute renamed to `webengine.name`.**
+  Uses the standard OTel semantic convention (`webengine.name = "yesod"`) instead of
+  the custom `http.framework` key. Update any dashboards or alerts that reference
+  `http.framework`.
 - **Fix: span name uses `{method} {route_template}` pattern.** When Yesod creates its
   own span (no WAI parent), name is now `GET /api/users/:id` instead of Haskell route
   constructor name. Falls back to just `{method}` when no route matches.

--- a/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
+++ b/instrumentation/yesod/hs-opentelemetry-instrumentation-yesod.cabal
@@ -35,13 +35,42 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , hs-opentelemetry-api ==0.3.*
+    , hs-opentelemetry-api ==0.4.*
     , hs-opentelemetry-instrumentation-wai >=0.0.1 && <0.2
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
     , microlens
     , template-haskell
     , text
     , unliftio
     , unordered-containers
+    , wai
+    , yesod-core
+  default-language: Haskell2010
+
+test-suite hs-opentelemetry-instrumentation-yesod-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      TestApp.ApiSub
+      TestApp.ApiSub.Routes
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , hs-opentelemetry-api ==0.4.*
+    , hs-opentelemetry-exporter-in-memory ==0.0.*
+    , hs-opentelemetry-instrumentation-wai ==0.1.*
+    , hs-opentelemetry-instrumentation-yesod ==0.1.*
+    , hs-opentelemetry-sdk ==0.1.*
+    , hs-opentelemetry-semantic-conventions >=1.40 && <2
+    , hspec
+    , http-types
+    , network
+    , template-haskell
+    , text
+    , unordered-containers
+    , vault
     , wai
     , yesod-core
   default-language: Haskell2010

--- a/instrumentation/yesod/package.yaml
+++ b/instrumentation/yesod/package.yaml
@@ -25,7 +25,8 @@ library:
   ghc-options: -Wall
   source-dirs: src
   dependencies:
-  - hs-opentelemetry-api ^>= 0.3
+  - hs-opentelemetry-api ^>= 0.4
+  - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
   - hs-opentelemetry-instrumentation-wai >= 0.0.1 && < 0.2
   - microlens
   - template-haskell
@@ -35,14 +36,30 @@ library:
   - wai
   - yesod-core
 
-# Test suite not yet implemented
-_tests:
+tests:
   hs-opentelemetry-instrumentation-yesod-test:
     main:                Spec.hs
     source-dirs:         test
+    other-modules:
+    - TestApp.ApiSub
+    - TestApp.ApiSub.Routes
     ghc-options:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - hs-opentelemetry-instrumentation-yesod
+    - hs-opentelemetry-instrumentation-yesod >= 0.1 && < 0.2
+    - hs-opentelemetry-instrumentation-wai >= 0.1 && < 0.2
+    - hs-opentelemetry-api == 0.4.*
+    - hs-opentelemetry-sdk == 0.1.*
+    - hs-opentelemetry-exporter-in-memory == 0.0.*
+    - hs-opentelemetry-semantic-conventions >= 1.40 && < 2
+    - hspec
+    - text
+    - wai
+    - http-types
+    - vault
+    - network
+    - yesod-core
+    - template-haskell
+    - unordered-containers

--- a/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
+++ b/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
@@ -6,10 +6,35 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- |
-[New HTTP semantic conventions have been declared stable.](https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#migration-plan) Opt-in by setting the environment variable OTEL_SEMCONV_STABILITY_OPT_IN to
-- "http" - to use the stable conventions
-- "http/dup" - to emit both the old and the stable conventions
-Otherwise, the old conventions will be used. The stable conventions will replace the old conventions in the next major release of this library.
+Module      : OpenTelemetry.Instrumentation.Yesod
+Copyright   : (c) Ian Duncan, 2021-2026
+License     : BSD-3
+Description : Automatic tracing for Yesod web applications
+Stability   : experimental
+
+= Overview
+
+Provides Yesod middleware that automatically creates spans for incoming
+HTTP requests. Uses Yesod's type-safe routing to produce meaningful span
+names (e.g. \"GET UserR\" instead of \"GET /users/123\").
+
+= Quick example
+
+@
+import OpenTelemetry.Instrumentation.Yesod (openTelemetryYesodMiddleware)
+
+instance Yesod App where
+  yesodMiddleware = openTelemetryYesodMiddleware . defaultYesodMiddleware
+@
+
+= What gets traced
+
+* A @Server@ span per request, named after the Yesod route type
+* Standard HTTP attributes: method, status code, path, scheme
+* Trace context extracted from incoming request headers
+
+[HTTP semantic conventions migration:](https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#migration-plan)
+set @OTEL_SEMCONV_STABILITY_OPT_IN@ to @http@, @http/dup@, or leave unset for legacy-only.
 -}
 module OpenTelemetry.Instrumentation.Yesod (
   -- * Middleware functionality
@@ -21,6 +46,12 @@ module OpenTelemetry.Instrumentation.Yesod (
   -- * Utilities
   rheSiteL,
   handlerEnvL,
+
+  -- * Testing helpers
+  renderPattern,
+  exceptionTypeName,
+  shouldMarkException,
+  isInternalError,
 ) where
 
 import Control.Monad (when)
@@ -30,11 +61,14 @@ import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import Data.Typeable (typeOf)
 import Language.Haskell.TH.Syntax
 import Lens.Micro
-import Network.Wai (requestHeaders)
+import Network.Wai (requestHeaders, requestMethod)
+import OpenTelemetry.Attributes.Key (AttributeKey (..), unkey)
 import qualified OpenTelemetry.Context as Context
 import OpenTelemetry.Instrumentation.Wai (requestContext)
+import qualified OpenTelemetry.SemanticConventions as SC
 import OpenTelemetry.SemanticsConfig
 import OpenTelemetry.Trace.Core hiding (inSpan, inSpan', inSpan'')
 import OpenTelemetry.Trace.Monad
@@ -177,14 +211,16 @@ renderPattern FlatResource {..} =
     concat
       [ if frCheck then [] else ["!"]
       , case formattedParentPieces <> concatMap routePortionSection frPieces of
-          [] -> ["/"]
+          [] -> case frDispatch of
+            Subsite {} -> []
+            _ -> ["/"]
           pieces -> pieces
       , case frDispatch of
           Methods {..} ->
             case methodsMulti of
               Nothing -> []
               Just t -> ["/+", t]
-          Subsite {} -> []
+          Subsite {} -> ["/**"]
       ]
   where
     routePortionSection :: Piece String -> [String]
@@ -198,15 +234,23 @@ renderPattern FlatResource {..} =
       routePortionSection piece
 
 
+-- | @http.handler@ – Yesod route type name (custom attribute).
+httpHandlerKey :: AttributeKey Text
+httpHandlerKey = AttributeKey "http.handler"
+
+
 data RouteRenderer site = RouteRenderer
   { nameRender :: Route site -> T.Text
   , pathRender :: Route site -> T.Text
   }
 
 
--- TODO figure out a way to get better code locations for these spans.
+{- | This middleware works best when used with `OpenTelemetry.Instrumentation.Wai` middleware.
 
--- | This middleware works best when used with `OpenTelemetry.Instrumentation.Wai` middleware.
+Note: span code locations reflect this middleware module rather than the
+Yesod handler source location. Propagating 'HasCallStack' through Yesod's
+handler monad would require upstream changes to the @yesod-core@ library.
+-}
 openTelemetryYesodMiddleware
   :: (ToTypedContent res)
   => RouteRenderer site
@@ -219,19 +263,19 @@ openTelemetryYesodMiddleware rr m = do
   let mspan = requestContext req >>= Context.lookupSpan
       sharedAttributes =
         H.fromList $
-          ("http.framework", toAttribute ("yesod" :: Text))
+          (unkey SC.webengine_name, toAttribute ("yesod" :: Text))
             : catMaybes
               [ do
                   r <- mr
-                  Just ("http.route", toAttribute $ pathRender rr r)
+                  Just (unkey SC.http_route, toAttribute $ pathRender rr r)
               , do
                   r <- mr
-                  Just ("http.handler", toAttribute $ nameRender rr r)
+                  Just (unkey httpHandlerKey, toAttribute $ nameRender rr r)
               , do
                   ff <- lookup "X-Forwarded-For" $ requestHeaders req
                   case httpOption semanticsOptions of
-                    Stable -> Just ("client.address", toAttribute $ T.decodeUtf8 ff)
-                    StableAndOld -> Just ("client.address", toAttribute $ T.decodeUtf8 ff)
+                    Stable -> Just (unkey SC.client_address, toAttribute $ T.decodeUtf8 ff)
+                    StableAndOld -> Just (unkey SC.client_address, toAttribute $ T.decodeUtf8 ff)
                     Old -> Nothing
               , do
                   ff <- lookup "X-Forwarded-For" $ requestHeaders req
@@ -245,9 +289,13 @@ openTelemetryYesodMiddleware rr m = do
           { kind = maybe Server (const Internal) mspan
           , attributes = sharedAttributes
           }
+  let method_ = T.decodeUtf8 $ requestMethod req
+      yesodSpanName = case mr of
+        Just r -> method_ <> " " <> pathRender rr r
+        Nothing -> method_
   case mspan of
     Nothing -> do
-      eResult <- inSpan' (maybe "notFound" (nameRender rr) mr) args $ \_s -> do
+      eResult <- inSpan' yesodSpanName args $ \_s -> do
         catch (Right <$> m) $ \e -> do
           when (isInternalError e) $ throwIO e
           pure (Left (e :: HandlerContents))
@@ -262,8 +310,13 @@ openTelemetryYesodMiddleware rr m = do
       -- meaning the exception details would not be otherwise attached.
       withException m $ \ex -> do
         when (shouldMarkException ex) $ do
+          addAttributes waiSpan (H.singleton (unkey SC.error_type) (toAttribute (exceptionTypeName ex)))
           recordException waiSpan mempty Nothing ex
           setStatus waiSpan $ Error $ T.pack $ displayException ex
+
+
+exceptionTypeName :: SomeException -> Text
+exceptionTypeName (SomeException e) = T.pack $ show $ typeOf e
 
 
 shouldMarkException :: SomeException -> Bool

--- a/instrumentation/yesod/test/Spec.hs
+++ b/instrumentation/yesod/test/Spec.hs
@@ -1,3 +1,337 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Main where
+
+import Control.Exception (ErrorCall (..), SomeException (..), toException)
+import Data.IORef
+import Data.Text (Text)
+import qualified Data.Vault.Lazy as Vault
+import Network.HTTP.Types (movedPermanently301, ok200)
+import Network.Socket (SockAddr (..))
+import Network.Wai (defaultRequest, responseLBS)
+import Network.Wai.Internal (Request (..), ResponseReceived (..))
+import OpenTelemetry.Attributes (lookupAttribute)
+import OpenTelemetry.Attributes.Attribute (Attribute (..), PrimitiveAttribute (..))
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryListExporter)
+import OpenTelemetry.Instrumentation.Wai (newOpenTelemetryWaiMiddleware')
+import OpenTelemetry.Instrumentation.Yesod
+import qualified OpenTelemetry.SemanticConventions as SC
+import OpenTelemetry.Trace.Core
+import System.Environment (setEnv)
+import Test.Hspec
+import TestApp.ApiSub
+import Yesod.Core
+import Yesod.Core.Types (ErrorResponse (..), HandlerContents (..))
+import Yesod.Routes.TH.Types (Dispatch (..), FlatResource (..), Piece (..))
+
+
+-- Main test app
+data TestApp = TestApp
+
+
+getApiSub :: TestApp -> ApiSub
+getApiSub _ = ApiSub
+
+
+mkYesodData
+  "TestApp"
+  [parseRoutes|
+/ HomeR GET
+/user/#Int UserR GET
+/api ApiR ApiSub getApiSub
+|]
+
+
+mkRouteToRenderer
+  ''TestApp
+  [parseRoutes|
+/ HomeR GET
+/user/#Int UserR GET
+/api ApiR ApiSub getApiSub
+|]
+
+
+mkRouteToPattern
+  ''TestApp
+  [parseRoutes|
+/ HomeR GET
+/user/#Int UserR GET
+/api ApiR ApiSub getApiSub
+|]
+
+
+instance Yesod TestApp where
+  yesodMiddleware =
+    openTelemetryYesodMiddleware
+      RouteRenderer
+        { nameRender = routeToRenderer
+        , pathRender = routeToPattern
+        }
+
+
+getHomeR :: HandlerFor TestApp Html
+getHomeR = return ""
+
+
+getUserR :: Int -> HandlerFor TestApp Html
+getUserR _ = return ""
+
+
+mkYesodDispatch
+  "TestApp"
+  [parseRoutes|
+/ HomeR GET
+/user/#Int UserR GET
+/api ApiR ApiSub getApiSub
+|]
+
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = do
+  setEnv "OTEL_SEMCONV_STABILITY_OPT_IN" "http"
+  hspec spec
+
+
+spec :: Spec
+spec = do
+  describe "renderPattern" $ do
+    it "renders a simple root route" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = []
+              , frName = "HomeR"
+              , frPieces = []
+              , frDispatch = Methods Nothing ["GET"]
+              , frCheck = True
+              }
+      renderPattern fr `shouldBe` "/"
+
+    it "renders a route with static and dynamic pieces" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = []
+              , frName = "UserR"
+              , frPieces = [Static "user", Dynamic "Int"]
+              , frDispatch = Methods Nothing ["GET"]
+              , frCheck = True
+              }
+      renderPattern fr `shouldBe` "/user/#{Int}"
+
+    it "renders a route with parent pieces" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = [("ApiR", [Static "api", Static "v1"])]
+              , frName = "ItemR"
+              , frPieces = [Dynamic "Int"]
+              , frDispatch = Methods Nothing ["GET", "PUT"]
+              , frCheck = True
+              }
+      renderPattern fr `shouldBe` "/api/v1/#{Int}"
+
+    it "renders unchecked route with ! prefix" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = []
+              , frName = "RawR"
+              , frPieces = [Static "raw"]
+              , frDispatch = Methods Nothing ["GET"]
+              , frCheck = False
+              }
+      renderPattern fr `shouldBe` "!/raw"
+
+    it "renders multi-piece route with suffix" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = []
+              , frName = "FileR"
+              , frPieces = [Static "files"]
+              , frDispatch = Methods (Just "Texts") ["GET"]
+              , frCheck = True
+              }
+      renderPattern fr `shouldBe` "/files/+Texts"
+
+    it "renders subsite route with /** wildcard" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = []
+              , frName = "ApiR"
+              , frPieces = [Static "api"]
+              , frDispatch = Subsite "ApiSub" "getApiSub"
+              , frCheck = True
+              }
+      renderPattern fr `shouldBe` "/api/**"
+
+    it "renders subsite at root with /** wildcard" $ do
+      let fr =
+            FlatResource
+              { frParentPieces = []
+              , frName = "SubR"
+              , frPieces = []
+              , frDispatch = Subsite "MySub" "getMySub"
+              , frCheck = True
+              }
+      renderPattern fr `shouldBe` "/**"
+
+  describe "exceptionTypeName" $ do
+    it "returns the type name of an IOException" $ do
+      let e = toException (userError "test")
+      exceptionTypeName e `shouldBe` "IOException"
+
+    it "returns the type name of an ErrorCall" $ do
+      let e = toException (ErrorCall "boom")
+      exceptionTypeName e `shouldBe` "ErrorCall"
+
+  describe "isInternalError" $ do
+    it "returns True for HCError (InternalError _)" $
+      isInternalError (HCError (InternalError "oops")) `shouldBe` True
+
+    it "returns False for HCError (NotFound)" $
+      isInternalError (HCError NotFound) `shouldBe` False
+
+    it "returns False for HCRedirect" $
+      isInternalError (HCRedirect movedPermanently301 "/new") `shouldBe` False
+
+  describe "shouldMarkException" $ do
+    it "returns True for non-HandlerContents exceptions" $ do
+      let e = toException (userError "io-error")
+      shouldMarkException e `shouldBe` True
+
+    it "returns True for InternalError wrapped as exception" $ do
+      let e = toException (HCError (InternalError "500"))
+      shouldMarkException e `shouldBe` True
+
+    it "returns False for NotFound wrapped as exception" $ do
+      let e = toException (HCError NotFound)
+      shouldMarkException e `shouldBe` False
+
+  describe "TH route renderers" $ do
+    it "routeToRenderer maps HomeR" $
+      routeToRenderer HomeR `shouldBe` "HomeR"
+
+    it "routeToRenderer maps UserR" $
+      routeToRenderer (UserR 42) `shouldBe` "UserR"
+
+    it "routeToRenderer maps subsite route ApiR" $
+      routeToRenderer (ApiR ApiSubHomeR) `shouldBe` "ApiR"
+
+    it "routeToPattern maps HomeR to /" $
+      routeToPattern HomeR `shouldBe` "/"
+
+    it "routeToPattern maps UserR to /user/#{Int}" $
+      routeToPattern (UserR 42) `shouldBe` "/user/#{Int}"
+
+    it "routeToPattern maps subsite ApiR to /api/**" $
+      routeToPattern (ApiR ApiSubHomeR) `shouldBe` "/api/**"
+
+  describe "WAI + Yesod middleware integration" $ do
+    it "adds http.route attribute to WAI span" $ do
+      (processor, ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions
+      let waiMw = newOpenTelemetryWaiMiddleware' tp
+      app <- toWaiAppPlain TestApp
+      let fullApp = waiMw app
+          req =
+            defaultRequest
+              { requestMethod = "GET"
+              , rawPathInfo = "/"
+              , requestHeaders = [("Host", "localhost")]
+              , remoteHost = SockAddrInet 12345 0x0100007f
+              , vault = Vault.empty
+              }
+      _ <- fullApp req $ \_ -> pure ResponseReceived
+      _ <- shutdownTracerProvider tp Nothing
+      spans <- readIORef ref
+      case spans of
+        [] -> expectationFailure "no spans recorded"
+        (s : _) -> do
+          hot <- readIORef (spanHot s)
+          lookupAttribute (hotAttributes hot) (unkey SC.http_route)
+            `shouldBe` Just (AttributeValue (TextAttribute "/"))
+          lookupAttribute (hotAttributes hot) "http.handler"
+            `shouldBe` Just (AttributeValue (TextAttribute "HomeR"))
+          lookupAttribute (hotAttributes hot) "webengine.name"
+            `shouldBe` Just (AttributeValue (TextAttribute "yesod"))
+
+    it "uses route pattern for UserR" $ do
+      (processor, ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions
+      let waiMw = newOpenTelemetryWaiMiddleware' tp
+      app <- toWaiAppPlain TestApp
+      let fullApp = waiMw app
+          req =
+            defaultRequest
+              { requestMethod = "GET"
+              , rawPathInfo = "/user/42"
+              , pathInfo = ["user", "42"]
+              , requestHeaders = [("Host", "localhost")]
+              , remoteHost = SockAddrInet 12345 0x0100007f
+              , vault = Vault.empty
+              }
+      _ <- fullApp req $ \_ -> pure ResponseReceived
+      _ <- shutdownTracerProvider tp Nothing
+      spans <- readIORef ref
+      case spans of
+        [] -> expectationFailure "no spans recorded"
+        (s : _) -> do
+          hot <- readIORef (spanHot s)
+          lookupAttribute (hotAttributes hot) (unkey SC.http_route)
+            `shouldBe` Just (AttributeValue (TextAttribute "/user/#{Int}"))
+
+    it "uses /** pattern for subsite routes" $ do
+      (processor, ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions
+      let waiMw = newOpenTelemetryWaiMiddleware' tp
+      app <- toWaiAppPlain TestApp
+      let fullApp = waiMw app
+          req =
+            defaultRequest
+              { requestMethod = "GET"
+              , rawPathInfo = "/api"
+              , pathInfo = ["api"]
+              , requestHeaders = [("Host", "localhost")]
+              , remoteHost = SockAddrInet 12345 0x0100007f
+              , vault = Vault.empty
+              }
+      _ <- fullApp req $ \_ -> pure ResponseReceived
+      _ <- shutdownTracerProvider tp Nothing
+      spans <- readIORef ref
+      case spans of
+        [] -> expectationFailure "no spans recorded"
+        (s : _) -> do
+          hot <- readIORef (spanHot s)
+          lookupAttribute (hotAttributes hot) (unkey SC.http_route)
+            `shouldBe` Just (AttributeValue (TextAttribute "/api/**"))
+          lookupAttribute (hotAttributes hot) "http.handler"
+            `shouldBe` Just (AttributeValue (TextAttribute "ApiR"))
+
+    it "uses /** pattern for subsite nested routes" $ do
+      (processor, ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions
+      let waiMw = newOpenTelemetryWaiMiddleware' tp
+      app <- toWaiAppPlain TestApp
+      let fullApp = waiMw app
+          req =
+            defaultRequest
+              { requestMethod = "GET"
+              , rawPathInfo = "/api/item/7"
+              , pathInfo = ["api", "item", "7"]
+              , requestHeaders = [("Host", "localhost")]
+              , remoteHost = SockAddrInet 12345 0x0100007f
+              , vault = Vault.empty
+              }
+      _ <- fullApp req $ \_ -> pure ResponseReceived
+      _ <- shutdownTracerProvider tp Nothing
+      spans <- readIORef ref
+      case spans of
+        [] -> expectationFailure "no spans recorded"
+        (s : _) -> do
+          hot <- readIORef (spanHot s)
+          lookupAttribute (hotAttributes hot) (unkey SC.http_route)
+            `shouldBe` Just (AttributeValue (TextAttribute "/api/**"))

--- a/instrumentation/yesod/test/TestApp/ApiSub.hs
+++ b/instrumentation/yesod/test/TestApp/ApiSub.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module TestApp.ApiSub (
+  module TestApp.ApiSub.Routes,
+) where
+
+import TestApp.ApiSub.Routes
+import Yesod.Core
+
+
+getApiSubHomeR :: SubHandlerFor ApiSub master Html
+getApiSubHomeR = liftHandler $ return ""
+
+
+getApiSubItemR :: Int -> SubHandlerFor ApiSub master Html
+getApiSubItemR _ = liftHandler $ return ""
+
+
+instance Yesod master => YesodSubDispatch ApiSub master where
+  yesodSubDispatch = $(mkYesodSubDispatch resourcesApiSub)

--- a/instrumentation/yesod/test/TestApp/ApiSub/Routes.hs
+++ b/instrumentation/yesod/test/TestApp/ApiSub/Routes.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module TestApp.ApiSub.Routes where
+
+import Yesod.Core
+
+
+data ApiSub = ApiSub
+
+
+mkYesodSubData
+  "ApiSub"
+  [parseRoutes|
+/ ApiSubHomeR GET
+/item/#Int ApiSubItemR GET
+|]


### PR DESCRIPTION
Update `hs-opentelemetry-instrumentation-yesod` for the API 0.4 interface.

## Changes
- Update trace APIs for API 0.4
- Fix semantic convention: `"http.framework"` → `"webengine.name"`
- Update `.cabal` and `package.yaml` dependency bounds

## Test plan
- [ ] `stack build --test hs-opentelemetry-instrumentation-yesod` passes
- [ ] Depends on #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)