### PR TITLE
Add unified SDK initialization (OTelSignals + withOpenTelemetry)

### DIFF
--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.38.3.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -34,6 +34,7 @@ flag tls-metadata
 
 library
   exposed-modules:
+      OpenTelemetry.SDK
       OpenTelemetry.Configuration
       OpenTelemetry.Configuration.Create
       OpenTelemetry.Configuration.Parse
@@ -113,6 +114,7 @@ library
     , case-insensitive
     , clock
     , containers
+    , directory
     , hashable
     , hs-opentelemetry-api ==1.0.*
     , hs-opentelemetry-exporter-handle ==1.0.*
@@ -131,6 +133,7 @@ library
     , scientific
     , stm
     , text
+    , time
     , unix-compat >=0.7.1
     , unordered-containers
     , vector

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -30,6 +30,7 @@ flags:
 
 library:
   exposed-modules:
+  - OpenTelemetry.SDK
   - OpenTelemetry.Configuration
   - OpenTelemetry.Configuration.Create
   - OpenTelemetry.Configuration.Parse
@@ -89,6 +90,7 @@ library:
   - aeson
   - async
   - bytestring
+  - directory
   - case-insensitive
   - clock
   - containers
@@ -101,6 +103,7 @@ library:
   - scientific
   - stm
   - text
+  - time
   - unix-compat >= 0.7.1 # for getProcessID
   - unordered-containers
   - vector

--- a/sdk/src/OpenTelemetry/Configuration.hs
+++ b/sdk/src/OpenTelemetry/Configuration.hs
@@ -31,7 +31,8 @@ module OpenTelemetry.Configuration (
   initializeFromText,
 
   -- * Components
-  OTelComponents (..),
+  OTelSignals (..),
+  OTelComponents,
 
   -- * Configuration model
   OTelConfiguration (..),
@@ -54,7 +55,6 @@ import OpenTelemetry.Configuration.Parse
 import OpenTelemetry.Configuration.Types
 import OpenTelemetry.Internal.Logging (otelLogDebug)
 import System.Environment (lookupEnv)
-import System.IO.Error (userError)
 
 
 {- | Check for a declarative config file and initialize from it if set.
@@ -66,7 +66,7 @@ Returns @Nothing@ if neither env var is set.
 
 @since 0.1.0.0
 -}
-initializeFromConfigFile :: IO (Maybe OTelComponents)
+initializeFromConfigFile :: IO (Maybe OTelSignals)
 initializeFromConfigFile = do
   mPath <- lookupEnv "OTEL_EXPERIMENTAL_CONFIG_FILE"
   mPathLegacy <- lookupEnv "OTEL_CONFIG_FILE"
@@ -81,7 +81,7 @@ initializeFromConfigFile = do
 
 @since 0.1.0.0
 -}
-initializeFromFile :: FilePath -> IO OTelComponents
+initializeFromFile :: FilePath -> IO OTelSignals
 initializeFromFile path = do
   result <- parseConfigFile path
   case result of
@@ -93,7 +93,7 @@ initializeFromFile path = do
 
 @since 0.1.0.0
 -}
-initializeFromText :: Text -> IO OTelComponents
+initializeFromText :: Text -> IO OTelSignals
 initializeFromText content = do
   result <- parseConfigBytes content
   case result of

--- a/sdk/src/OpenTelemetry/Configuration/Create.hs
+++ b/sdk/src/OpenTelemetry/Configuration/Create.hs
@@ -9,10 +9,10 @@ See: https://opentelemetry.io/docs/specs/otel/configuration/sdk/#create
 -}
 module OpenTelemetry.Configuration.Create (
   createFromConfig,
-  OTelComponents (..),
+  OTelSignals (..),
+  OTelComponents,
 ) where
 
-import Control.Exception (finally)
 import Control.Monad (when)
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Map.Strict as Map
@@ -32,11 +32,11 @@ import OpenTelemetry.Exporter.OTLP.LogRecord (otlpLogRecordExporter)
 import OpenTelemetry.Exporter.OTLP.Metric (otlpMetricExporter)
 import OpenTelemetry.Exporter.OTLP.Span (CompressionFormat (..), OTLPExporterConfig (..), otlpExporter)
 import OpenTelemetry.Exporter.Span (SpanExporter (..))
-import OpenTelemetry.Internal.Common.Types (ExportResult (..), FlushResult (..), ShutdownResult (..))
+import OpenTelemetry.Internal.Common.Types (ExportResult (..))
 import OpenTelemetry.Internal.Logging (otelLogWarning)
 import OpenTelemetry.Log.Core (LoggerProvider, LoggerProviderOptions (..), createLoggerProvider, emptyLoggerProviderOptions, shutdownLoggerProvider)
 import OpenTelemetry.MeterProvider
