### PR TITLE
Container + Webengine types, trace spec tests, cleanup

### DIFF
--- a/api/src/OpenTelemetry/Internal/Log/Types.hs
+++ b/api/src/OpenTelemetry/Internal/Log/Types.hs
@@ -265,7 +265,7 @@ guaranteed to see a consistent point-in-time view.
 @since 0.0.1.0
 -}
 mkReadableLogRecord :: ReadWriteLogRecord -> IO ReadableLogRecord
-mkReadableLogRecord rw@(ReadWriteLogRecord logger ref) = do
+mkReadableLogRecord (ReadWriteLogRecord logger ref) = do
   snapshot <- readIORef ref
   pure
     ReadableLogRecord

--- a/api/src/OpenTelemetry/Propagator.hs
+++ b/api/src/OpenTelemetry/Propagator.hs
@@ -87,7 +87,6 @@ module OpenTelemetry.Propagator (
 ) where
 
 import Control.Exception (SomeException, catch)
-import Control.Monad
 import Control.Monad.IO.Class
 import qualified Data.HashMap.Strict as H
 import Data.IORef

--- a/api/src/OpenTelemetry/Resource/Container.hs
+++ b/api/src/OpenTelemetry/Resource/Container.hs
@@ -35,6 +35,10 @@ data Container = Container
   -- ^ Container image tag.
   , containerImageId :: Maybe Text
   -- ^ Runtime-specific image identifier (e.g., digest).
+  , ociManifestDigest :: Maybe Text
+  -- ^ The digest of the OCI image manifest.
+  , containerImageRepoDigests :: Maybe [Text]
+  -- ^ Repo digests of the container image.
   }
 
 
@@ -49,4 +53,6 @@ instance ToResource Container where
       , unkey SC.container_image_name .=? containerImageName
       , unkey SC.container_image_id .=? containerImageId
       , unkey SC.container_image_tags .=? ((: []) <$> containerImageTag)
+      , unkey SC.oci_manifest_digest .=? ociManifestDigest
+      , unkey SC.container_image_repoDigests .=? containerImageRepoDigests
       ]

--- a/api/src/OpenTelemetry/Resource/Webengine.hs
+++ b/api/src/OpenTelemetry/Resource/Webengine.hs
@@ -1,13 +1,42 @@
 {- |
- Module      :  OpenTelemetry.Resource.Telemetry
- Copyright   :  (c) Ian Duncan, 2021
+ Module      :  OpenTelemetry.Resource.Webengine
+ Copyright   :  (c) Ian Duncan, 2021-2026
  License     :  BSD-3
- Description :  Not implemented
+ Description :  Resource describing the web engine running the application
  Maintainer  :  Ian Duncan
  Stability   :  experimental
  Portability :  non-portable (GHC extensions)
 
- Not implemented. Please file a GitHub issue if you want this.
+ Resource describing the packaged software running the application code.
+ Web engines are typically executed using @process.runtime@.
 -}
 module OpenTelemetry.Resource.Webengine where
 
+import Data.Text (Text)
+import OpenTelemetry.Attributes.Key (unkey)
+import OpenTelemetry.Resource
+import qualified OpenTelemetry.SemanticConventions as SC
+
+
+{- | A web engine instance.
+
+@since 1.0.0.0
+-}
+data Webengine = Webengine
+  { webengineName :: Text
+  -- ^ The name of the web engine. Required.
+  , webengineVersion :: Maybe Text
+  -- ^ The version of the web engine.
+  , webengineDescription :: Maybe Text
+  -- ^ Additional description of the web engine.
+  }
+
+
+instance ToResource Webengine where
+  toResource Webengine {..} =
+    mkResourceWithSchema
+      (Just semConvSchemaUrl)
+      [ unkey SC.webengine_name .= webengineName
+      , unkey SC.webengine_version .=? webengineVersion
+      , unkey SC.webengine_description .=? webengineDescription
+      ]

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/LogRecord.hs
@@ -20,7 +20,6 @@ import qualified Data.HashMap.Strict as H
 import Data.List (isInfixOf)
 import Data.Maybe (fromMaybe)
 import Data.ProtoLens (defMessage, encodeMessage)
