### PR TITLE
Fix cloud.platform Azure values (dot notation per spec)

### DIFF
--- a/sdk/src/OpenTelemetry/Resource/Cloud/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/Cloud/Detector.hs
@@ -26,10 +26,8 @@ module OpenTelemetry.Resource.Cloud.Detector (
 ) where
 
 import Data.Maybe (fromMaybe)
-import qualified Data.Text as T
 import OpenTelemetry.Resource.Cloud (Cloud (..))
 import OpenTelemetry.Resource.Detector.Internal (firstEnv, lookupEnvText)
-import System.Environment (lookupEnv)
 
 
 -- | @since 0.0.1.0
@@ -157,12 +155,11 @@ detectAzure = do
     else do
       mRegion <- lookupEnvText "REGION_NAME"
       mSub <- lookupEnvText "AZURE_SUBSCRIPTION_ID"
-      let platform = case () of
-            _
-              | mFunctions /= Nothing || mAzureEnv /= Nothing -> Just "azure_functions"
-              | mContainerApp /= Nothing -> Just "azure_container_apps"
-              | mWebsite /= Nothing -> Just "azure_app_service"
-              | otherwise -> Nothing
+      let platform
+            | mFunctions /= Nothing || mAzureEnv /= Nothing = Just "azure.functions"
+            | mContainerApp /= Nothing = Just "azure.container_apps"
+            | mWebsite /= Nothing = Just "azure.app_service"
+            | otherwise = Nothing
       pure $
         Just
           Cloud

--- a/sdk/src/OpenTelemetry/Resource/Detector/Azure.hs
+++ b/sdk/src/OpenTelemetry/Resource/Detector/Azure.hs
@@ -68,8 +68,8 @@ detectAzureVM client = do
       mK8sHost <- lookupEnv "KUBERNETES_SERVICE_HOST"
       let platform :: Text
           platform = case mK8sHost of
-            Just _ -> "azure_aks"
-            Nothing -> "azure_vm"
+            Just _ -> "azure.aks"
+            Nothing -> "azure.vm"
       pure $
         mkResource
           [ unkey SC.cloud_provider .= ("azure" :: Text)


### PR DESCRIPTION
## Summary
Azure cloud.platform values changed from underscore to dot notation per current semconv spec.

## Test plan
- [x] `cabal build hs-opentelemetry-sdk`