### PR TITLE
Fixed compilation errors in `OpenTelemetry.Instrumentation.ProcessMetrics`.

### DIFF
--- a/instrumentation/ghc-metrics/ChangeLog.md
+++ b/instrumentation/ghc-metrics/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for hs-opentelemetry-instrumentation-ghc-metrics
 
+## 1.0.0.1
+
+- Fixed compilation errors in `OpenTelemetry.Instrumentation.ProcessMetrics`.
+
 ## 1.0.0.0 - 2026-05-29
 
 - Promoted to 1.0.0.0 for the hs-opentelemetry 1.0 release.

--- a/instrumentation/ghc-metrics/hs-opentelemetry-instrumentation-ghc-metrics.cabal
+++ b/instrumentation/ghc-metrics/hs-opentelemetry-instrumentation-ghc-metrics.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          hs-opentelemetry-instrumentation-ghc-metrics
-version:       1.0.0.0
+version:       1.0.0.1
 synopsis:      OpenTelemetry metrics for the GHC runtime (RTS statistics)
 description:
   Registers observable instruments that report GHC RTS statistics as OpenTelemetry

--- a/instrumentation/ghc-metrics/src/OpenTelemetry/Instrumentation/ProcessMetrics.hs
+++ b/instrumentation/ghc-metrics/src/OpenTelemetry/Instrumentation/ProcessMetrics.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 {- |
 Module      : OpenTelemetry.Instrumentation.ProcessMetrics
@@ -86,6 +87,7 @@ import System.IO.Unsafe (unsafePerformIO)
 #if defined(linux_HOST_OS)
 import Control.Exception (SomeException, catch)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as Char8
 import System.Directory (listDirectory)
 #endif
 
@@ -379,7 +381,7 @@ parseProcCountField label =
     `catch` \(_ :: SomeException) -> pure Nothing
 
 extractCountField :: BS.ByteString -> BS.ByteString -> Maybe Int64
-extractCountField label bs = go (BS.lines bs)
+extractCountField label bs = go (Char8.lines bs)
   where
     go [] = Nothing
     go (line : rest)
@@ -394,7 +396,7 @@ extractCountField label bs = go (BS.lines bs)
     isDigit w = w >= 0x30 && w <= 0x39
 
 extractKbField :: BS.ByteString -> BS.ByteString -> Maybe Int64
-extractKbField label bs = go (BS.lines bs)
+extractKbField label bs = go (Char8.lines bs)
   where
     go [] = Nothing
     go (line : rest)


### PR DESCRIPTION
Hello :wave:

I wanted to test out the new `hs-opentelemetry-instrumentation-ghc-metrics` package, but when I went to try it out in my project, I got the the following errors:
```
[2 of 2] Compiling OpenTelemetry.Instrumentation.ProcessMetrics ( src/OpenTelemetry/Instrumentation/ProcessMetrics.hs, dist/build/OpenTelemetry/Instrumentation/ProcessMetrics.o, dist/build/OpenTelemetry/Instrumentation/ProcessMetrics.dyn_o )
src/OpenTelemetry/Instrumentation/ProcessMetrics.hs:371:15: error: [GHC-74097]
    Illegal type signature: ‘SomeException’
      Type signatures are only allowed in patterns with ScopedTypeVariables
    Suggested fix:
      Perhaps you intended to use the ‘ScopedTypeVariables’ extension
    |
371 |     `catch` \(_ :: SomeException) -> pure Nothing
    |               ^^^^^^^^^^^^^^^^^^

src/OpenTelemetry/Instrumentation/ProcessMetrics.hs:379:15: error: [GHC-74097]
    Illegal type signature: ‘SomeException’
      Type signatures are only allowed in patterns with ScopedTypeVariables
    Suggested fix:
      Perhaps you intended to use the ‘ScopedTypeVariables’ extension
    |
379 |     `catch` \(_ :: SomeException) -> pure Nothing
    |               ^^^^^^^^^^^^^^^^^^

src/OpenTelemetry/Instrumentation/ProcessMetrics.hs:382:34: error: [GHC-76037]
    Not in scope: ‘BS.lines’
    Note: The module ‘Data.ByteString’ does not export ‘lines’.
    |
382 | extractCountField label bs = go (BS.lines bs)
    |                                  ^^^^^^^^

src/OpenTelemetry/Instrumentation/ProcessMetrics.hs:397:31: error: [GHC-76037]
    Not in scope: ‘BS.lines’
    Note: The module ‘Data.ByteString’ does not export ‘lines’.
    |
397 | extractKbField label bs = go (BS.lines bs)
    |                               ^^^^^^^^

src/OpenTelemetry/Instrumentation/ProcessMetrics.hs:422:15: error: [GHC-74097]
    Illegal type signature: ‘SomeException’
      Type signatures are only allowed in patterns with ScopedTypeVariables
    Suggested fix:
      Perhaps you intended to use the ‘ScopedTypeVariables’ extension
    |
422 |     `catch` \(_ :: SomeException) -> pure 0
    |               ^^^^^^^^^^^^^^^^^^

src/OpenTelemetry/Instrumentation/ProcessMetrics.hs:432:15: error: [GHC-74097]
    Illegal type signature: ‘SomeException’
      Type signatures are only allowed in patterns with ScopedTypeVariables
    Suggested fix:
      Perhaps you intended to use the ‘ScopedTypeVariables’ extension
    |
432 |     `catch` \(_ :: SomeException) -> pure (0, 0)
    |               ^^^^^^^^^^^^^^^^^^

Error: [Cabal-7125]
Failed to build hs-opentelemetry-instrumentation-ghc-metrics-1.0.0.0 (which is required by test:discoslab-core-test from discoslab-core-0.0.0.0). See the build log above for details.
```

---

I fixed the errors by adding `ScopedTypeVariables` as an extension to the module and importing `lines` from `Data.ByteString.Char8` instead of `Data.ByteString`.