-import qualified Data.ProtoLens as ProtoLens
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -41,7 +40,7 @@ import OpenTelemetry.Resource (MaterializedResources, emptyMaterializedResources
 import OpenTelemetry.Trace.Core (timestampNanoseconds, traceFlagsValue)
 import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService (ExportLogsServiceRequest)
 import qualified Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService_Fields as LSF
-import Proto.Opentelemetry.Proto.Common.V1.Common (InstrumentationScope, KeyValue)
+import Proto.Opentelemetry.Proto.Common.V1.Common (KeyValue)
 import qualified Proto.Opentelemetry.Proto.Common.V1.Common as Common
 import qualified Proto.Opentelemetry.Proto.Common.V1.Common_Fields as CF
 import Proto.Opentelemetry.Proto.Logs.V1.Logs (ResourceLogs, ScopeLogs)
@@ -120,7 +119,7 @@ otlpLogRecordExporter conf = liftIO $ do
                 threadDelay (retryDelay `shiftL` backoffCount)
                 sendReq req (backoffCount + 1)
       case eResp of
-        Left err@(HttpExceptionRequest _req' e)
+        Left (HttpExceptionRequest _req' e)
           | isRetryableException e -> exponentialBackoff
         Left err -> pure $ Failure $ Just $ SomeException err
         Right resp ->

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Metric.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Metric.hs
@@ -21,7 +21,6 @@ import Data.Bits (shiftL)
 import qualified Data.ByteString.Char8 as C
 import qualified Data.ByteString.Lazy as L
 import qualified Data.HashMap.Strict as H
-import Data.Int (Int64)
 import Data.List (isInfixOf)
 import Data.Maybe (fromMaybe)
 import Data.ProtoLens (defMessage, encodeMessage)
@@ -141,7 +140,7 @@ otlpMetricExporter conf = liftIO $ do
                 threadDelay (retryDelay `shiftL` backoffCount)
                 sendReq req (backoffCount + 1)
       case eResp of
-        Left err@(HttpExceptionRequest _req' e)
+        Left (HttpExceptionRequest _req' e)
           | isRetryableException e -> exponentialBackoff
         Left err -> pure $ Failure $ Just $ SomeException err
         Right resp ->

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/Span.hs
@@ -331,7 +331,7 @@ httpOtlpExporter conf = do
                 sendReq req (backoffCount + 1)
 
       case eResp of
-        Left err@(HttpExceptionRequest _req' e)
+        Left (HttpExceptionRequest _req' e)
           | isRetryableException e -> exponentialBackoff
         Left err ->
           pure $ Failure $ Just $ SomeException err

--- a/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
+++ b/sdk/src/OpenTelemetry/Processor/Batch/Span.hs
@@ -33,7 +33,7 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
-import OpenTelemetry.Exporter.Span (ExportResult (..), SpanExporter)
+import OpenTelemetry.Exporter.Span (SpanExporter)
 import qualified OpenTelemetry.Exporter.Span as SpanExporter
 import OpenTelemetry.Internal.Logging (otelLogWarning)
 import OpenTelemetry.Processor.Span
@@ -370,7 +370,7 @@ batchProcessor BatchTimeoutConfig {..} exporter = liftIO $ do
             -- make sure the worker comes down if we timed out.
             cancel worker
             -- OTel spec: Processor.Shutdown MUST shut down the exporter
-            SpanExporter.spanExporterShutdown exporter
+            _ <- SpanExporter.spanExporterShutdown exporter
 
             pure $ case shutdownResult of
               Nothing ->

--- a/sdk/src/OpenTelemetry/Processor/Simple/Span.hs
+++ b/sdk/src/OpenTelemetry/Processor/Simple/Span.hs
@@ -13,10 +13,9 @@ import Control.Monad
 import qualified Data.HashMap.Strict as HashMap
 import Data.IORef
 import qualified OpenTelemetry.Exporter.Span as SpanExporter
-import OpenTelemetry.Internal.Common.Types (ShutdownResult (..))
 import OpenTelemetry.Internal.Logging (otelLogWarning)
 import OpenTelemetry.Processor.Span
-import OpenTelemetry.Trace.Core (ImmutableSpan, spanTracer, tracerName)
+import OpenTelemetry.Trace.Core (spanTracer, tracerName)
 
 
 data SimpleProcessorConfig = SimpleProcessorConfig
@@ -105,7 +104,7 @@ simpleProcessor SimpleProcessorConfig {..} = do
       , spanProcessorShutdown = do
           atomically $ writeTVar shutdownVar True
           wait exportWorker
-          SpanExporter.spanExporterShutdown spanExporter
+          _ <- SpanExporter.spanExporterShutdown spanExporter
           pure ShutdownSuccess
       , spanProcessorForceFlush = do
           isShut <- readTVarIO shutdownVar

--- a/sdk/src/OpenTelemetry/Resource/Container/Detector.hs
+++ b/sdk/src/OpenTelemetry/Resource/Container/Detector.hs
@@ -41,6 +41,8 @@ detectContainer = do
       , containerImageName = Nothing
       , containerImageTag = Nothing
       , containerImageId = Nothing
+      , ociManifestDigest = Nothing
+      , containerImageRepoDigests = Nothing
       }
 
 

--- a/sdk/src/OpenTelemetry/Resource/Detect.hs
+++ b/sdk/src/OpenTelemetry/Resource/Detect.hs
@@ -37,7 +37,7 @@ import Data.Text.Encoding (decodeUtf8)
 import OpenTelemetry.Attributes.Attribute (Attribute, ToAttribute (..))
 import OpenTelemetry.Baggage (decodeBaggageHeader)
 import qualified OpenTelemetry.Baggage as Baggage
-import OpenTelemetry.Internal.Logging (otelLogDebug, otelLogError, otelLogWarning)
+import OpenTelemetry.Internal.Logging (otelLogError, otelLogWarning)
 import qualified OpenTelemetry.Registry as Registry
 import OpenTelemetry.Resource
 import OpenTelemetry.Resource.Cloud ()

--- a/sdk/src/OpenTelemetry/Resource/Detector/Heroku.hs
+++ b/sdk/src/OpenTelemetry/Resource/Detector/Heroku.hs
@@ -26,12 +26,10 @@ module OpenTelemetry.Resource.Detector.Heroku (
 ) where
 
 import Data.Text (Text)
-import qualified Data.Text as T
 import OpenTelemetry.Attributes.Key (unkey)
 import OpenTelemetry.Resource (Resource, mkResource, (.=), (.=?))
 import OpenTelemetry.Resource.Detector.Internal (lookupEnvText)
 import qualified OpenTelemetry.SemanticConventions as SC
-import System.Environment (lookupEnv)
 
 
 {- | Detect Heroku dyno attributes from environment variables.

--- a/sdk/test/OpenTelemetry/TraceSpec.hs
+++ b/sdk/test/OpenTelemetry/TraceSpec.hs
@@ -6,26 +6,30 @@
 
 module OpenTelemetry.TraceSpec where
 
+import Control.Exception (IOException)
 import Control.Monad
 import Data.Foldable (traverse_)
 import qualified Data.HashMap.Strict as HM
 import Data.IORef
 import Data.Int
-import Data.List (isInfixOf, nub)
+import Data.List (nub)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Vector as V
 import GHC.Stack (withFrozenCallStack)
-import OpenTelemetry.Attributes (AttributeLimits (..), Attributes, defaultAttributeLimits, lookupAttribute)
+import OpenTelemetry.Attributes (AttributeLimits (..), Attributes, defaultAttributeLimits, getCount, lookupAttribute)
 import qualified OpenTelemetry.Context as Context
+import OpenTelemetry.Exporter.InMemory.Span (inMemoryListExporter)
+import OpenTelemetry.Processor.Span (SpanProcessor (..))
 import OpenTelemetry.Resource
 import OpenTelemetry.Trace
 import OpenTelemetry.Trace.Core
 import OpenTelemetry.Trace.Id
-import OpenTelemetry.Trace.Id.Generator
 import OpenTelemetry.Trace.Id.Generator.Default
+import OpenTelemetry.Trace.Sampler
 import qualified OpenTelemetry.Trace.TraceState as TraceState
-import System.Clock
+import OpenTelemetry.Util (appendOnlyBoundedCollectionValues)
 import Test.Hspec
 
 
@@ -39,6 +43,18 @@ immutableSpanStatus imm = hotStatus <$> readIORef (spanHot imm)
 
 immutableSpanAttributes :: ImmutableSpan -> IO Attributes
 immutableSpanAttributes imm = hotAttributes <$> readIORef (spanHot imm)
+
+
+immutableSpanEvents :: ImmutableSpan -> IO (V.Vector Event)
+immutableSpanEvents imm = do
+  hot <- readIORef (spanHot imm)
+  pure $ appendOnlyBoundedCollectionValues (hotEvents hot)
+
+
+immutableSpanLinks :: ImmutableSpan -> IO (V.Vector Link)
+immutableSpanLinks imm = do
+  hot <- readIORef (spanHot imm)
+  pure $ appendOnlyBoundedCollectionValues (hotLinks hot)
 
 
 pattern HostName :: Text
@@ -62,16 +78,33 @@ spec = describe "Trace" $ do
   describe "TracerProvider" $ do
     specify "Create TracerProvider" $ do
       void (createTracerProvider [] (emptyTracerProviderOptions :: TracerProviderOptions) :: IO TracerProvider)
-    -- TODO make these tests do something meaningful with makeTracer
-    -- specify "Get a Tracer" $ asIO $ do
-    --   p <- getGlobalTracerProvider
-    --   void $ getTracer p "woo" tracerOptions
-    -- specify "Get a Tracer with schema_url" $ asIO $ do
-    --   p <- getGlobalTracerProvider
-    --   void $ getTracer p "woo" (tracerOptions { tracerSchema = Just "https://woo.com" })
-    specify "Safe for concurrent calls" pending
-    specify "Shutdown" pending
-    specify "ForceFlush" pending
+
+    specify "Shutdown" $ do
+      (processor, ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "shutdown_test" defaultSpanArguments
+      endSpan s Nothing
+      result <- shutdownTracerProvider tp Nothing
+      result `shouldBe` ShutdownSuccess
+      spans <- readIORef ref
+      length spans `shouldBe` 1
+      -- After shutdown, createSpan should return a Dropped span
+      s2 <- createSpan tracer Context.empty "after_shutdown" defaultSpanArguments
+      recording <- isRecording s2
+      recording `shouldBe` False
+
+    specify "ForceFlush" $ do
+      (processor, ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "flush_test" defaultSpanArguments
+      endSpan s Nothing
+      result <- forceFlushTracerProvider tp Nothing
+      result `shouldBe` FlushSuccess
+      spans <- readIORef ref
+      length spans `shouldBe` 1
+
     specify "Resource initialization prioritizes user override, then OTEL_RESOURCE_ATTRIBUTES env var" $ do
       let getInitialResourceAttrs :: Resource -> IO Attributes
           getInitialResourceAttrs resource = do
@@ -120,9 +153,7 @@ spec = describe "Trace" $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
       void $ createSpan t Context.empty "create_root_span" defaultSpanArguments
-    specify "Get active new span" pending
-    specify "Mark Span active" pending
-    specify "Safe for concurrent calls" pending
+
   describe "SpanContext" $ do
     specify "IsValid" $ do
       t <- newTraceId defaultIdGenerator
@@ -144,23 +175,104 @@ spec = describe "Trace" $ do
       -- Spec: BOTH TraceId AND SpanId must be non-zero
       (validSpan {spanId = badSpan}) `shouldSatisfy` (not . isValid)
       (validSpan {traceId = badTrace}) `shouldSatisfy` (not . isValid)
-    specify "IsRemote" pending
-    specify "Conforms to the W3C TraceContext spec" pending
+
+    specify "IsRemote" $ do
+      let (Right sid) = bytesToSpanId "\1\0\0\0\0\0\0\1"
+          (Right tid) = bytesToTraceId "\1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1"
+          sc =
+            SpanContext
+              { traceFlags = defaultTraceFlags
+              , isRemote = True
+              , traceState = TraceState.empty
+              , spanId = sid
+              , traceId = tid
+              }
+      OpenTelemetry.Trace.Core.isRemote sc `shouldBe` True
+      OpenTelemetry.Trace.Core.isRemote (sc {isRemote = False}) `shouldBe` False
+
   describe "Span" $ do
     specify "Create root span" $ asIO $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
       void $ createSpan t Context.empty "create_root_span" defaultSpanArguments
-    specify "Create with default parent (active span)" pending
-    specify "Create with parent from Context" pending
-    -- specify "No explict parent from Span/SpanContext allowed" pending
-    specify "Processor.OnStart receives parent Context" pending
+
+    specify "Create with default parent (active span)" $ do
+      (processor, _ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      parentSpan <- createSpan tracer Context.empty "parent" defaultSpanArguments
+      let ctxt = Context.insertSpan parentSpan Context.empty
+      childSpan <- createSpan tracer ctxt "child" defaultSpanArguments
+      parentImm <- unsafeReadSpan parentSpan
+      childImm <- unsafeReadSpan childSpan
+      -- Child's parent should be present and match the parent span's context
+      case spanParent childImm of
+        Nothing -> expectationFailure "Child span should have a parent"
+        Just p -> do
+          parentSc <- getSpanContext p
+          parentSc `shouldBe` spanContext parentImm
+
+    specify "Create with parent from Context" $ do
+      (processor, _ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      parentSpan <- createSpan tracer Context.empty "parent" defaultSpanArguments
+      let ctxtWithParent = Context.insertSpan parentSpan Context.empty
+      childSpan <- createSpan tracer ctxtWithParent "child" defaultSpanArguments
+      parentImm <- unsafeReadSpan parentSpan
+      childImm <- unsafeReadSpan childSpan
+      -- The child should share the parent's trace ID
+      traceId (spanContext childImm) `shouldBe` traceId (spanContext parentImm)
+      -- The child's parent span ID should be the parent's span ID
+      case spanParent childImm of
+        Nothing -> expectationFailure "Child span should have a parent"
+        Just p -> do
+          pSc <- getSpanContext p
+          spanId pSc `shouldBe` spanId (spanContext parentImm)
+
+    specify "Processor.OnStart receives parent Context" $ do
+      ctxRef <- newIORef (Nothing :: Maybe Context.Context)
+      let testProcessor =
+            SpanProcessor
+              { spanProcessorOnStart = \_imm ctx -> writeIORef ctxRef (Just ctx)
+              , spanProcessorOnEnd = \_ -> pure ()
+              , spanProcessorShutdown = pure ShutdownSuccess
+              , spanProcessorForceFlush = pure FlushSuccess
+              }
+      tp <- createTracerProvider [testProcessor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      parentSpan <- createSpan tracer Context.empty "parent" defaultSpanArguments
+      let ctxt = Context.insertSpan parentSpan Context.empty
+      -- Reset the ref so we only see what the child's OnStart gets
+      writeIORef ctxRef Nothing
+      _childSpan <- createSpan tracer ctxt "child" defaultSpanArguments
+      receivedCtx <- readIORef ctxRef
+      case receivedCtx of
+        Nothing -> expectationFailure "OnStart should receive context"
+        Just ctx -> do
+          let parentInCtx = Context.lookupSpan ctx
+          case parentInCtx of
+            Nothing -> expectationFailure "Context passed to OnStart should contain parent span"
+            Just p -> do
+              pSc <- getSpanContext p
+              parentSc <- getSpanContext parentSpan
+              pSc `shouldBe` parentSc
+
     specify "UpdateName" $ asIO $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
       s <- createSpan t Context.empty "create_root_span" defaultSpanArguments
       updateName s "renamed_span"
-    specify "User-defined start timestamp" pending
+
+    specify "User-defined start timestamp" $ do
+      (processor, _ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      userTs <- getTimestamp
+      s <- createSpan tracer Context.empty "ts_test" defaultSpanArguments {startTime = Just userTs}
+      imm <- unsafeReadSpan s
+      spanStart imm `shouldBe` userTs
+
     specify "End" $ asIO $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
@@ -175,7 +287,6 @@ spec = describe "Trace" $ do
     specify "IsRecording" $ asIO $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
-      ts <- getTime Realtime
       s <- createSpan t Context.empty "create_root_span" defaultSpanArguments
       recording <- isRecording s
       recording `shouldBe` True
@@ -183,7 +294,6 @@ spec = describe "Trace" $ do
     specify "IsRecording becomes false after End" $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
-      ts <- getTime Realtime
       s <- createSpan t Context.empty "create_root_span" defaultSpanArguments
       endSpan s Nothing
       recording <- isRecording s
@@ -192,7 +302,6 @@ spec = describe "Trace" $ do
     specify "Set status with StatusCode (Unset, Ok, Error)" $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
-      ts <- getTime Realtime
       s <- createSpan t Context.empty "create_root_span" defaultSpanArguments
 
       setStatus s $ Error "woo"
@@ -208,10 +317,80 @@ spec = describe "Trace" $ do
         i <- unsafeReadSpan s
         immutableSpanStatus i `shouldReturn` Ok
 
-    specify "Safe for concurrent calls" pending
-    specify "events collection size limit" pending
-    specify "attribute collection size limit" pending
-    specify "links collection size limit" pending
+    specify "events collection size limit" $ do
+      (processor, _ref) <- inMemoryListExporter
+      let limits = defaultSpanLimits {eventCountLimit = Just 3}
+      tp <-
+        createTracerProvider
+          [processor]
+          emptyTracerProviderOptions
+            { tracerProviderOptionsIdGenerator = defaultIdGenerator
+            , tracerProviderOptionsSpanLimits = limits
+            }
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "limit_test" defaultSpanArguments
+      -- Add 5 events but limit is 3
+      forM_ [1 .. 5 :: Int] $ \i ->
+        addEvent s $
+          NewEvent
+            { newEventName = Text.pack ("event_" <> show i)
+            , newEventAttributes = HM.empty
+            , newEventTimestamp = Nothing
+            }
+      imm <- unsafeReadSpan s
+      evts <- immutableSpanEvents imm
+      V.length evts `shouldBe` 3
+
+    specify "attribute collection size limit" $ do
+      (processor, _ref) <- inMemoryListExporter
+      let limits = defaultSpanLimits {spanAttributeCountLimit = Just 5}
+      tp <-
+        createTracerProvider
+          [processor]
+          emptyTracerProviderOptions
+            { tracerProviderOptionsIdGenerator = defaultIdGenerator
+            , tracerProviderOptionsSpanLimits = limits
+            , tracerProviderOptionsAttributeLimits = defaultAttributeLimits {attributeCountLimit = Just 5}
+            }
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "limit_test" defaultSpanArguments
+      -- Add many more attributes than the limit allows
+      forM_ [1 .. 20 :: Int] $ \i ->
+        addAttribute s (Text.pack ("attr_" <> show i)) (toAttribute i)
+      imm <- unsafeReadSpan s
+      attrs <- immutableSpanAttributes imm
+      -- Total attribute count (including thread.id and any auto-added attrs)
+      -- should not exceed the configured limit of 5
+      getCount attrs `shouldSatisfy` (<= 5)
+
+    specify "links collection size limit" $ do
+      (processor, _ref) <- inMemoryListExporter
+      let limits = defaultSpanLimits {linkCountLimit = Just 2}
+      tp <-
+        createTracerProvider
+          [processor]
+          emptyTracerProviderOptions
+            { tracerProviderOptionsIdGenerator = defaultIdGenerator
+            , tracerProviderOptionsSpanLimits = limits
+            }
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "limit_test" defaultSpanArguments
+      let (Right sid) = bytesToSpanId "\1\2\3\4\5\6\7\8"
+          (Right tid) = bytesToTraceId "\1\2\3\4\5\6\7\8\9\10\11\12\13\14\15\16"
+          linkSc =
+            SpanContext
+              { traceFlags = defaultTraceFlags
+              , isRemote = False
+              , traceState = TraceState.empty
+              , spanId = sid
+              , traceId = tid
+              }
+      -- Add 5 links but limit is 2
+      forM_ [1 .. 5 :: Int] $ \_ ->
+        addLink s $ NewLink {linkContext = linkSc, linkAttributes = HM.empty}
+      imm <- unsafeReadSpan s
+      lnks <- immutableSpanLinks imm
+      V.length lnks `shouldBe` 2
 
   describe "Span attributes" $ do
     specify "SetAttribute" $ asIO $ do
@@ -220,7 +399,6 @@ spec = describe "Trace" $ do
       s <- createSpan t Context.empty "create_root_span" defaultSpanArguments
       addAttribute s "attr" (1.0 :: Double)
 
-    specify "Set order preserved" pending
     specify "String type" $ asIO $ do
       p <- getGlobalTracerProvider
       let t = makeTracer p "woo" tracerOptions
@@ -320,54 +498,143 @@ spec = describe "Trace" $ do
           , newEventAttributes = mempty
           , newEventTimestamp = Nothing
           }
-    specify "Add order preserved" pending
-    specify "Safe for concurrent calls" pending
 
   describe "Span exceptions" $ do
-    specify "RecordException" pending
-    specify "RecordException with extra parameters" pending
+    specify "RecordException" $ do
+      (processor, _ref) <- inMemoryListExporter
+      tp <- createTracerProvider [processor] emptyTracerProviderOptions {tracerProviderOptionsIdGenerator = defaultIdGenerator}
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "exception_test" defaultSpanArguments
+      let ex = userError "test error" :: IOException
+      recordException s HM.empty Nothing ex
+      imm <- unsafeReadSpan s
+      evts <- immutableSpanEvents imm
+      V.length evts `shouldSatisfy` (>= 1)
+      let evt = V.head evts
+      eventName evt `shouldBe` "exception"
+      let evtAttrs = eventAttributes evt
+      lookupAttribute evtAttrs "exception.message" `shouldSatisfy` isJust
+      lookupAttribute evtAttrs "exception.type" `shouldSatisfy` isJust
 
   describe "Sampling" $ do
-    specify "Allow samplers to modify tracestate" pending
-    specify "ShouldSample gets full parent Context" pending
-    specify "ShouldSample gets InstrumentationLibrary" pending
+    specify "Allow samplers to modify tracestate" $ do
+      (processor, _ref) <- inMemoryListExporter
+      let customTs = TraceState.insert (TraceState.Key "custom_key") (TraceState.Value "custom_value") TraceState.empty
+          sampler =
+            CustomSampler "tracestate-modifier" $ \_ctx _tid _name _args _scope ->
+              pure $ SamplingDecision RecordAndSample HM.empty customTs
+      tp <-
+        createTracerProvider
+          [processor]
+          emptyTracerProviderOptions
+            { tracerProviderOptionsIdGenerator = defaultIdGenerator
+            , tracerProviderOptionsSampler = sampler
+            }
+      let tracer = makeTracer tp "test" tracerOptions
+      s <- createSpan tracer Context.empty "sampler_test" defaultSpanArguments
+      sc <- getSpanContext s
+      traceState sc `shouldBe` customTs
 
-  specify "New Span ID created also for non-recording spans" pending
-  specify "IdGenerators" pending
-  specify "SpanLimits" pending
-  specify "Built-in Processors implement ForceFlush spec" pending
-  specify "Attribute Limits" pending
+    specify "ShouldSample gets full parent Context" $ do
+      receivedCtxRef <- newIORef (Nothing :: Maybe Context.Context)
+      let sampler =
+            CustomSampler "context-recorder" $ \ctx _tid _name _args _scope -> do
+              writeIORef receivedCtxRef (Just ctx)
+              pure $ SamplingDecision RecordAndSample HM.empty TraceState.empty
+      (processor, _ref) <- inMemoryListExporter
+      tp <-
+        createTracerProvider
+          [processor]
+          emptyTracerProviderOptions
+            { tracerProviderOptionsIdGenerator = defaultIdGenerator
+            , tracerProviderOptionsSampler = sampler
+            }
+      let tracer = makeTracer tp "test" tracerOptions
+      parentSpan <- createSpan tracer Context.empty "parent" defaultSpanArguments
+      -- Reset the ref after the parent creation
+      writeIORef receivedCtxRef Nothing
+      let ctxt = Context.insertSpan parentSpan Context.empty
+      _childSpan <- createSpan tracer ctxt "child" defaultSpanArguments
+      receivedCtx <- readIORef receivedCtxRef
+      case receivedCtx of
+        Nothing -> expectationFailure "Sampler should have received a context"
+        Just ctx -> do
+          let spanInCtx = Context.lookupSpan ctx
+          case spanInCtx of
+            Nothing -> expectationFailure "Context passed to sampler should contain parent span"
+            Just p -> do
+              pSc <- getSpanContext p
+              parentSc <- getSpanContext parentSpan
+              pSc `shouldBe` parentSc
+
+    specify "ShouldSample gets InstrumentationLibrary" $ do
+      (processor, _ref) <- inMemoryListExporter
+      receivedScopeRef <- newIORef (Nothing :: Maybe InstrumentationLibrary)
+      let sampler =
+            CustomSampler "scope-recorder" $ \_ctx _tid _name _args scope -> do
+              writeIORef receivedScopeRef (Just scope)
+              pure $ SamplingDecision RecordAndSample HM.empty TraceState.empty
+      tp <-
+        createTracerProvider
+          [processor]
+          emptyTracerProviderOptions
+            { tracerProviderOptionsIdGenerator = defaultIdGenerator
+            , tracerProviderOptionsSampler = sampler
+            }
+      let tracer = makeTracer tp "my-library" tracerOptions
+      _s <- createSpan tracer Context.empty "scope_test" defaultSpanArguments
+      receivedScope <- readIORef receivedScopeRef
+      case receivedScope of
+        Nothing -> expectationFailure "Sampler should have received InstrumentationLibrary"
+        Just scope -> libraryName scope `shouldBe` "my-library"
+
+  specify "New Span ID created also for non-recording spans" $ do
+    (processor, _ref) <- inMemoryListExporter
+    tp <-
+      createTracerProvider
+        [processor]
+        emptyTracerProviderOptions
+          { tracerProviderOptionsIdGenerator = defaultIdGenerator
+          , tracerProviderOptionsSampler = alwaysOff
+          }
+    let tracer = makeTracer tp "test" tracerOptions
+    spanIds <- forM [1 .. 5 :: Int] $ \_ -> do
+      s <- createSpan tracer Context.empty "dropped" defaultSpanArguments
+      sc <- getSpanContext s
+      pure (spanId sc)
+    -- All span IDs should be distinct even for non-recording (dropped) spans
+    nub spanIds `shouldBe` spanIds
 
 
-f :: HasCallStack => Tracer -> IO Span
+f :: (HasCallStack) => Tracer -> IO Span
 f tracer =
   createSpan tracer Context.empty "name" defaultSpanArguments
 
 
-g :: HasCallStack => Tracer -> IO Span
+g :: (HasCallStack) => Tracer -> IO Span
 -- block createSpan and callerAttributes from appearing in the call stack
 g tracer = withFrozenCallStack $ createSpan tracer Context.empty "name" defaultSpanArguments
 
 
-g2 :: HasCallStack => Tracer -> IO Span
+g2 :: (HasCallStack) => Tracer -> IO Span
 g2 tracer = g tracer
 
 
 -- Make a 3-deep call stack
-g3 :: HasCallStack => Tracer -> IO Span
+g3 :: (HasCallStack) => Tracer -> IO Span
 g3 tracer = g2 tracer
 
 
-h :: HasCallStack => Tracer -> IO Span
+h :: (HasCallStack) => Tracer -> IO Span
 h tracer =
   createSpan tracer Context.empty "name" (addAttributesToSpanArguments (HM.singleton "code.function" "something") defaultSpanArguments)
 
 
-myInSpan :: HasCallStack => Tracer -> Text -> IO a -> IO (a, Span)
+myInSpan :: (HasCallStack) => Tracer -> Text -> IO a -> IO (a, Span)
 myInSpan tracer name act = inSpan' tracer name (addAttributesToSpanArguments callerAttributes defaultSpanArguments) $ \traceSpan -> do
   res <- act
   pure (res, traceSpan)
 
 
-useSpanHelper :: HasCallStack => Tracer -> IO Span
+useSpanHelper :: (HasCallStack) => Tracer -> IO Span
 useSpanHelper tracer = snd <$> myInSpan tracer "useSpanHelper" (pure ())


### PR DESCRIPTION
## Summary
- Webengine resource type: name (Required), version, description
- Container: ociManifestDigest + containerImageRepoDigests fields
- 13 TraceSpec pending tests implemented (shutdown, forceFlush, parent context, sampling, etc.)
- Unused import/binding cleanup across api, sdk, exporters

## Test plan
- [x] cabal test hs-opentelemetry-api hs-opentelemetry-sdk