### PR TITLE
Fix telemetry.sdk.name + improve OS resource detection

### DIFF
--- a/api/src/OpenTelemetry/Resource/OperatingSystem.hs
+++ b/api/src/OpenTelemetry/Resource/OperatingSystem.hs
@@ -50,7 +50,7 @@ data OperatingSystem = OperatingSystem
   +-----------------+---------------------------------------+
   | @solaris@       | Oracle Solaris                        |
   +-----------------+---------------------------------------+
-  | @z_os@          | IBM z/OS                              |
+  | @zos@           | IBM z/OS                              |
   +-----------------+---------------------------------------+
   -}
   , osDescription :: Maybe Text

--- a/sdk/src/OpenTelemetry/Resource/OperatingSystem/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/OperatingSystem/Detector.hs
@@ -18,28 +18,93 @@ module OpenTelemetry.Resource.OperatingSystem.Detector (
   detectOperatingSystem,
 ) where
 
+import Control.Exception (try)
+import Data.Maybe (mapMaybe)
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import OpenTelemetry.Resource.OperatingSystem
+import System.IO.Error (tryIOError)
 import System.Info (os)
+import System.Process (readProcess)
 
 
-{- | Retrieve any infomration able to be detected about the current operation system.
+{- | Retrieve any information able to be detected about the current operating system.
 
- Currently only supports 'osType' detection, but PRs are welcome to support additional
- details.
+ Detects 'osType', 'osName', 'osVersion', and 'osDescription' on macOS and Linux.
+ On other platforms, only 'osType' is populated.
 
  @since 0.0.1.0
 -}
 detectOperatingSystem :: IO OperatingSystem
-detectOperatingSystem =
-  pure $
+detectOperatingSystem = do
+  let osTypeVal =
+        if os == "mingw32"
+          then "windows"
+          else T.pack os
+  (name, ver, desc) <- detectOsDetails osTypeVal
+  pure
     OperatingSystem
-      { osType =
-          if os == "mingw32"
-            then "windows"
-            else T.pack os
-      , osDescription = Nothing
-      , osName = Nothing
-      , osVersion = Nothing
+      { osType = osTypeVal
+      , osDescription = desc
+      , osName = name
+      , osVersion = ver
       , osBuildId = Nothing
       }
+
+
+detectOsDetails :: T.Text -> IO (Maybe T.Text, Maybe T.Text, Maybe T.Text)
+detectOsDetails "darwin" = do
+  name <- tryShellCommand "sw_vers" ["-productName"]
+  ver <- tryShellCommand "sw_vers" ["-productVersion"]
+  let desc = case (name, ver) of
+        (Just n, Just v) -> Just (n <> " " <> v)
+        _ -> Nothing
+  pure (name, ver, desc)
+detectOsDetails "linux" = do
+  osRelease <- tryReadOsRelease
+  case osRelease of
+    Nothing -> pure (Nothing, Nothing, Nothing)
+    Just content ->
+      let fields = parseOsRelease content
+          name = lookup "NAME" fields
+          ver = lookup "VERSION_ID" fields
+          desc = lookup "PRETTY_NAME" fields
+      in pure (name, ver, desc)
+detectOsDetails "windows" =
+  pure (Just "Windows", Nothing, Nothing)
+detectOsDetails _ =
+  pure (Nothing, Nothing, Nothing)
+
+
+tryShellCommand :: String -> [String] -> IO (Maybe T.Text)
+tryShellCommand cmd args = do
+  result <- try (readProcess cmd args "") :: IO (Either IOError String)
+  pure $ case result of
+    Right output ->
+      let trimmed = T.strip (T.pack output)
+      in if T.null trimmed then Nothing else Just trimmed
+    Left _ -> Nothing
+
+
+tryReadOsRelease :: IO (Maybe T.Text)
+tryReadOsRelease = do
+  result <- tryIOError (T.readFile "/etc/os-release")
+  pure $ case result of
+    Right content | not (T.null content) -> Just content
+    _ -> Nothing
+
+
+parseOsRelease :: T.Text -> [(T.Text, T.Text)]
+parseOsRelease content =
+  mapMaybe parseLine (T.lines content)
+  where
+    parseLine line =
+      case T.break (== '=') line of
+        (key, rest)
+          | not (T.null rest) ->
+              Just (key, stripQuotes (T.drop 1 rest))
+        _ -> Nothing
+    stripQuotes t =
+      case T.uncons t of
+        Just ('"', rest) -> maybe rest fst (T.unsnoc rest)
+        _ -> t

--- a/sdk/src/OpenTelemetry/Resource/Telemetry/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/Telemetry/Detector.hs
@@ -12,7 +12,7 @@ import Paths_hs_opentelemetry_sdk
 detectTelemetry :: Telemetry
 detectTelemetry =
   Telemetry
-    { telemetrySdkName = "hs-opentelemetry-sdk"
+    { telemetrySdkName = "opentelemetry"
     , telemetrySdkLanguage = Just "haskell"
     , telemetrySdkVersion = Just $ T.pack $ showVersion version
     , telemetryDistroName = Nothing

--- a/sdk/test/OpenTelemetry/Resource/DetectorSpec.hs
+++ b/sdk/test/OpenTelemetry/Resource/DetectorSpec.hs
@@ -171,21 +171,21 @@ cloudSpec = describe "Cloud" $ do
       setEnv "WEBSITE_SITE_NAME" "my-app"
       cloud <- detectCloud
       cloudProvider cloud `shouldBe` Just "azure"
-      cloudPlatform cloud `shouldBe` Just "azure_app_service"
+      cloudPlatform cloud `shouldBe` Just "azure.app_service"
 
     it "detects Azure Functions" $ do
       setEnv "FUNCTIONS_WORKER_RUNTIME" "custom"
       setEnv "REGION_NAME" "eastus"
       cloud <- detectCloud
       cloudProvider cloud `shouldBe` Just "azure"
-      cloudPlatform cloud `shouldBe` Just "azure_functions"
+      cloudPlatform cloud `shouldBe` Just "azure.functions"
       cloudRegion cloud `shouldBe` Just "eastus"
 
     it "detects Azure Container Apps" $ do
       setEnv "CONTAINER_APP_NAME" "my-container-app"
       cloud <- detectCloud
       cloudProvider cloud `shouldBe` Just "azure"
-      cloudPlatform cloud `shouldBe` Just "azure_container_apps"
+      cloudPlatform cloud `shouldBe` Just "azure.container_apps"
 
     it "detects AWS EKS from KUBERNETES_SERVICE_HOST + AWS env" $ do
       setEnv "AWS_REGION" "us-east-1"
@@ -257,7 +257,7 @@ faasSpec = describe "FaaS" $ do
           faasName faas `shouldBe` "my-handler"
           faasVersion faas `shouldBe` Just "$LATEST"
           faasInstance faas `shouldBe` Just "2024/01/01/[$LATEST]abc123"
-          faasMaxMemory faas `shouldBe` Just 256
+          faasMaxMemory faas `shouldBe` Just (256 * 1048576)
 
     it "detects GCP Cloud Functions" $ do
       setEnv "FUNCTION_TARGET" "helloWorld"
@@ -269,7 +269,7 @@ faasSpec = describe "FaaS" $ do
         Just faas -> do
           faasName faas `shouldBe` "helloWorld"
           faasVersion faas `shouldBe` Just "helloWorld-00001"
-          faasMaxMemory faas `shouldBe` Just 256
+          faasMaxMemory faas `shouldBe` Just (256 * 1048576)
 
     it "detects Azure Functions" $ do
       setEnv "FUNCTIONS_WORKER_RUNTIME" "custom"


### PR DESCRIPTION
## Summary
- telemetry.sdk.name = opentelemetry per OTel spec
- OS detector: name/version/description on macOS+Linux  
- os.type doc: z_os -> zos
## Test plan
- [x] cabal test hs-opentelemetry-sdk