### PR TITLE
Amazonka hooks

### DIFF
--- a/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
+++ b/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
@@ -43,10 +43,21 @@ module OpenTelemetry.Instrumentation.Amazonka (
 
 import Amazonka.Data.Text (toText)
 import Amazonka.Env (Env, Env' (..))
-import Amazonka.Env.Hooks (Finality (..), Hook, Hook_, Hooks (..))
+import Amazonka.Env.Hooks (
+  Finality (..),
+  Hook,
+  Hook_,
+  Hooks (..),
+  addHook_,
+  clientResponseHook,
+  configuredRequestHook,
+  errorHook,
+  responseHook,
+ )
 import qualified Amazonka.Types as AWS
 import Control.Applicative ((<|>))
 import Control.Exception (onException)
+import Data.Function ((&))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -98,20 +109,21 @@ control over hook composition.
 instrumentHooks :: Tracer -> Hooks -> Hooks
 instrumentHooks tracer baseHooks =
   baseHooks
-    { configuredRequest = tracingConfiguredRequest tracer (configuredRequest baseHooks)
-    , clientResponse = tracingClientResponse (clientResponse baseHooks)
-    , response = tracingResponse (response baseHooks)
-    , error = tracingError (error baseHooks)
-    }
+    & configuredRequestHook (addTracingConfiguredRequest tracer)
+    & clientResponseHook (addHook_ tracingClientResponse)
+    & responseHook (addHook_ tracingResponse)
+    & errorHook (addHook_ tracingError)
 
 
-tracingConfiguredRequest
+-- Unlike the other hooks in this module, we have to call the base
+-- hook ourselves to catch exceptions here.
+addTracingConfiguredRequest
   :: forall a
    . (AWS.AWSRequest a, Typeable a)
   => Tracer
   -> Hook (AWS.Request a)
   -> Hook (AWS.Request a)
-tracingConfiguredRequest tracer baseHook env req = do
+addTracingConfiguredRequest tracer baseHook env req = do
   let svc = (AWS.service req :: AWS.Service)
       svcAbbrev = toText svc.abbrev
       opName = T.pack $ tyConName $ typeRepTyCon $ typeRep (Proxy @a)
@@ -143,8 +155,7 @@ tracingClientResponse
   :: forall a
    . (AWS.AWSRequest a, Typeable a)
   => Hook_ (AWS.Request a, AWS.ClientResponse ())
-  -> Hook_ (AWS.Request a, AWS.ClientResponse ())
-tracingClientResponse baseHook env arg@(_req, resp) = do
+tracingClientResponse _ (_, resp) = do
   ctx <- getContext
   case lookupSpan ctx of
     Just span -> do
@@ -158,47 +169,39 @@ tracingClientResponse baseHook env arg@(_req, resp) = do
                   Nothing -> []
       addAttributes span attrs
     Nothing -> pure ()
-  baseHook env arg
 
 
 tracingResponse
   :: forall a
    . (AWS.AWSRequest a, Typeable a)
   => Hook_ (AWS.Request a, AWS.ClientResponse (AWS.AWSResponse a))
-  -> Hook_ (AWS.Request a, AWS.ClientResponse (AWS.AWSResponse a))
-tracingResponse baseHook env arg = do
-  result <- baseHook env arg
+tracingResponse _ _ = do
   ctx <- getContext
   case lookupSpan ctx of
     Just span -> endSpan span Nothing
     Nothing -> pure ()
-  pure result
 
 
 tracingError
   :: forall a
    . (AWS.AWSRequest a, Typeable a)
   => Hook_ (Finality, AWS.Request a, AWS.Error)
-  -> Hook_ (Finality, AWS.Request a, AWS.Error)
-tracingError baseHook env arg@(finality, _req, err) = do
-  case finality of
-    Final -> do
-      ctx <- getContext
-      case lookupSpan ctx of
-        Just span -> do
-          let errDesc = describeError err
-              attrs =
-                HM.fromList $
-                  (unkey SC.error_type, toAttribute errDesc)
-                    : case extractServiceRequestId err of
-                      Just reqId -> [(unkey SC.aws_requestId, toAttribute reqId)]
-                      Nothing -> []
-          addAttributes span attrs
-          setStatus span (Error errDesc)
-          endSpan span Nothing
-        Nothing -> pure ()
-    NotFinal -> pure ()
-  baseHook env arg
+tracingError _ (Final, _, err) = do
+  ctx <- getContext
+  case lookupSpan ctx of
+    Just span -> do
+      let errDesc = describeError err
+          attrs =
+            HM.fromList $
+              (unkey SC.error_type, toAttribute errDesc)
+                : case extractServiceRequestId err of
+                  Just reqId -> [(unkey SC.aws_requestId, toAttribute reqId)]
+                  Nothing -> []
+      addAttributes span attrs
+      setStatus span (Error errDesc)
+      endSpan span Nothing
+    Nothing -> pure ()
+tracingError _ _ = pure ()
 
 
 requestIdFromHeaders :: [Header] -> Maybe T.Text

--- a/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
+++ b/instrumentation/amazonka/src/OpenTelemetry/Instrumentation/Amazonka.hs
@@ -60,7 +60,6 @@ import OpenTelemetry.Context (insertSpan, lookupSpan)
 import OpenTelemetry.Context.ThreadLocal (getAndAdjustContext, getContext)
 import qualified OpenTelemetry.SemanticConventions as SC
 import OpenTelemetry.Trace.Core (
-  Span,
   SpanArguments (..),
   SpanKind (Client),
   SpanStatus (Error),
@@ -71,7 +70,7 @@ import OpenTelemetry.Trace.Core (
   endSpan,
   setStatus,
  )
-import Prelude hiding (error)
+import Prelude hiding (error, span)
 
 
 {- | Add OpenTelemetry tracing hooks to an Amazonka 'Env'.
@@ -117,7 +116,7 @@ tracingConfiguredRequest tracer baseHook env req = do
       svcAbbrev = toText svc.abbrev
       opName = T.pack $ tyConName $ typeRepTyCon $ typeRep (Proxy @a)
       spanName = svcAbbrev <> "." <> opName
-      region = AWS.fromRegion (Amazonka.Env.region env)
+      region_ = AWS.fromRegion (Amazonka.Env.region env)
       endpoint_ = AWS.endpoint (AWS.service req) (Amazonka.Env.region env)
       host = TE.decodeUtf8 (AWS.host endpoint_)
 
@@ -131,7 +130,7 @@ tracingConfiguredRequest tracer baseHook env req = do
               [ (unkey SC.rpc_system, toAttribute ("aws-api" :: T.Text))
               , (unkey SC.rpc_service, toAttribute svcAbbrev)
               , (unkey SC.rpc_method, toAttribute opName)
-              , (unkey SC.cloud_region, toAttribute region)
+              , (unkey SC.cloud_region, toAttribute region_)
               , (unkey SC.server_address, toAttribute host)
               ]
         }


### PR DESCRIPTION
It's cool that you've been able to use the Amazonka hooks system to implement this instrumentation. That's the sort of thing I hoped we would see when I built it. But the implementation doesn't use what I'd hoped would be the "easiest" interface. The payoff is that you write your hooks as standalone definitions and don't have to manually call the "base" hook.

*****

`Amazonka.Env.Hooks` has functions to simplify the wiring in of hooks
into its `Env` type. Where possible, migrate the Amazonka
instrumentation to use them.

`tracingConfiguredRequest` needs to manually wrap the base hook to
correctly handle exceptions; it has been renamed to
`addTracingConfiguredRequest` to make this distinction clear.

Note that `addHook_` will be deprecated in Amazonka 2.1 (whenever that
is released), and made internal in Amazonka 2.2, in favour of
field-specific hook-adding functions like `addConfiguredRequestHook`,
`addClientResponseHook`, etc.