### PR TITLE
fix(xray): add 512-byte header size limit for DoS protection

### DIFF
--- a/propagators/xray/src/OpenTelemetry/Propagator/XRay/Internal.hs
+++ b/propagators/xray/src/OpenTelemetry/Propagator/XRay/Internal.hs
@@ -61,9 +61,8 @@ data XRayHeader = XRayHeader
   { xhTraceId :: !TraceId
   , xhSpanId :: !SpanId
   , xhSampled :: !(Maybe Bool)
-  {- ^ @Nothing@ when the @Sampled@ field is absent (deferred decision).
-  @Just True@ = sampled, @Just False@ = not sampled.
-  -}
+  -- ^ @Nothing@ when the @Sampled@ field is absent (deferred decision).
+  --   @Just True@ = sampled, @Just False@ = not sampled.
   }
   deriving (Eq, Show)
 
@@ -92,15 +91,30 @@ xrayTraceIdToOTel bs
           unique = BS.drop 11 bs
           combined = epoch <> unique
       in case baseEncodedToTraceId Base16 combined of
-           Left _ -> Nothing
-           Right tid -> Just tid
+          Left _ -> Nothing
+          Right tid -> Just tid
 
 
 -- Decoders -------------------------------------------------------------------
 
+{- | Maximum allowed size for an X-Ray header in bytes.
+
+The standard format is ~74 bytes:
+@Root=1-{8hex}-{24hex};Parent={16hex};Sampled={0|1}@
+
+We allow 512 bytes to accommodate optional custom fields while still
+preventing DoS from scanning arbitrarily large inputs. This is well below
+typical web server header limits (8KB-50KB).
+-}
+maxHeaderSize :: Int
+maxHeaderSize = 512
+
+
 -- | Parse a full @X-Amzn-Trace-Id@ header value.
 decodeXRayHeader :: ByteString -> Maybe XRayHeader
-decodeXRayHeader = parseXRayKVs
+decodeXRayHeader bs
+  | BS.length bs > maxHeaderSize = Nothing
+  | otherwise = parseXRayKVs bs
 
 
 {- | Hand-rolled parser for semicolon-separated key=value pairs.
@@ -118,12 +132,12 @@ parseXRayKVs bs = go bs Nothing Nothing Nothing
           let !trimmed = BS.dropWhile (== charW8 ' ') remaining
               (!key, !afterEq) = BS.break (== charW8 '=') trimmed
           in if BS.null afterEq
-               then Nothing -- no '=' found
-               else
-                 let !valAndRest = BS.drop 1 afterEq -- skip '='
-                     (!val, !rest) = breakSemicolon valAndRest
-                     !next = skipSpacesAfterSemicolon rest
-                 in if
+              then Nothing -- no '=' found
+              else
+                let !valAndRest = BS.drop 1 afterEq -- skip '='
+                    (!val, !rest) = breakSemicolon valAndRest
+                    !next = skipSpacesAfterSemicolon rest
+                in if
                     | key == "Root" ->
                         case xrayTraceIdToOTel val of
                           Nothing -> Nothing

--- a/propagators/xray/test/OpenTelemetry/Propagator/XRaySpec.hs
+++ b/propagators/xray/test/OpenTelemetry/Propagator/XRaySpec.hs
@@ -157,6 +157,14 @@ spec =
       it "rejects empty header" $ do
         decodeXRayHeader "" `shouldSatisfy` isNothing
 
+      it "rejects oversized header (> 512 bytes)" $ do
+        -- Create a header with valid Root/Parent but padded with junk to exceed 512 bytes
+        let validPart = "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=1"
+            -- Add enough padding to exceed 512 bytes (valid part is ~81 bytes)
+            padding = replicate (512 - length validPart + 1) 'x'
+            oversized = TE.encodeUtf8 $ T.pack $ validPart ++ padding
+        decodeXRayHeader oversized `shouldSatisfy` isNothing
+
     describe "trace context extraction" $ do
       it "extracts sampled span context from header" $ do
         ctx <- extractWith "Root=1-65a8c9d2-0abcdef1234567890abcdef0;Parent=53995c3f42cd8ad8;Sampled=1"


### PR DESCRIPTION
## Summary
Adds DoS protection to the XRay propagator by rejecting oversized headers.

## Changes
- Add `maxHeaderSize = 512` constant
- Reject headers > 512 bytes immediately in `decodeXRayHeader`  
- Add test case for oversized header rejection

## Rationale
Standard X-Ray headers are ~74 bytes. Without a limit, malformed headers could cause excessive CPU usage scanning for delimiters. 512 bytes allows room for custom fields while providing defense-in-depth against DoS attacks.

This addresses security concerns raised by @jkachmar about hand-rolled parsers and potential LangSec/Mythos-style vulnerabilities.

## Test plan
- [x] All 28 tests pass
- [x] New test validates oversized header rejection

Co-authored-by: jkachmar <git@jkachmar.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)