### PR TITLE
Process resource: creation time, Opt-In fields, fix command_args

### DIFF
--- a/api/src/OpenTelemetry/Resource/Process.hs
+++ b/api/src/OpenTelemetry/Resource/Process.hs
@@ -55,6 +55,23 @@ data Process = Process
 
   Example: @root@
   -}
+  , processCreationTime :: Maybe Text
+  {- ^ The date and time the process was created, in ISO 8601 format.
+
+  Example: @"2023-11-21T09:25:34.853Z"@
+  -}
+  , processArgsCount :: Maybe Int
+  -- ^ Length of the process.command_args array. Opt-In.
+  , processParentPid :: Maybe Int
+  -- ^ Parent Process identifier (PPID). Opt-In.
+  , processWorkingDirectory :: Maybe Text
+  -- ^ The working directory of the process. Opt-In.
+  , processInteractive :: Maybe Bool
+  -- ^ Whether the process is connected to an interactive shell. Opt-In.
+  , processTitle :: Maybe Text
+  -- ^ Process title (proctitle). Opt-In.
+  , processLinuxCgroup :: Maybe Text
+  -- ^ The control group associated with the process. Opt-In.
   }
 
 
@@ -69,6 +86,13 @@ instance ToResource Process where
       , unkey SC.process_commandLine .=? processCommandLine
       , unkey SC.process_commandArgs .=? processCommandArgs
       , unkey SC.process_owner .=? processOwner
+      , unkey SC.process_creation_time .=? processCreationTime
+      , unkey SC.process_argsCount .=? processArgsCount
+      , unkey SC.process_parentPid .=? processParentPid
+      , unkey SC.process_workingDirectory .=? processWorkingDirectory
+      , unkey SC.process_interactive .=? processInteractive
+      , unkey SC.process_title .=? processTitle
+      , unkey SC.process_linux_cgroup .=? processLinuxCgroup
       ]
 
 

--- a/sdk/hs-opentelemetry-sdk.cabal
+++ b/sdk/hs-opentelemetry-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.38.3.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -34,6 +34,7 @@ flag tls-metadata
 
 library
   exposed-modules:
+      OpenTelemetry.SDK
       OpenTelemetry.Configuration
       OpenTelemetry.Configuration.Create
       OpenTelemetry.Configuration.Parse
@@ -113,6 +114,7 @@ library
     , case-insensitive
     , clock
     , containers
+    , directory
     , hashable
     , hs-opentelemetry-api ==1.0.*
     , hs-opentelemetry-exporter-handle ==1.0.*
@@ -131,6 +133,7 @@ library
     , scientific
     , stm
     , text
+    , time
     , unix-compat >=0.7.1
     , unordered-containers
     , vector

--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -30,6 +30,7 @@ flags:
 
 library:
   exposed-modules:
+  - OpenTelemetry.SDK
   - OpenTelemetry.Configuration
   - OpenTelemetry.Configuration.Create
   - OpenTelemetry.Configuration.Parse
@@ -89,6 +90,7 @@ library:
   - aeson
   - async
   - bytestring
+  - directory
   - case-insensitive
   - clock
   - containers
@@ -101,6 +103,7 @@ library:
   - scientific
   - stm
   - text
+  - time
   - unix-compat >= 0.7.1 # for getProcessID
   - unordered-containers
   - vector

--- a/sdk/src/OpenTelemetry/Resource/Process/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/Process/Detector.hs
@@ -1,14 +1,20 @@
 module OpenTelemetry.Resource.Process.Detector where
 
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.Version
-import OpenTelemetry.Platform (tryGetUser)
+import OpenTelemetry.Platform (tryGetParentProcessID, tryGetUser)
 import OpenTelemetry.Resource.Process
+import System.Directory (getCurrentDirectory)
 import System.Environment (
   getArgs,
   getExecutablePath,
   getProgName,
  )
+import System.IO (hIsTerminalDevice, stdin)
+import System.IO.Error (tryIOError)
 import System.Info
 import System.PosixCompat.Process (getProcessID)
 
@@ -20,14 +26,41 @@ import System.PosixCompat.Process (getProcessID)
 -}
 detectProcess :: IO Process
 detectProcess = do
+  progName <- getProgName
+  args <- getArgs
+  now <- getCurrentTime
+  let allArgs = progName : args
+  ppid <- tryGetParentProcessID
+  cwd <- Just . T.pack <$> getCurrentDirectory
+  interactive <- Just <$> hIsTerminalDevice stdin
+  cgroup <- detectLinuxCgroup
   Process
     <$> (Just . fromIntegral <$> getProcessID)
-    <*> (Just . T.pack <$> getProgName)
+    <*> pure (Just (T.pack progName))
     <*> (Just . T.pack <$> getExecutablePath)
-    <*> (Just . T.pack <$> getProgName)
+    <*> pure (Just (T.pack progName))
     <*> pure Nothing
-    <*> (Just . map T.pack <$> getArgs)
+    <*> pure (Just (fmap T.pack allArgs))
     <*> tryGetUser
+    <*> pure (Just (T.pack (iso8601Show now)))
+    <*> pure (Just (length allArgs))
+    <*> pure ppid
+    <*> pure cwd
+    <*> pure interactive
+    <*> pure (Just (T.pack progName))
+    <*> pure cgroup
+
+
+detectLinuxCgroup :: IO (Maybe T.Text)
+detectLinuxCgroup = do
+  result <- tryIOError (T.readFile "/proc/self/cgroup")
+  pure $ case result of
+    Right content
+      | not (T.null content) ->
+          case T.lines content of
+            (firstLine : _) -> Just (T.strip firstLine)
+            _ -> Nothing
+    _ -> Nothing
 
 
 {- | A 'ProcessRuntime' 'Resource' populated with the current process' knoweldge

--- a/sdk/src/platform/unix/OpenTelemetry/Platform.hs
+++ b/sdk/src/platform/unix/OpenTelemetry/Platform.hs
@@ -8,6 +8,7 @@ module OpenTelemetry.Platform where
 import Control.Exception (throwIO, try)
 import qualified Data.Text as T
 import System.IO.Error (isDoesNotExistError)
+import System.Posix.Process (getParentProcessID)
 import System.Posix.User (getEffectiveUserName)
 
 
@@ -20,3 +21,8 @@ tryGetUser = do
         then pure Nothing
         else throwIO err
     Right ok -> pure $ Just $ T.pack ok
+
+
+tryGetParentProcessID :: IO (Maybe Int)
+tryGetParentProcessID =
+  Just . fromIntegral <$> getParentProcessID

--- a/sdk/src/platform/windows/OpenTelemetry/Platform.hs
+++ b/sdk/src/platform/windows/OpenTelemetry/Platform.hs
@@ -10,3 +10,7 @@ import qualified Data.Text as T
 
 tryGetUser :: IO (Maybe T.Text)
 tryGetUser = pure Nothing
+
+
+tryGetParentProcessID :: IO (Maybe Int)
+tryGetParentProcessID = pure Nothing


### PR DESCRIPTION
## Summary
- process.creation.time (Required per spec): detected at SDK init
- process.command_args includes argv[0] per spec
- 6 new Opt-In fields with auto-detection: args_count, parent_pid, working_directory, interactive, title, linux.cgroup

## Test plan
- [x] cabal test hs-opentelemetry-sdk