-import OpenTelemetry.Metric.Core (MeterProvider (..))
+import OpenTelemetry.Metric.Core (MeterProvider (..), shutdownMeterProvider)
 import OpenTelemetry.MetricReader
 import OpenTelemetry.Processor.Batch.LogRecord (batchLogRecordProcessor)
 import qualified OpenTelemetry.Processor.Batch.LogRecord as BlogProc
@@ -55,8 +55,8 @@ import OpenTelemetry.Trace.Id.Generator.Default (defaultIdGenerator)
 import OpenTelemetry.Trace.Sampler
 
 
--- | @since 0.1.0.0
-data OTelComponents = OTelComponents
+-- | @since 1.0.0.0
+data OTelSignals = OTelSignals
   { otelTracerProvider :: !TracerProvider
   , otelMeterProvider :: !MeterProvider
   , otelLoggerProvider :: !LoggerProvider
@@ -65,12 +65,18 @@ data OTelComponents = OTelComponents
   }
 
 
+{-# DEPRECATED OTelComponents "Use OTelSignals instead" #-}
+
+
+type OTelComponents = OTelSignals
+
+
 {- | Create SDK components from a parsed configuration model.
 Returns all three providers and the composite propagator.
 
 @since 0.1.0.0
 -}
-createFromConfig :: OTelConfiguration -> IO OTelComponents
+createFromConfig :: OTelConfiguration -> IO OTelSignals
 createFromConfig cfg = do
   let disabled = fromMaybe False (configDisabled cfg)
   if disabled
@@ -79,7 +85,7 @@ createFromConfig cfg = do
       (mp, _env) <- createMeterProvider emptyMaterializedResources defaultSdkMeterProviderOptions
       lp <- createLoggerProvider [] emptyLoggerProviderOptions
       pure
-        OTelComponents
+        OTelSignals
           { otelTracerProvider = tp
           , otelMeterProvider = mp
           , otelLoggerProvider = lp
@@ -110,22 +116,19 @@ createFromConfig cfg = do
       tp <- createTracerProvider spanProcessors tpOpts
 
       -- MeterProvider
-      (mp, meterShutdown) <- buildMeterProvider cfg res
+      mp <- buildMeterProvider cfg res
 
       -- LoggerProvider
       (lp, _logShutdowns) <- buildLoggerProvider cfg globalAttrLimits res
 
       let shutdown = do
             _ <- shutdownTracerProvider tp Nothing
-            -- Stop the periodic reader thread before shutting down the meter
-            -- provider; the provider shutdown flushes + closes the exporter,
-            -- so the reader must not try to export after that point.
-            meterShutdown `finally` meterProviderShutdown mp
+            _ <- shutdownMeterProvider mp
             _ <- shutdownLoggerProvider lp Nothing
             pure ()
 
       pure
-        OTelComponents
+        OTelSignals
           { otelTracerProvider = tp
           , otelMeterProvider = mp
           , otelLoggerProvider = lp
@@ -251,16 +254,16 @@ buildSpanExporter SpanExporterNone =
       }
 
 
-buildMeterProvider :: OTelConfiguration -> MaterializedResources -> IO (MeterProvider, IO ())
+buildMeterProvider :: OTelConfiguration -> MaterializedResources -> IO MeterProvider
 buildMeterProvider cfg res = case configMeterProvider cfg >>= mpReaders of
   Nothing -> do
     (mp, _env) <- createMeterProvider res defaultSdkMeterProviderOptions
-    pure (mp, pure ())
+    pure mp
   Just readers -> do
     case readers of
       [] -> do
         (mp, _env) <- createMeterProvider res defaultSdkMeterProviderOptions
-        pure (mp, pure ())
+        pure mp
       (MetricReaderPeriodic pmc : rest) -> do
         when (not (null rest)) $
           otelLogWarning "Multiple metric readers configured; only the first is currently supported — additional readers will be ignored"
@@ -275,10 +278,15 @@ buildMeterProvider cfg res = case configMeterProvider cfg >>= mpReaders of
             let interval = fromMaybe 60000 (pmrInterval pmc)
                 readerOpts = PeriodicMetricReaderOptions {periodicIntervalMicros = interval * 1000}
             handle <- forkPeriodicMetricReader env ex readerOpts
-            pure (mp, stopPeriodicMetricReader handle)
+            pure
+              mp
+                { meterProviderShutdown = do
+                    stopPeriodicMetricReader handle
+                    meterProviderShutdown mp
+                }
           Nothing -> do
             (mp, _env) <- createMeterProvider res defaultSdkMeterProviderOptions
-            pure (mp, pure ())
+            pure mp
 
 
 buildMetricExporter :: PushMetricExporterConfig -> IO (Maybe MetricExporter)

--- a/sdk/src/OpenTelemetry/SDK.hs
+++ b/sdk/src/OpenTelemetry/SDK.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+Module      :  OpenTelemetry.SDK
+Copyright   :  (c) Ian Duncan, 2026
+License     :  BSD-3
+Description :  Unified SDK initialization for all three signals (traces, metrics, logs).
+Stability   :  stable
+
+= Overview
+
+This is the recommended entry point for applications using the
+OpenTelemetry SDK. It initializes all three signal providers
+(TracerProvider, MeterProvider, LoggerProvider) from environment
+variables in a single call.
+
+= Quick example
+
+@
+import OpenTelemetry.SDK
+
+main :: IO ()
+main = withOpenTelemetry $ \otel -> do
+  let tracer = makeTracer (otelTracerProvider otel) "my-app" tracerOptions
+  -- ... application code ...
+@
+
+All configuration is via the standard @OTEL_*@ environment variables:
+
+* @OTEL_SERVICE_NAME@ — service name resource attribute
+* @OTEL_TRACES_EXPORTER@ — trace exporter (default: @otlp@)
+* @OTEL_METRICS_EXPORTER@ — metrics exporter (default: @otlp@)
+* @OTEL_LOGS_EXPORTER@ — logs exporter (default: @otlp@)
+* @OTEL_EXPORTER_OTLP_ENDPOINT@ — OTLP endpoint
+* @OTEL_METRIC_EXPORT_INTERVAL@ — metrics export interval (ms, default: 60000)
+
+See "OpenTelemetry.Trace", "OpenTelemetry.Metric", and "OpenTelemetry.Log"
+for signal-specific configuration and per-signal initialization.
+-}
+module OpenTelemetry.SDK (
+  -- * Unified initialization
+  OTelSignals (..),
+  initializeOpenTelemetry,
+  withOpenTelemetry,
+) where
+
+import Control.Exception (SomeException, bracket, catch)
+import Control.Monad (void)
+import OpenTelemetry.Configuration.Create (OTelSignals (..))
+import OpenTelemetry.Log (initializeGlobalLoggerProvider, shutdownLoggerProvider)
+import OpenTelemetry.Metric (MeterProviderHandle (..), initializeGlobalMeterProvider, shutdownMeterProviderHandle)
+import OpenTelemetry.Trace (initializeGlobalTracerProvider, shutdownTracerProvider)
+
+
+{- | Initialize all three signal providers from @OTEL_*@ environment variables,
+install them as globals, and return an 'OTelSignals' with a unified shutdown handle.
+
+@since 1.0.0.0
+-}
+initializeOpenTelemetry :: IO OTelSignals
+initializeOpenTelemetry = do
+  tp <- initializeGlobalTracerProvider
+  mph <- initializeGlobalMeterProvider
+  lp <- initializeGlobalLoggerProvider
+  let shutdown = do
+        void (shutdownTracerProvider tp Nothing) `catch` \(_ :: SomeException) -> pure ()
+        shutdownMeterProviderHandle mph `catch` \(_ :: SomeException) -> pure ()
+        void (shutdownLoggerProvider lp Nothing) `catch` \(_ :: SomeException) -> pure ()
+  pure
+    OTelSignals
+      { otelTracerProvider = tp
+      , otelMeterProvider = meterProviderHandleProvider mph
+      , otelLoggerProvider = lp
+      , otelPropagators = mempty
+      , otelShutdown = shutdown
+      }
+
+
+{- | Initialize all signal providers, run an action, then shut everything down.
+
+@
+main = withOpenTelemetry $ \otel -> do
+  -- use otelTracerProvider, otelMeterProvider, otelLoggerProvider
+  runMyApp
+@
+
+@since 1.0.0.0
+-}
+withOpenTelemetry :: (OTelSignals -> IO a) -> IO a
+withOpenTelemetry = bracket initializeOpenTelemetry otelShutdown

--- a/sdk/test/OpenTelemetry/ConfigurationSpec.hs
+++ b/sdk/test/OpenTelemetry/ConfigurationSpec.hs
@@ -6,7 +6,7 @@ import Control.Exception (bracket, bracket_)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text, pack)
 import OpenTelemetry.Attributes (lookupAttribute, toAttribute)
-import OpenTelemetry.Configuration.Create (OTelComponents (..), createFromConfig)
+import OpenTelemetry.Configuration.Create (OTelSignals (..), createFromConfig)
 import OpenTelemetry.Configuration.Parse (ConfigParseError (..), parseConfigBytes, parseConfigFile)
 import OpenTelemetry.Configuration.Types
 import OpenTelemetry.Propagator (Propagator (..))


### PR DESCRIPTION
## Summary
- New `OpenTelemetry.SDK` module with `OTelSignals`, `initializeOpenTelemetry`, `withOpenTelemetry`
- Renamed `OTelComponents` to `OTelSignals` (deprecated alias preserved)
- One call initializes all three signal providers from env vars, one shutdown handle

## Test plan
- [x] `cabal test hs-opentelemetry-sdk` passes
