### PR TITLE
Fix FaaS resource spec compliance

### DIFF
--- a/api/src/OpenTelemetry/Resource/FaaS.hs
+++ b/api/src/OpenTelemetry/Resource/FaaS.hs
@@ -1,6 +1,6 @@
 {- |
  Module      :  OpenTelemetry.Resource.FaaS
- Copyright   :  (c) Ian Duncan, 2021
+ Copyright   :  (c) Ian Duncan, 2026
  License     :  BSD-3
  Description :  Resource information about a "function as a service" aka "serverless function" instance
  Maintainer  :  Ian Duncan
@@ -27,29 +27,12 @@ data FaaS = FaaS
 
   Examples: 'my-function'
   -}
-  , faasId :: Maybe Text
-  {- ^ The unique ID of the single function that this runtime instance executes.
+  , faasCloudResourceId :: Maybe Text
+  {- ^ The cloud resource ID (@cloud.resource_id@) of the function.
 
   Depending on the cloud provider, use:
 
-  - AWS Lambda: The function ARN. Take care not to use the "invoked ARN" directly but replace any alias suffix with the resolved function version, as the same runtime instance may be invokable with multiple different aliases.
-  - GCP: The URI of the resource
-  - Azure: The Fully Qualified Resource ID.
-
-  Examples: 'arn:aws:lambda:us-west-2:123456789012:function:my-function'
-  -}
-  , -- \^ The name of the single function that this runtime instance executes.
-    --
-    --  This is the name of the function as configured/deployed on the FaaS platform and is usually different from the name of the callback function (which may be stored in the code.namespace/code.function span attributes).
-    --
-    --  Examples: 'my-function'
-    --
-    faasCloudResourceId :: Maybe Text
-  {- ^ The unique ID of the single function that this runtime instance executes.
-
-  Depending on the cloud provider, use:
-
-  - AWS Lambda: The function ARN. Take care not to use the "invoked ARN" directly but replace any alias suffix with the resolved function version, as the same runtime instance may be invokable with multiple different aliases.
+  - AWS Lambda: The function ARN.
   - GCP: The URI of the resource
   - Azure: The Fully Qualified Resource ID.
 
@@ -75,11 +58,11 @@ data FaaS = FaaS
   Examples: '2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de'
   -}
   , faasMaxMemory :: Maybe Int
-  {- ^ The amount of memory available to the serverless function in MiB.
+  {- ^ The amount of memory available to the serverless function converted to bytes.
 
-  It's recommended to set this attribute since e.g. too little memory can easily an AWS Lambda function from working correctly. On AWS Lambda, the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this information.
+  It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this information (which must be multiplied by 1,048,576).
 
-  Examples: '128'
+  Examples: '134217728'
   -}
   }
   deriving (Show)

--- a/api/src/OpenTelemetry/Resource/FaaS.hs
+++ b/api/src/OpenTelemetry/Resource/FaaS.hs
@@ -60,7 +60,7 @@ data FaaS = FaaS
   , faasMaxMemory :: Maybe Int
   {- ^ The amount of memory available to the serverless function converted to bytes.
 
-  It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this information (which must be multiplied by 1,048,576).
+  It's recommended to set this attribute since e.g. too little memory can easily stop an AWS Lambda function from working correctly. On AWS Lambda, the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this information (which must be multiplied by 1,048,576).
 
   Examples: '134217728'
   -}

--- a/sdk/src/OpenTelemetry/Resource/FaaS/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/FaaS/Detector.hs
@@ -25,7 +25,6 @@ module OpenTelemetry.Resource.FaaS.Detector (
   detectFaaS,
 ) where
 
-import qualified Data.Text as T
 import OpenTelemetry.Resource.Detector.Internal (lookupEnvText)
 import OpenTelemetry.Resource.FaaS (FaaS (..))
 import System.Environment (lookupEnv)
@@ -54,7 +53,7 @@ detectLambda = do
       mVersion <- lookupEnvText "AWS_LAMBDA_FUNCTION_VERSION"
       mLogStream <- lookupEnvText "AWS_LAMBDA_LOG_STREAM_NAME"
       mMemStr <- lookupEnv "AWS_LAMBDA_FUNCTION_MEMORY_SIZE"
-      let mMem = mMemStr >>= readMaybe
+      let mMem = fmap (* 1048576) (mMemStr >>= readMaybe)
       mRegion <- lookupEnvText "AWS_REGION"
       mAcctAndFn <- buildLambdaArn name mRegion
       pure $
@@ -84,7 +83,7 @@ detectGCF = do
     Just target -> do
       mRevision <- lookupEnvText "K_REVISION"
       mMemStr <- lookupEnv "FUNCTION_MEMORY_MB"
-      let mMem = mMemStr >>= readMaybe
+      let mMem = fmap (* 1048576) (mMemStr >>= readMaybe)
       pure $
         Just
           FaaS
@@ -102,10 +101,15 @@ detectAzureFunctions = do
   case mRuntime of
     Nothing -> pure Nothing
     Just _ -> do
-      mName <- lookupEnvText "WEBSITE_SITE_NAME"
-      case mName of
+      mSiteName <- lookupEnvText "WEBSITE_SITE_NAME"
+      case mSiteName of
         Nothing -> pure Nothing
-        Just name ->
+        Just siteName -> do
+          -- Spec: Azure faas.name = "<WEBSITE_SITE_NAME>/<FUNCTION_NAME>"
+          mFuncName <- lookupEnvText "FUNCTION_NAME"
+          let name = case mFuncName of
+                Just funcName -> siteName <> "/" <> funcName
+                Nothing -> siteName
           pure $
             Just
               FaaS


### PR DESCRIPTION
## Summary
- `faas.max_memory` now converts MiB/MB to bytes per spec requirement
- Azure `faas.name` combines `WEBSITE_SITE_NAME/FUNCTION_NAME` per spec
- Removed dead `faasId` field (no semconv key, replaced by `cloud.resource_id`)

## Test plan
- [x] `cabal build hs-opentelemetry-api hs-opentelemetry-sdk`