### PR TITLE
Attach backtraces from exception context with base-4.20+

### DIFF
--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Added `recordSomeException`.** Records an exception using the
+  `Backtraces` annotation attached to a `SomeException`'s `ExceptionContext`
+  (introduced in base 4.20 / GHC 9.10), so `exception.stacktrace` reflects
+  the richer stacks captured by `HasCallStack`, IPE, and other backtrace
+  mechanisms — not just cost-centre stacks. Falls back to `whoCreated` when
+  no `Backtraces` annotation is present or on older GHCs. Internal span
+  machinery (`inSpan`, `bracketError`-based helpers, and the persistent /
+  yesod / conduit instrumentations) now uses it so that any context attached
+  to a caught `SomeException` survives recording. (#239)
+
 ## 1.0.0.0 - 2026-05-29
 
 ### Full Spec conformance against 1.55.0

--- a/api/ChangeLog.md
+++ b/api/ChangeLog.md
@@ -6,11 +6,22 @@
   `Backtraces` annotation attached to a `SomeException`'s `ExceptionContext`
   (introduced in base 4.20 / GHC 9.10), so `exception.stacktrace` reflects
   the richer stacks captured by `HasCallStack`, IPE, and other backtrace
-  mechanisms — not just cost-centre stacks. Falls back to `whoCreated` when
-  no `Backtraces` annotation is present or on older GHCs. Internal span
-  machinery (`inSpan`, `bracketError`-based helpers, and the persistent /
-  yesod / conduit instrumentations) now uses it so that any context attached
-  to a caught `SomeException` survives recording. (#239)
+  mechanisms — not just cost-centre stacks.  (#239)
+- **Added `recordExceptionWithContext`.** Takes an
+  `ExceptionWithContext e` so callers who do have access to an exception's
+  `ExceptionContext` at the catch site can record it without losing the
+  attached annotations to a stray `toException` conversion. The function is
+  exported on all supported GHCs (so no CPP is needed at use sites), but
+  `ExceptionWithContext` can only be obtained on base 4.20+ (GHC 9.10+); on
+  older bases an uninhabited compat stub of the type is provided.
+- **Added `recordSomeError` and `recordErrorWithContext`.** Like
+  `recordError` but taking a `SomeException` or an `ExceptionWithContext`
+  respectively, preserving any attached `ExceptionContext`.
+- **Deprecated `recordException` and `recordError`.** They silently discard
+  any `ExceptionContext` attached to the exception. Prefer
+  `recordSomeException` / `recordSomeError` when you have a `SomeException`,
+  or `recordExceptionWithContext` / `recordErrorWithContext` when you can
+  supply an `ExceptionWithContext`.
 
 ## 1.0.0.0 - 2026-05-29
 

--- a/api/hs-opentelemetry-api.cabal
+++ b/api/hs-opentelemetry-api.cabal
@@ -87,6 +87,7 @@ library
       OpenTelemetry.Context.Types
       OpenTelemetry.Internal.Metric.Export
       OpenTelemetry.Internal.Metric.Types
+      OpenTelemetry.Internal.Trace.ExceptionContext
       OpenTelemetry.Internal.Trace.Types
       OpenTelemetry.Internal.UnpackedMaybe
       Paths_hs_opentelemetry_api
@@ -145,7 +146,9 @@ test-suite hs-opentelemetry-api-test
       OpenTelemetry.RegistrySpec
       OpenTelemetry.ResourceSpec
       OpenTelemetry.SemanticsConfigSpec
+      OpenTelemetry.Trace.ExceptionContextSpec
       OpenTelemetry.Trace.ExceptionHandlerSpec
+      OpenTelemetry.Trace.ExceptionHandlerSpec.Helpers
       OpenTelemetry.Trace.IdCodecSpec
       OpenTelemetry.Trace.MonadSpec
       OpenTelemetry.Trace.SamplerSpec

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -57,6 +57,7 @@ library:
   - OpenTelemetry.Context.Types
   - OpenTelemetry.Internal.Metric.Export
   - OpenTelemetry.Internal.Metric.Types
+  - OpenTelemetry.Internal.Trace.ExceptionContext
   - OpenTelemetry.Internal.Trace.Types
   - OpenTelemetry.Internal.UnpackedMaybe
   - Paths_hs_opentelemetry_api
@@ -100,7 +101,9 @@ tests:
     - OpenTelemetry.RegistrySpec
     - OpenTelemetry.ResourceSpec
     - OpenTelemetry.SemanticsConfigSpec
+    - OpenTelemetry.Trace.ExceptionContextSpec
     - OpenTelemetry.Trace.ExceptionHandlerSpec
+    - OpenTelemetry.Trace.ExceptionHandlerSpec.Helpers
     - OpenTelemetry.Trace.IdCodecSpec
     - OpenTelemetry.Trace.MonadSpec
     - OpenTelemetry.Trace.SamplerSpec

--- a/api/src/OpenTelemetry/Internal/Trace/ExceptionContext.hs
+++ b/api/src/OpenTelemetry/Internal/Trace/ExceptionContext.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Module      :  OpenTelemetry.Internal.Trace.ExceptionContext
+Copyright   :  (c) Ian Duncan, 2021-2026
+License     :  BSD-3
+Description :  Internal helpers for rendering exception context
+
+This module isolates all of the base-version-dependent code for working with
+the 'Control.Exception.Context' API introduced in @base-4.20@ (GHC 9.10) and
+the 'WhileHandling' annotation introduced in @base-4.21@ (GHC 9.12). Keeping
+the @#if MIN_VERSION_base@ blocks in one place makes the public modules easier
+to read and maintain: in particular it means they need no CPP of their own to
+mention 'ExceptionWithContext' (see the compat stub below).
+-}
+module OpenTelemetry.Internal.Trace.ExceptionContext (
+  exceptionStackText,
+  ExceptionWithContext,
+  exceptionWithContextToSomeException,
+) where
+
+import Control.Exception (SomeException (..))
+import Data.Text (Text)
+import qualified Data.Text as T
+
+
+#if MIN_VERSION_base(4,20,0)
+import Control.Exception (Exception, ExceptionWithContext, someExceptionContext, toException)
+import Control.Exception.Annotation (displayExceptionAnnotation)
+import Control.Exception.Backtrace (Backtraces)
+import Control.Exception.Context (ExceptionContext, getExceptionAnnotations)
+#else
+import Control.Exception (Exception (..))
+import GHC.Stack (whoCreated)
+import GHC.TypeLits (ErrorMessage (..), TypeError)
+#endif
+#if MIN_VERSION_base(4,21,0)
+import Control.Exception (WhileHandling)
+#endif
+
+#if !MIN_VERSION_base(4,20,0)
+{- | Compat stub for @ExceptionWithContext@ from @base-4.20@ (GHC 9.10).
+
+On older base versions there is no exception context machinery, so this type
+is uninhabited: it exists only so that
+'OpenTelemetry.Trace.Core.recordExceptionWithContext' can be exported with
+the same type signature on every supported GHC without any CPP at its
+definition or export sites. Code that obtains an @ExceptionWithContext@
+will only compile on @base-4.20+@, where this name is a re-export of the
+real type.
+
+We deliberately give this stub only /unsatisfiable/ instances (via
+'TypeError'), for two reasons:
+
+* A working 'Exception' instance would be a footgun: its @fromException@
+  could only ever return @Nothing@, so a handler like
+  @\\(e :: ExceptionWithContext IOException) -> ...@ would compile on old
+  bases but silently never match, whereas on @base-4.20+@ the same handler
+  catches the exception.
+
+* /No/ instance would reject such code, but only with an unhelpful
+  \"No instance for Exception (ExceptionWithContext ...)\" error. The
+  unsatisfiable instances reject it with an explanation instead.
+-}
+data ExceptionWithContext e
+
+
+type ExceptionWithContextUnavailableMessage =
+  'Text "ExceptionWithContext requires base >= 4.20 (GHC 9.10+)."
+    ':$$: 'Text "This version of base has no exception context machinery, so an ExceptionWithContext cannot be obtained here."
+    ':$$: 'Text "Use recordSomeException / recordSomeError with a SomeException instead; they preserve exception context on GHCs that support it."
+
+
+instance (TypeError ExceptionWithContextUnavailableMessage) => Show (ExceptionWithContext e) where
+  show x = case x of {}
+
+
+instance (Exception e, TypeError ExceptionWithContextUnavailableMessage) => Exception (ExceptionWithContext e) where
+  toException x = case x of {}
+  fromException _ = Nothing
+  displayException x = case x of {}
+#endif
+
+
+{- | Convert an 'ExceptionWithContext' to a 'SomeException', preserving the
+attached exception context.
+
+On @base-4.20+@ this is just 'toException'; on older bases the argument type
+is uninhabited, so this can never actually be reached.
+-}
+exceptionWithContextToSomeException :: (Exception e) => ExceptionWithContext e -> SomeException
+#if MIN_VERSION_base(4,20,0)
+exceptionWithContextToSomeException = toException
+#else
+exceptionWithContextToSomeException x = case x of {}
+#endif
+
+
+{- | Render the stacktrace text for an exception.
+
+On @base-4.20+@ (GHC 9.10+), this walks the exception's 'ExceptionContext'
+and renders any 'Backtraces' annotation. On @base-4.21+@ (GHC 9.12+), it
+also renders the 'WhileHandling' annotation, so an exception thrown while
+handling another exception carries the originating exception's display in
+its rendered output too.
+
+On older bases without the Backtraces API, this falls back to 'whoCreated'
+to preserve the historical behaviour of the SDK.
+-}
+exceptionStackText :: SomeException -> IO Text
+#if MIN_VERSION_base(4,20,0)
+exceptionStackText se = pure $ T.pack $ unlines $ filter (not . null) sections
+  where
+    annotations :: ExceptionContext
+    annotations = someExceptionContext se
+
+    -- We use 'displayExceptionAnnotation' so we get the same rendering as GHC
+    -- would use.
+    sections :: [String]
+    sections =
+      map displayExceptionAnnotation (getExceptionAnnotations @Backtraces annotations)
+#if MIN_VERSION_base(4,21,0)
+        ++ map displayExceptionAnnotation (getExceptionAnnotations @WhileHandling annotations)
+#endif
+#else
+exceptionStackText (SomeException inner) = do
+  cs <- whoCreated inner
+  pure $ T.unlines $ map T.pack cs
+#endif

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -210,6 +210,7 @@ module OpenTelemetry.Trace.Core (
 
   -- ** Recording error information
   recordException,
+  recordSomeException,
   recordError,
   setStatus,
   SpanStatus (..),
@@ -261,6 +262,17 @@ import Control.Concurrent.Async
 import Control.Concurrent.Thread.Storage (getCurrentThreadId)
 import Control.Exception (Exception (..), SomeException (..), catch, displayException)
 import qualified Control.Exception as EUnsafe
+
+
+#if MIN_VERSION_base(4,20,0)
+import Control.Exception (someExceptionContext)
+import Control.Exception.Annotation (displayExceptionAnnotation)
+import Control.Exception.Backtrace (Backtraces)
+import Control.Exception.Context (ExceptionContext, getExceptionAnnotations)
+#endif
+#if MIN_VERSION_base(4,21,0)
+import Control.Exception (WhileHandling)
+#endif
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
@@ -694,9 +706,9 @@ inSpanInternal t n args extraAttrs f
           case classification of
             ErrorException -> do
               setStatus s $ Error $ T.pack $ displayException inner
-              recordException s (H.union [(unkey SC.exception_escaped, toAttribute True)] exAttrs) Nothing inner
+              recordSomeException s (H.union [(unkey SC.exception_escaped, toAttribute True)] exAttrs) Nothing someEx
             RecordedException ->
-              recordException s (H.union [(unkey SC.exception_escaped, toAttribute True)] exAttrs) Nothing inner
+              recordSomeException s (H.union [(unkey SC.exception_escaped, toAttribute True)] exAttrs) Nothing someEx
             IgnoredException ->
               pure ()
           endSpan s Nothing
@@ -1023,30 +1035,83 @@ endSpan (Dropped _) _ = pure ()
 {-# SPECIALIZE endSpan :: Span -> Maybe Timestamp -> IO () #-}
 
 
-{- | A specialized variant of @addEvent@ that records attributes conforming to
- the OpenTelemetry specification's
- <https://github.com/open-telemetry/opentelemetry-specification/blob/49c2f56f3c0468ceb2b69518bcadadd96e0a5a8b/specification/trace/semantic_conventions/exceptions.md semantic conventions>
+{- | A specialized variant of @recordSomeException@.
 
- @since 0.0.1.0
+Prefer using @recordSomeException@ to preserve exception context.
+
+@since 0.0.1.0
 -}
 recordException :: (MonadIO m, Exception e) => Span -> AttributeMap -> Maybe Timestamp -> e -> m ()
-recordException s attrs ts e = liftIO $ do
-  cs <- whoCreated e
-  let message = T.pack $ displayException e
+recordException s attrs ts e = recordSomeException s attrs ts (toException e)
+{-# INLINEABLE recordException #-}
+{-# SPECIALIZE recordException :: (Exception e) => Span -> AttributeMap -> Maybe Timestamp -> e -> IO () #-}
+
+
+{- | Like 'recordException', but takes a 'SomeException' directly so that any
+'ExceptionContext' attached to it is preserved.
+
+Library code that catches a 'SomeException' should prefer this function over
+'recordException', and pass the outer 'SomeException' without unwrapping to avoid
+losing exception context.
+
+Records attributres conforming to the OpenTelemetry specification's
+ <https://github.com/open-telemetry/opentelemetry-specification/blob/49c2f56f3c0468ceb2b69518bcadadd96e0a5a8b/specification/trace/semantic_conventions/exceptions.md semantic conventions>.
+
+@since 1.0.1.0
+-}
+recordSomeException :: (MonadIO m) => Span -> AttributeMap -> Maybe Timestamp -> SomeException -> m ()
+recordSomeException s attrs ts someEx@(SomeException inner) = liftIO $ do
+  stack <- exceptionStackText someEx
+  let message = T.pack $ displayException inner
   addEvent s $
     NewEvent
       { newEventName = "exception"
       , newEventAttributes =
           H.union
             attrs
-            [ (unkey SC.exception_type, A.toAttribute $ T.pack $ show $ typeOf e)
+            [ (unkey SC.exception_type, A.toAttribute $ T.pack $ show $ typeOf inner)
             , (unkey SC.exception_message, A.toAttribute message)
-            , (unkey SC.exception_stacktrace, A.toAttribute $ T.unlines $ map T.pack cs)
+            , (unkey SC.exception_stacktrace, A.toAttribute stack)
             ]
       , newEventTimestamp = ts
       }
-{-# INLINEABLE recordException #-}
-{-# SPECIALIZE recordException :: (Exception e) => Span -> AttributeMap -> Maybe Timestamp -> e -> IO () #-}
+{-# INLINEABLE recordSomeException #-}
+{-# SPECIALIZE recordSomeException :: Span -> AttributeMap -> Maybe Timestamp -> SomeException -> IO () #-}
+
+
+{- | Render the stacktrace text for an exception.
+
+On base 4.20+ (GHC 9.10+), this walks the exception's 'ExceptionContext' and
+renders any 'Backtraces' annotation. On
+base 4.21+ (GHC 9.12+), it also renders the 'WhileHandling' annotation, so an
+exception thrown while handling another exception carries the originating
+exception's display in its rendered output too.
+
+On older bases without the Backtraces API, this uses 'whoCreated' to keep
+the historical behaviour of the SDK.
+
+@since 1.0.1.0
+-}
+exceptionStackText :: SomeException -> IO Text
+#if MIN_VERSION_base(4,20,0)
+exceptionStackText se = pure $ T.pack $ unlines $ filter (not . null) sections
+  where
+    annotations :: ExceptionContext
+    annotations = someExceptionContext se
+
+    sections :: [String]
+    sections =
+      -- We use 'displayExceptionAnnotation' so we get the same rendering as GHC
+      -- would use
+      map displayExceptionAnnotation (getExceptionAnnotations annotations :: [Backtraces])
+#if MIN_VERSION_base(4,21,0)
+        ++ map displayExceptionAnnotation (getExceptionAnnotations annotations :: [WhileHandling])
+#endif
+#else
+exceptionStackText (SomeException inner) = do
+  cs <- whoCreated inner
+  pure $ T.unlines $ map T.pack cs
+#endif
 
 
 {- | Record an error and set the span status in one call.

--- a/api/src/OpenTelemetry/Trace/Core.hs
+++ b/api/src/OpenTelemetry/Trace/Core.hs
@@ -95,7 +95,7 @@ event with stack trace), set the span status to Error, and re-throw. You
 can also manually set error status:
 
 > setStatus span (Error "payment declined")
-> recordException span mempty Nothing myException
+> recordSomeException span mempty Nothing (toException myException)
 
 = Source location
 
@@ -211,7 +211,11 @@ module OpenTelemetry.Trace.Core (
   -- ** Recording error information
   recordException,
   recordSomeException,
+  recordExceptionWithContext,
+  ExceptionWithContext,
   recordError,
+  recordSomeError,
+  recordErrorWithContext,
   setStatus,
   SpanStatus (..),
 
@@ -262,17 +266,6 @@ import Control.Concurrent.Async
 import Control.Concurrent.Thread.Storage (getCurrentThreadId)
 import Control.Exception (Exception (..), SomeException (..), catch, displayException)
 import qualified Control.Exception as EUnsafe
-
-
-#if MIN_VERSION_base(4,20,0)
-import Control.Exception (someExceptionContext)
-import Control.Exception.Annotation (displayExceptionAnnotation)
-import Control.Exception.Backtrace (Backtraces)
-import Control.Exception.Context (ExceptionContext, getExceptionAnnotations)
-#endif
-#if MIN_VERSION_base(4,21,0)
-import Control.Exception (WhileHandling)
-#endif
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
@@ -300,6 +293,8 @@ import OpenTelemetry.Internal.Common.Types
 import OpenTelemetry.Internal.Log.Core (emitOTelLogRecord)
 import qualified OpenTelemetry.Internal.Log.Types as SeverityNumber (SeverityNumber (..))
 import OpenTelemetry.Internal.Logging (otelLogWarning)
+import OpenTelemetry.Internal.Trace.ExceptionContext (ExceptionWithContext)
+import qualified OpenTelemetry.Internal.Trace.ExceptionContext as ExCtx
 import OpenTelemetry.Internal.Trace.Types
 import qualified OpenTelemetry.Internal.Trace.Types as Types
 import OpenTelemetry.Propagator (TextMapPropagator)
@@ -1035,9 +1030,13 @@ endSpan (Dropped _) _ = pure ()
 {-# SPECIALIZE endSpan :: Span -> Maybe Timestamp -> IO () #-}
 
 
-{- | A specialized variant of @recordSomeException@.
+{- | Record an exception on a span by 'toException'-converting it to a
+'SomeException' first.
 
-Prefer using @recordSomeException@ to preserve exception context.
+Note that this throws away any 'Control.Exception.Context.ExceptionContext'
+already attached to @e@: if @e@ is a 'SomeException', use 'recordSomeException'
+instead, and if you have an exception together with a context, use
+'recordExceptionWithContext'.
 
 @since 0.0.1.0
 -}
@@ -1045,23 +1044,27 @@ recordException :: (MonadIO m, Exception e) => Span -> AttributeMap -> Maybe Tim
 recordException s attrs ts e = recordSomeException s attrs ts (toException e)
 {-# INLINEABLE recordException #-}
 {-# SPECIALIZE recordException :: (Exception e) => Span -> AttributeMap -> Maybe Timestamp -> e -> IO () #-}
+{-# DEPRECATED
+  recordException
+  "This silently discards any ExceptionContext attached to the exception. Prefer recordSomeException (when you have a SomeException) or recordExceptionWithContext (when you can supply an ExceptionWithContext)."
+  #-}
 
 
 {- | Like 'recordException', but takes a 'SomeException' directly so that any
-'ExceptionContext' attached to it is preserved.
+'Control.Exception.Context.ExceptionContext' attached to it is preserved.
 
 Library code that catches a 'SomeException' should prefer this function over
 'recordException', and pass the outer 'SomeException' without unwrapping to avoid
 losing exception context.
 
-Records attributres conforming to the OpenTelemetry specification's
+Records attributes conforming to the OpenTelemetry specification's
  <https://github.com/open-telemetry/opentelemetry-specification/blob/49c2f56f3c0468ceb2b69518bcadadd96e0a5a8b/specification/trace/semantic_conventions/exceptions.md semantic conventions>.
 
 @since 1.0.1.0
 -}
 recordSomeException :: (MonadIO m) => Span -> AttributeMap -> Maybe Timestamp -> SomeException -> m ()
 recordSomeException s attrs ts someEx@(SomeException inner) = liftIO $ do
-  stack <- exceptionStackText someEx
+  stack <- ExCtx.exceptionStackText someEx
   let message = T.pack $ displayException inner
   addEvent s $
     NewEvent
@@ -1079,60 +1082,86 @@ recordSomeException s attrs ts someEx@(SomeException inner) = liftIO $ do
 {-# SPECIALIZE recordSomeException :: Span -> AttributeMap -> Maybe Timestamp -> SomeException -> IO () #-}
 
 
-{- | Render the stacktrace text for an exception.
+{- | Like 'recordException', but accepts an 'ExceptionWithContext' so that
+any exception context bundled with the exception (in particular, any
+@Backtraces@ annotation attached by the GHC runtime) is preserved when the
+exception event is recorded.
 
-On base 4.20+ (GHC 9.10+), this walks the exception's 'ExceptionContext' and
-renders any 'Backtraces' annotation. On
-base 4.21+ (GHC 9.12+), it also renders the 'WhileHandling' annotation, so an
-exception thrown while handling another exception carries the originating
-exception's display in its rendered output too.
+Prefer this over 'recordException' when you have access to the exception's
+context at the catch site.
 
-On older bases without the Backtraces API, this uses 'whoCreated' to keep
-the historical behaviour of the SDK.
+'ExceptionWithContext' can only be obtained on @base-4.20+@ (GHC 9.10+). On
+older bases this function still exists with the same signature (so no CPP is
+needed at use sites or in re-exports), but the argument type is an
+uninhabited stub, so any code that obtains a value to pass here — e.g. a
+@catch@ handler typed at @ExceptionWithContext e@ — will fail to compile
+with an error explaining the situation.
 
 @since 1.0.1.0
 -}
-exceptionStackText :: SomeException -> IO Text
-#if MIN_VERSION_base(4,20,0)
-exceptionStackText se = pure $ T.pack $ unlines $ filter (not . null) sections
-  where
-    annotations :: ExceptionContext
-    annotations = someExceptionContext se
-
-    sections :: [String]
-    sections =
-      -- We use 'displayExceptionAnnotation' so we get the same rendering as GHC
-      -- would use
-      map displayExceptionAnnotation (getExceptionAnnotations annotations :: [Backtraces])
-#if MIN_VERSION_base(4,21,0)
-        ++ map displayExceptionAnnotation (getExceptionAnnotations annotations :: [WhileHandling])
-#endif
-#else
-exceptionStackText (SomeException inner) = do
-  cs <- whoCreated inner
-  pure $ T.unlines $ map T.pack cs
-#endif
+recordExceptionWithContext
+  :: (MonadIO m, Exception e)
+  => Span
+  -> AttributeMap
+  -> Maybe Timestamp
+  -> ExceptionWithContext e
+  -> m ()
+recordExceptionWithContext s attrs ts e = recordSomeException s attrs ts (ExCtx.exceptionWithContextToSomeException e)
+{-# INLINEABLE recordExceptionWithContext #-}
+{-# SPECIALIZE recordExceptionWithContext :: (Exception e) => Span -> AttributeMap -> Maybe Timestamp -> ExceptionWithContext e -> IO () #-}
 
 
-{- | Record an error and set the span status in one call.
+{- | Record an error and set the span status in one call, by
+'toException'-converting the exception to a 'SomeException' first.
 
-Combines 'setStatus' with 'Error' and 'recordException'. This is a common
-pattern when handling errors outside of 'inSpan' (which does this
-automatically for uncaught exceptions).
-
-@
-case result of
-  Left err -> recordError span err
-  Right _  -> setStatus span Ok
-@
+Note that, like 'recordException', this throws away any
+'Control.Exception.Context.ExceptionContext' already attached to @e@:
+prefer 'recordSomeError' or 'recordErrorWithContext'.
 
 @since 0.4.1.0
 -}
 recordError :: (MonadIO m, Exception e) => Span -> e -> m ()
-recordError s e = do
-  setStatus s $ Error $ T.pack $ displayException e
-  recordException s H.empty Nothing e
+recordError s e = recordSomeError s (toException e)
 {-# INLINE recordError #-}
+{-# DEPRECATED
+  recordError
+  "This silently discards any ExceptionContext attached to the exception. Prefer recordSomeError (when you have a SomeException) or recordErrorWithContext (when you can supply an ExceptionWithContext)."
+  #-}
+
+
+{- | Record an error and set the span status in one call. Takes a
+'SomeException' directly so that any
+'Control.Exception.Context.ExceptionContext' attached to it is preserved.
+
+Combines 'setStatus' with 'Error' and 'recordSomeException'. This is a
+common pattern when handling errors outside of 'inSpan' (which does this
+automatically for uncaught exceptions).
+
+@
+case result of
+  Left err -> recordSomeError span (toException err)
+  Right _  -> setStatus span Ok
+@
+
+@since 1.0.1.0
+-}
+recordSomeError :: (MonadIO m) => Span -> SomeException -> m ()
+recordSomeError s someEx@(SomeException inner) = do
+  setStatus s $ Error $ T.pack $ displayException inner
+  recordSomeException s H.empty Nothing someEx
+{-# INLINE recordSomeError #-}
+
+
+{- | Like 'recordError', but accepts an 'ExceptionWithContext' so that any
+exception context bundled with the exception is preserved when the
+exception event is recorded. See 'recordExceptionWithContext', including
+its note on availability across base versions.
+
+@since 1.0.1.0
+-}
+recordErrorWithContext :: (MonadIO m, Exception e) => Span -> ExceptionWithContext e -> m ()
+recordErrorWithContext s e = recordSomeError s (ExCtx.exceptionWithContextToSomeException e)
+{-# INLINE recordErrorWithContext #-}
 
 
 {- | Returns @True@ if the @SpanContext@ has a non-zero @TraceID@ and a non-zero @SpanID@.

--- a/api/test/OpenTelemetry/Trace/ExceptionContextSpec.hs
+++ b/api/test/OpenTelemetry/Trace/ExceptionContextSpec.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module OpenTelemetry.Trace.ExceptionContextSpec (spec) where
+
+import Test.Hspec (Spec)
+
+
+#if MIN_VERSION_base(4,20,0)
+import qualified Control.Exception
+import Control.Exception (ErrorCall (..), ExceptionWithContext (..), SomeException, toException)
+import Control.Exception.Backtrace (collectBacktraces)
+import Control.Exception.Context (addExceptionAnnotation, emptyExceptionContext)
+import qualified Data.HashMap.Strict as H
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Stack (HasCallStack)
+import OpenTelemetry.Attributes (fromAttribute, lookupAttribute)
+import OpenTelemetry.Context (empty)
+import OpenTelemetry.Processor.Span (FlushResult (..), ShutdownResult (..), SpanProcessor (..))
+import Data.IORef (readIORef)
+import OpenTelemetry.Trace.Core (
+  Event (..),
+  ImmutableSpan (..),
+  SpanHot (..),
+  SpanStatus (..),
+  createSpan,
+  createTracerProvider,
+  defaultSpanArguments,
+  emptyTracerProviderOptions,
+  instrumentationLibrary,
+  makeTracer,
+  recordErrorWithContext,
+  recordExceptionWithContext,
+  recordSomeException,
+  tracerOptions,
+  unsafeReadSpan,
+ )
+import Test.Hspec (describe, expectationFailure, it, shouldBe, shouldNotBe, shouldSatisfy)
+
+import OpenTelemetry.Trace.ExceptionHandlerSpec.Helpers (dummySpanProcessor, getOnlyExceptionEvent)
+#endif
+
+
+spec :: Spec
+#if MIN_VERSION_base(4,20,0)
+spec = describe "ExceptionContext-aware stacktrace rendering" $ do
+  it "leaves exception.stacktrace empty when no annotation is present" $ do
+    let ex = toException (ErrorCall "no-stack")
+    tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+    let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+    s <- createSpan tracer empty "span" defaultSpanArguments
+    recordSomeException s H.empty Nothing ex
+    evt <- getOnlyExceptionEvent s
+    (lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text)
+      `shouldBe` Just ""
+
+  it "recordExceptionWithContext preserves the Backtraces in the attached context" $ do
+    -- 'recordExceptionWithContext' should funnel the bundled context through
+    -- the same renderer as 'recordSomeException'. Construct a context with
+    -- a real 'Backtraces' annotation (so it actually gets rendered) and
+    -- check the result is non-empty — the lossy 'recordException' path
+    -- would have stripped this context.
+    bts <- collectBacktraces
+    let annotated =
+          ExceptionWithContext
+            (addExceptionAnnotation bts emptyExceptionContext)
+            (ErrorCall "boom")
+    tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+    let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+    s <- createSpan tracer empty "span" defaultSpanArguments
+    recordExceptionWithContext s H.empty Nothing annotated
+    evt <- getOnlyExceptionEvent s
+    case lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text of
+      Nothing -> expectationFailure "exception.stacktrace attribute missing"
+      Just stack -> stack `shouldNotBe` ""
+
+  it "recordErrorWithContext sets Error status and preserves the attached context" $ do
+    bts <- collectBacktraces
+    let annotated =
+          ExceptionWithContext
+            (addExceptionAnnotation bts emptyExceptionContext)
+            (ErrorCall "boom")
+    tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+    let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+    s <- createSpan tracer empty "span" defaultSpanArguments
+    recordErrorWithContext s annotated
+    imm <- unsafeReadSpan s
+    hot <- readIORef (spanHot imm)
+    hotStatus hot `shouldSatisfy` \case Error _ -> True; _ -> False
+    evt <- getOnlyExceptionEvent s
+    case lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text of
+      Nothing -> expectationFailure "exception.stacktrace attribute missing"
+      Just stack -> stack `shouldNotBe` ""
+
+  it "captures Backtraces attached by the runtime to a thrown exception (base 4.20+)" $ do
+    -- End-to-end: rely on the GHC runtime to attach a Backtraces annotation
+    -- when an exception is thrown from inside an IO HasCallStack chain.
+    -- This is the path real instrumented code exercises (via 'inSpan').
+    caughtEx <-
+      Control.Exception.try @SomeException ioStackLevelOne >>= \case
+        Left e -> pure e
+        Right () -> error "expected exception was not thrown"
+    tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+    let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+    s <- createSpan tracer empty "span" defaultSpanArguments
+    recordSomeException s H.empty Nothing caughtEx
+    evt <- getOnlyExceptionEvent s
+    case lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text of
+      Nothing -> expectationFailure "exception.stacktrace attribute missing"
+      Just stack -> do
+        stack `shouldNotBe` ""
+        -- The rendered Backtraces should have the HasCallStack header and
+        -- mention each link in our chain — the "non-trivial" check.
+        T.isInfixOf "HasCallStack" stack `shouldBe` True
+        T.isInfixOf "ioStackLevelOne" stack `shouldBe` True
+        T.isInfixOf "ioStackLevelTwo" stack `shouldBe` True
+        T.isInfixOf "ExceptionContextSpec.hs" stack `shouldBe` True
+
+#if MIN_VERSION_base(4,21,0)
+  it "renders the WhileHandling chain when an exception is thrown during handling (base 4.21+)" $ do
+    -- GHC 9.12+ attaches a WhileHandling annotation when an exception is
+    -- thrown from inside another exception's handler. Our stack rendering
+    -- recurses into it so the originating exception's stack is included.
+    caughtEx <-
+      Control.Exception.try @SomeException nestedThrowDuringHandling >>= \case
+        Left e -> pure e
+        Right () -> error "expected exception was not thrown"
+    tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+    let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+    s <- createSpan tracer empty "span" defaultSpanArguments
+    recordSomeException s H.empty Nothing caughtEx
+    evt <- getOnlyExceptionEvent s
+    case lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text of
+      Nothing -> expectationFailure "exception.stacktrace attribute missing"
+      Just stack -> do
+        stack `shouldNotBe` ""
+        -- The handler's own thrown exception (the outer one) should be
+        -- there.
+        T.isInfixOf "secondaryThrow" stack `shouldBe` True
+        -- GHC's WhileHandling annotation renders as "While handling
+        -- <displayException of inner>". The inner ErrorCall display is
+        -- just its message, "original-boom".
+        T.isInfixOf "While handling" stack `shouldBe` True
+        T.isInfixOf "original-boom" stack `shouldBe` True
+#endif
+
+
+-- | IO chain that throws an exception via 'error'. The runtime attaches a
+-- 'Backtraces' annotation populated from 'HasCallStack' on GHC 9.10+, which
+-- is exactly the path real instrumented code exercises.
+ioStackLevelOne :: (HasCallStack) => IO ()
+ioStackLevelOne = ioStackLevelTwo
+{-# NOINLINE ioStackLevelOne #-}
+
+
+ioStackLevelTwo :: (HasCallStack) => IO ()
+ioStackLevelTwo = error "boom"
+{-# NOINLINE ioStackLevelTwo #-}
+
+
+#if MIN_VERSION_base(4,21,0)
+-- | Throw an exception, catch it, and throw a new one from the handler. On
+-- base 4.21+ the runtime attaches a 'WhileHandling' annotation to the
+-- secondary exception pointing back at the original.
+nestedThrowDuringHandling :: (HasCallStack) => IO ()
+nestedThrowDuringHandling =
+  Control.Exception.catch originalThrow $ \(_ :: SomeException) -> secondaryThrow
+{-# NOINLINE nestedThrowDuringHandling #-}
+
+
+originalThrow :: (HasCallStack) => IO ()
+originalThrow = error "original-boom"
+{-# NOINLINE originalThrow #-}
+
+
+secondaryThrow :: (HasCallStack) => IO ()
+secondaryThrow = error "secondary-boom"
+{-# NOINLINE secondaryThrow #-}
+#endif
+
+#else
+spec = pure ()
+#endif

--- a/api/test/OpenTelemetry/Trace/ExceptionHandlerSpec.hs
+++ b/api/test/OpenTelemetry/Trace/ExceptionHandlerSpec.hs
@@ -1,16 +1,20 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module OpenTelemetry.Trace.ExceptionHandlerSpec where
 
 import Control.Exception (ErrorCall (..), Exception (..), IOException, SomeException, toException)
+import qualified Control.Exception
 import qualified Data.HashMap.Strict as H
 import Data.IORef (readIORef)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Typeable (Typeable)
 import qualified Data.Vector as V
+import GHC.Stack (HasCallStack)
 import OpenTelemetry.Attributes (fromAttribute, lookupAttribute)
 import OpenTelemetry.Context (empty)
 import OpenTelemetry.Processor.Span (FlushResult (..), ShutdownResult (..), SpanProcessor (..))
@@ -27,9 +31,11 @@ import OpenTelemetry.Trace.Core (
   instrumentationLibrary,
   makeTracer,
   recordException,
+  recordSomeException,
   tracerOptions,
   unsafeReadSpan,
  )
+import qualified OpenTelemetry.Trace.Core
 import OpenTelemetry.Trace.ExceptionHandler
 import OpenTelemetry.Util (appendOnlyBoundedCollectionValues)
 import System.Exit (ExitCode (..))
@@ -161,6 +167,135 @@ spec = describe "ExceptionHandler" $ do
         `shouldBe` Just (T.pack (displayException ex))
       (lookupAttribute (eventAttributes evt) "exception.message" >>= fromAttribute @Text)
         `shouldNotBe` Just (T.pack (show ex))
+
+  describe "recordSomeException" $ do
+    it "records exception.type from the inner exception, not SomeException" $ do
+      let ex = toException DisplayDiffersFromShow
+      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+      s <- createSpan tracer empty "span" defaultSpanArguments
+      recordSomeException s H.empty Nothing ex
+      evt <- getOnlyExceptionEvent s
+      (lookupAttribute (eventAttributes evt) "exception.type" >>= fromAttribute @Text)
+        `shouldBe` Just "DisplayDiffersFromShow"
+      (lookupAttribute (eventAttributes evt) "exception.message" >>= fromAttribute @Text)
+        `shouldBe` Just (T.pack (displayException DisplayDiffersFromShow))
+
+    it "leaves exception.stacktrace empty when no annotation is present" $ do
+      let ex = toException (ErrorCall "no-stack")
+      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+      s <- createSpan tracer empty "span" defaultSpanArguments
+      recordSomeException s H.empty Nothing ex
+      evt <- getOnlyExceptionEvent s
+      case lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text of
+        Nothing -> expectationFailure "exception.stacktrace attribute missing"
+#if MIN_VERSION_base(4,20,0)
+        Just t -> t `shouldBe` ""
+#else
+        Just _ -> pure ()
+#endif
+
+#if MIN_VERSION_base(4,20,0)
+    it "captures Backtraces attached by the runtime to a thrown exception (base 4.20+)" $ do
+      -- End-to-end: rely on the GHC runtime to attach a Backtraces annotation
+      -- when an exception is thrown from inside an IO HasCallStack chain.
+      -- This is the path real instrumented code exercises (via 'inSpan').
+      caughtEx <-
+        Control.Exception.try @SomeException ioStackLevelOne >>= \case
+          Left e -> pure e
+          Right () -> error "expected exception was not thrown"
+      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+      s <- createSpan tracer empty "span" defaultSpanArguments
+      recordSomeException s H.empty Nothing caughtEx
+      evt <- getOnlyExceptionEvent s
+      let mStack = lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text
+      case mStack of
+        Nothing -> expectationFailure "exception.stacktrace attribute missing"
+        Just stack -> do
+          stack `shouldNotBe` ""
+          -- The rendered Backtraces should have the HasCallStack header and
+          -- mention each link in our chain — the "non-trivial" check.
+          T.isInfixOf "HasCallStack" stack `shouldBe` True
+          T.isInfixOf "ioStackLevelOne" stack `shouldBe` True
+          T.isInfixOf "ioStackLevelTwo" stack `shouldBe` True
+          T.isInfixOf "ExceptionHandlerSpec.hs" stack `shouldBe` True
+#endif
+
+#if MIN_VERSION_base(4,21,0)
+    it "renders the WhileHandling chain when an exception is thrown during handling (base 4.21+)" $ do
+      -- GHC 9.12+ attaches a WhileHandling annotation when an exception is
+      -- thrown from inside another exception's handler. Our stack rendering
+      -- recurses into it so the originating exception's stack is included.
+      caughtEx <-
+        Control.Exception.try @SomeException nestedThrowDuringHandling >>= \case
+          Left e -> pure e
+          Right () -> error "expected exception was not thrown"
+      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
+      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
+      s <- createSpan tracer empty "span" defaultSpanArguments
+      recordSomeException s H.empty Nothing caughtEx
+      evt <- getOnlyExceptionEvent s
+      let mStack = lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text
+      case mStack of
+        Nothing -> expectationFailure "exception.stacktrace attribute missing"
+        Just stack -> do
+          stack `shouldNotBe` ""
+          -- The handler's own thrown exception (the outer one) should be
+          -- there.
+          T.isInfixOf "secondaryThrow" stack `shouldBe` True
+          -- GHC's WhileHandling annotation renders as "While handling
+          -- <displayException of inner>". The inner ErrorCall display is
+          -- just its message, "original-boom".
+          T.isInfixOf "While handling" stack `shouldBe` True
+          T.isInfixOf "original-boom" stack `shouldBe` True
+#endif
+
+#if MIN_VERSION_base(4,20,0)
+-- | IO chain that throws an exception via 'error'. The runtime attaches a
+-- 'Backtraces' annotation populated from 'HasCallStack' on GHC 9.10+, which
+-- is exactly the path real instrumented code exercises.
+ioStackLevelOne :: (HasCallStack) => IO ()
+ioStackLevelOne = ioStackLevelTwo
+{-# NOINLINE ioStackLevelOne #-}
+
+ioStackLevelTwo :: (HasCallStack) => IO ()
+ioStackLevelTwo = error "boom"
+{-# NOINLINE ioStackLevelTwo #-}
+#endif
+
+#if MIN_VERSION_base(4,21,0)
+-- | Throw an exception, catch it, and throw a new one from the handler. On
+-- base 4.21+ the runtime attaches a 'WhileHandling' annotation to the
+-- secondary exception pointing back at the original.
+nestedThrowDuringHandling :: (HasCallStack) => IO ()
+nestedThrowDuringHandling =
+  Control.Exception.catch originalThrow $ \(_ :: SomeException) -> secondaryThrow
+{-# NOINLINE nestedThrowDuringHandling #-}
+
+originalThrow :: (HasCallStack) => IO ()
+originalThrow = error "original-boom"
+{-# NOINLINE originalThrow #-}
+
+secondaryThrow :: (HasCallStack) => IO ()
+secondaryThrow = error "secondary-boom"
+{-# NOINLINE secondaryThrow #-}
+#endif
+
+
+{- | Read the single \"exception\" event from a span. Fails the test if the
+event count is not exactly one.
+-}
+getOnlyExceptionEvent :: (HasCallStack) => OpenTelemetry.Trace.Core.Span -> IO Event
+getOnlyExceptionEvent s = do
+  imm <- unsafeReadSpan s
+  hot <- readIORef (spanHot imm)
+  let evts = appendOnlyBoundedCollectionValues (hotEvents hot)
+  V.length evts `shouldBe` 1
+  let evt = V.head evts
+  eventName evt `shouldBe` "exception"
+  pure evt
 
 
 data DisplayDiffersFromShow = DisplayDiffersFromShow

--- a/api/test/OpenTelemetry/Trace/ExceptionHandlerSpec.hs
+++ b/api/test/OpenTelemetry/Trace/ExceptionHandlerSpec.hs
@@ -1,23 +1,20 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+-- Tests for the deprecated 'recordException' wrapper need to call it
+-- without triggering the warning we just added.
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module OpenTelemetry.Trace.ExceptionHandlerSpec where
 
 import Control.Exception (ErrorCall (..), Exception (..), IOException, SomeException, toException)
-import qualified Control.Exception
 import qualified Data.HashMap.Strict as H
 import Data.IORef (readIORef)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Typeable (Typeable)
 import qualified Data.Vector as V
-import GHC.Stack (HasCallStack)
 import OpenTelemetry.Attributes (fromAttribute, lookupAttribute)
 import OpenTelemetry.Context (empty)
-import OpenTelemetry.Processor.Span (FlushResult (..), ShutdownResult (..), SpanProcessor (..))
 import OpenTelemetry.Trace.Core (
   Event (..),
   ImmutableSpan (..),
@@ -35,8 +32,12 @@ import OpenTelemetry.Trace.Core (
   tracerOptions,
   unsafeReadSpan,
  )
-import qualified OpenTelemetry.Trace.Core
 import OpenTelemetry.Trace.ExceptionHandler
+import OpenTelemetry.Trace.ExceptionHandlerSpec.Helpers (
+  DisplayDiffersFromShow (..),
+  dummySpanProcessor,
+  getOnlyExceptionEvent,
+ )
 import OpenTelemetry.Util (appendOnlyBoundedCollectionValues)
 import System.Exit (ExitCode (..))
 import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldNotBe)
@@ -180,141 +181,3 @@ spec = describe "ExceptionHandler" $ do
         `shouldBe` Just "DisplayDiffersFromShow"
       (lookupAttribute (eventAttributes evt) "exception.message" >>= fromAttribute @Text)
         `shouldBe` Just (T.pack (displayException DisplayDiffersFromShow))
-
-    it "leaves exception.stacktrace empty when no annotation is present" $ do
-      let ex = toException (ErrorCall "no-stack")
-      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
-      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
-      s <- createSpan tracer empty "span" defaultSpanArguments
-      recordSomeException s H.empty Nothing ex
-      evt <- getOnlyExceptionEvent s
-      case lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text of
-        Nothing -> expectationFailure "exception.stacktrace attribute missing"
-#if MIN_VERSION_base(4,20,0)
-        Just t -> t `shouldBe` ""
-#else
-        Just _ -> pure ()
-#endif
-
-#if MIN_VERSION_base(4,20,0)
-    it "captures Backtraces attached by the runtime to a thrown exception (base 4.20+)" $ do
-      -- End-to-end: rely on the GHC runtime to attach a Backtraces annotation
-      -- when an exception is thrown from inside an IO HasCallStack chain.
-      -- This is the path real instrumented code exercises (via 'inSpan').
-      caughtEx <-
-        Control.Exception.try @SomeException ioStackLevelOne >>= \case
-          Left e -> pure e
-          Right () -> error "expected exception was not thrown"
-      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
-      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
-      s <- createSpan tracer empty "span" defaultSpanArguments
-      recordSomeException s H.empty Nothing caughtEx
-      evt <- getOnlyExceptionEvent s
-      let mStack = lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text
-      case mStack of
-        Nothing -> expectationFailure "exception.stacktrace attribute missing"
-        Just stack -> do
-          stack `shouldNotBe` ""
-          -- The rendered Backtraces should have the HasCallStack header and
-          -- mention each link in our chain — the "non-trivial" check.
-          T.isInfixOf "HasCallStack" stack `shouldBe` True
-          T.isInfixOf "ioStackLevelOne" stack `shouldBe` True
-          T.isInfixOf "ioStackLevelTwo" stack `shouldBe` True
-          T.isInfixOf "ExceptionHandlerSpec.hs" stack `shouldBe` True
-#endif
-
-#if MIN_VERSION_base(4,21,0)
-    it "renders the WhileHandling chain when an exception is thrown during handling (base 4.21+)" $ do
-      -- GHC 9.12+ attaches a WhileHandling annotation when an exception is
-      -- thrown from inside another exception's handler. Our stack rendering
-      -- recurses into it so the originating exception's stack is included.
-      caughtEx <-
-        Control.Exception.try @SomeException nestedThrowDuringHandling >>= \case
-          Left e -> pure e
-          Right () -> error "expected exception was not thrown"
-      tp <- createTracerProvider [dummySpanProcessor] emptyTracerProviderOptions
-      let tracer = makeTracer tp (instrumentationLibrary "test" "1") tracerOptions
-      s <- createSpan tracer empty "span" defaultSpanArguments
-      recordSomeException s H.empty Nothing caughtEx
-      evt <- getOnlyExceptionEvent s
-      let mStack = lookupAttribute (eventAttributes evt) "exception.stacktrace" >>= fromAttribute @Text
-      case mStack of
-        Nothing -> expectationFailure "exception.stacktrace attribute missing"
-        Just stack -> do
-          stack `shouldNotBe` ""
-          -- The handler's own thrown exception (the outer one) should be
-          -- there.
-          T.isInfixOf "secondaryThrow" stack `shouldBe` True
-          -- GHC's WhileHandling annotation renders as "While handling
-          -- <displayException of inner>". The inner ErrorCall display is
-          -- just its message, "original-boom".
-          T.isInfixOf "While handling" stack `shouldBe` True
-          T.isInfixOf "original-boom" stack `shouldBe` True
-#endif
-
-#if MIN_VERSION_base(4,20,0)
--- | IO chain that throws an exception via 'error'. The runtime attaches a
--- 'Backtraces' annotation populated from 'HasCallStack' on GHC 9.10+, which
--- is exactly the path real instrumented code exercises.
-ioStackLevelOne :: (HasCallStack) => IO ()
-ioStackLevelOne = ioStackLevelTwo
-{-# NOINLINE ioStackLevelOne #-}
-
-ioStackLevelTwo :: (HasCallStack) => IO ()
-ioStackLevelTwo = error "boom"
-{-# NOINLINE ioStackLevelTwo #-}
-#endif
-
-#if MIN_VERSION_base(4,21,0)
--- | Throw an exception, catch it, and throw a new one from the handler. On
--- base 4.21+ the runtime attaches a 'WhileHandling' annotation to the
--- secondary exception pointing back at the original.
-nestedThrowDuringHandling :: (HasCallStack) => IO ()
-nestedThrowDuringHandling =
-  Control.Exception.catch originalThrow $ \(_ :: SomeException) -> secondaryThrow
-{-# NOINLINE nestedThrowDuringHandling #-}
-
-originalThrow :: (HasCallStack) => IO ()
-originalThrow = error "original-boom"
-{-# NOINLINE originalThrow #-}
-
-secondaryThrow :: (HasCallStack) => IO ()
-secondaryThrow = error "secondary-boom"
-{-# NOINLINE secondaryThrow #-}
-#endif
-
-
-{- | Read the single \"exception\" event from a span. Fails the test if the
-event count is not exactly one.
--}
-getOnlyExceptionEvent :: (HasCallStack) => OpenTelemetry.Trace.Core.Span -> IO Event
-getOnlyExceptionEvent s = do
-  imm <- unsafeReadSpan s
-  hot <- readIORef (spanHot imm)
-  let evts = appendOnlyBoundedCollectionValues (hotEvents hot)
-  V.length evts `shouldBe` 1
-  let evt = V.head evts
-  eventName evt `shouldBe` "exception"
-  pure evt
-
-
-data DisplayDiffersFromShow = DisplayDiffersFromShow
-  deriving (Typeable)
-
-
-instance Show DisplayDiffersFromShow where
-  show _ = "ShowForm"
-
-
-instance Exception DisplayDiffersFromShow where
-  displayException _ = "DisplayForm"
-
-
-dummySpanProcessor :: SpanProcessor
-dummySpanProcessor =
-  SpanProcessor
-    { spanProcessorOnStart = \_ _ -> pure ()
-    , spanProcessorOnEnd = \_ -> pure ()
-    , spanProcessorShutdown = pure ShutdownSuccess
-    , spanProcessorForceFlush = pure FlushSuccess
-    }

--- a/api/test/OpenTelemetry/Trace/ExceptionHandlerSpec/Helpers.hs
+++ b/api/test/OpenTelemetry/Trace/ExceptionHandlerSpec/Helpers.hs
@@ -1,0 +1,62 @@
+{- | Shared helpers used by both 'OpenTelemetry.Trace.ExceptionHandlerSpec'
+and 'OpenTelemetry.Trace.ExceptionContextSpec'. Extracted to its own
+module so the base-version-gated spec can import them without depending
+on the main spec module.
+-}
+module OpenTelemetry.Trace.ExceptionHandlerSpec.Helpers (
+  getOnlyExceptionEvent,
+  dummySpanProcessor,
+  DisplayDiffersFromShow (..),
+) where
+
+import Control.Exception (Exception (..))
+import Data.IORef (readIORef)
+import Data.Typeable (Typeable)
+import qualified Data.Vector as V
+import GHC.Stack (HasCallStack)
+import OpenTelemetry.Processor.Span (FlushResult (..), ShutdownResult (..), SpanProcessor (..))
+import OpenTelemetry.Trace.Core (
+  Event (..),
+  ImmutableSpan (..),
+  Span,
+  SpanHot (..),
+  unsafeReadSpan,
+ )
+import OpenTelemetry.Util (appendOnlyBoundedCollectionValues)
+import Test.Hspec (shouldBe)
+
+
+{- | Read the single \"exception\" event from a span. Fails the test if the
+event count is not exactly one.
+-}
+getOnlyExceptionEvent :: (HasCallStack) => Span -> IO Event
+getOnlyExceptionEvent s = do
+  imm <- unsafeReadSpan s
+  hot <- readIORef (spanHot imm)
+  let evts = appendOnlyBoundedCollectionValues (hotEvents hot)
+  V.length evts `shouldBe` 1
+  let evt = V.head evts
+  eventName evt `shouldBe` "exception"
+  pure evt
+
+
+dummySpanProcessor :: SpanProcessor
+dummySpanProcessor =
+  SpanProcessor
+    { spanProcessorOnStart = \_ _ -> pure ()
+    , spanProcessorOnEnd = \_ -> pure ()
+    , spanProcessorShutdown = pure ShutdownSuccess
+    , spanProcessorForceFlush = pure FlushSuccess
+    }
+
+
+data DisplayDiffersFromShow = DisplayDiffersFromShow
+  deriving (Typeable)
+
+
+instance Show DisplayDiffersFromShow where
+  show _ = "ShowForm"
+
+
+instance Exception DisplayDiffersFromShow where
+  displayException _ = "DisplayForm"

--- a/api/test/OpenTelemetry/Trace/UtilsSpec.hs
+++ b/api/test/OpenTelemetry/Trace/UtilsSpec.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+-- This file exercises the deprecated 'recordError' wrapper directly.
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module OpenTelemetry.Trace.UtilsSpec where
 
+import Control.Exception (toException)
 import qualified Data.HashMap.Strict as H
 import Data.IORef
 import Data.Maybe (isJust, isNothing)
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Vector as V
 import OpenTelemetry.Attributes (lookupAttribute)
 import qualified OpenTelemetry.Attributes as A
@@ -134,5 +138,24 @@ spec = describe "Trace utilities" $ do
       V.length evts `shouldBe` 1
       let evt = V.head evts
       eventName evt `shouldBe` "exception"
+      lookupAttribute (eventAttributes evt) "exception.type" `shouldSatisfy` isJust
+      lookupAttribute (eventAttributes evt) "exception.message" `shouldSatisfy` isJust
+
+  describe "recordSomeError" $ do
+    it "sets span status to Error and records exception event" $ withTracer $ \t -> do
+      s <- createSpan t empty "test-span" defaultSpanArguments
+      let err = toException (userError "something broke")
+      recordSomeError s err
+      endSpan s Nothing
+      is <- unsafeReadSpan s
+      hot <- readIORef (spanHot is)
+      hotStatus hot `shouldSatisfy` \case Error _ -> True; _ -> False
+      let evts = appendOnlyBoundedCollectionValues (hotEvents hot)
+      V.length evts `shouldBe` 1
+      let evt = V.head evts
+      eventName evt `shouldBe` "exception"
+      -- The status message and exception.type should describe the inner
+      -- exception, not the SomeException wrapper.
+      hotStatus hot `shouldSatisfy` \case Error msg -> not (T.null msg); _ -> False
       lookupAttribute (eventAttributes evt) "exception.type" `shouldSatisfy` isJust
       lookupAttribute (eventAttributes evt) "exception.message" `shouldSatisfy` isJust

--- a/api/test/Spec.hs
+++ b/api/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified OpenTelemetry.PropagatorSpec as PropagatorSpec
 import qualified OpenTelemetry.RegistrySpec as Registry
 import qualified OpenTelemetry.ResourceSpec as Resource
 import qualified OpenTelemetry.SemanticsConfigSpec as SemanticsConfigSpec
+import qualified OpenTelemetry.Trace.ExceptionContextSpec as ExceptionContext
 import qualified OpenTelemetry.Trace.ExceptionHandlerSpec as ExceptionHandler
 import qualified OpenTelemetry.Trace.IdCodecSpec as IdCodec
 import qualified OpenTelemetry.Trace.MonadSpec as TraceMonad
@@ -41,6 +42,7 @@ main = hspec $ do
   InstrumentationLibrary.spec
   Logging.spec
   ExceptionHandler.spec
+  ExceptionContext.spec
   IdCodec.spec
   TraceMonad.spec
   Sampler.spec

--- a/instrumentation/conduit/ChangeLog.md
+++ b/instrumentation/conduit/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for hs-opentelemetry-instrumentation-conduit
 
+## Unreleased
+
+- Use `recordSomeException` in the streaming `inSpan` exception
+  handler so `exception.stacktrace` is populated from the runtime-attached
+  `Backtraces` annotation on GHC 9.10+. (#239)
+
 ## 1.0.0.0 - 2026-05-29
 
 - Promoted to 1.0.0.0 for the hs-opentelemetry 1.0 release.

--- a/instrumentation/conduit/src/OpenTelemetry/Instrumentation/Conduit.hs
+++ b/instrumentation/conduit/src/OpenTelemetry/Instrumentation/Conduit.hs
@@ -57,5 +57,5 @@ inSpan t n args f = do
     $ \span_ -> do
       catchC (f span_) $ \e -> do
         liftIO $ do
-          recordException span_ [(unkey SC.exception_escaped, toAttribute True)] Nothing (e :: SomeException)
+          recordSomeException span_ [(unkey SC.exception_escaped, toAttribute True)] Nothing (e :: SomeException)
           throwIO e

--- a/instrumentation/persistent/ChangeLog.md
+++ b/instrumentation/persistent/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Use `recordSomeException` so the runtime-attached `Backtraces`
+  annotation (HasCallStack, IPE, ...) is preserved when recording exceptions
+  caught around statement execution and transaction commit/rollback. (#239)
+
 ## 1.0.0.0 - 2026-05-29
 
 - Internal: `db.transaction.*` attribute keys are now typed `AttributeKey` constants

--- a/instrumentation/persistent/src/OpenTelemetry/Instrumentation/Persistent.hs
+++ b/instrumentation/persistent/src/OpenTelemetry/Instrumentation/Persistent.hs
@@ -271,8 +271,8 @@ wrapSqlBackend' tp attrs conn_ = do
                       case stmtQuery stmt ps of
                         Acquire stmtQueryAcquireF -> Acquire $ \f ->
                           handleAny
-                            ( \(SomeException err) -> do
-                                recordException child [(unkey SC.exception_escaped, toAttribute True)] Nothing err
+                            ( \someEx@(SomeException err) -> do
+                                recordSomeException child [(unkey SC.exception_escaped, toAttribute True)] Nothing someEx
                                 endSpan child Nothing
                                 throwIO err
                             )
@@ -324,8 +324,8 @@ wrapSqlBackend' tp attrs conn_ = do
                         ]
                       endSpan s Nothing
                       case result of
-                        Left (SomeException err) -> do
-                          recordException s [(unkey SC.exception_escaped, toAttribute True)] Nothing err
+                        Left someEx@(SomeException err) -> do
+                          recordSomeException s [(unkey SC.exception_escaped, toAttribute True)] Nothing someEx
                           throwIO err
                         Right _ -> pure ()
               act `finally` do
@@ -348,8 +348,8 @@ wrapSqlBackend' tp attrs conn_ = do
                         ]
                       endSpan s Nothing
                       case result of
-                        Left (SomeException err) -> do
-                          recordException s [(unkey SC.exception_escaped, toAttribute True)] Nothing err
+                        Left someEx@(SomeException err) -> do
+                          recordSomeException s [(unkey SC.exception_escaped, toAttribute True)] Nothing someEx
                           throwIO err
                         Right _ -> pure ()
               act `finally` do

--- a/instrumentation/yesod/ChangeLog.md
+++ b/instrumentation/yesod/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Use `recordSomeException` when recording exceptions caught by the
+  Yesod error middleware, so `exception.stacktrace` reflects the
+  `Backtraces` attached by the runtime on GHC 9.10+. (#239)
+
 ## 1.0.0.0 - 2026-05-29
 
 - **Breaking: `http.framework` attribute renamed to `webengine.name`.**

--- a/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
+++ b/instrumentation/yesod/src/OpenTelemetry/Instrumentation/Yesod.hs
@@ -318,7 +318,7 @@ openTelemetryYesodMiddleware rr m = do
       withException m $ \ex -> do
         when (shouldMarkException ex) $ do
           addAttributes waiSpan (H.singleton (unkey SC.error_type) (toAttribute (exceptionTypeName ex)))
-          recordException waiSpan mempty Nothing ex
+          recordSomeException waiSpan mempty Nothing ex
           setStatus waiSpan $ Error $ T.pack $ displayException ex
 
 

--- a/sdk/src/OpenTelemetry/Trace.hs
+++ b/sdk/src/OpenTelemetry/Trace.hs
@@ -125,6 +125,7 @@ module OpenTelemetry.Trace (
   addAttribute,
   addAttributes,
   recordException,
+  recordSomeException,
   setStatus,
   SpanStatus (..),
   NewEvent (..),

--- a/sdk/src/OpenTelemetry/Trace.hs
+++ b/sdk/src/OpenTelemetry/Trace.hs
@@ -126,6 +126,8 @@ module OpenTelemetry.Trace (
   addAttributes,
   recordException,
   recordSomeException,
+  recordExceptionWithContext,
+  ExceptionWithContext,
   setStatus,
   SpanStatus (..),
   NewEvent (..),

--- a/sdk/test/OpenTelemetry/TraceSpec.hs
+++ b/sdk/test/OpenTelemetry/TraceSpec.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+-- This file exercises the deprecated 'recordException' wrapper directly.
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module OpenTelemetry.TraceSpec where
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -39,13 +39,6 @@ packages:
       size: 168
   original:
     hackage: proto-lens-runtime-0.7.0.7
-- completed:
-    hackage: co-log-0.6.1.2@sha256:86d61e07356a5cb45b8ec28217b579a21f555d025dc0d9e1eecd9ff8d288f6fc,6512
-    pantry-tree:
-      sha256: 8a03f66e378e8653f3a5784b14ba1b01fca3cfce1350eec8d323bd27aa894a34
-      size: 1198
-  original:
-    hackage: co-log-0.6.1.2
 snapshots:
 - completed:
     sha256: 6406d8039dd538f18fc0d242f01c7066ee386d81ba3c8751b914ac1ae193ec5d

--- a/utils/exceptions/ChangeLog.md
+++ b/utils/exceptions/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for exceptions
 
+## Unreleased
+
+- `inSpanM` and friends now use `recordSomeException` so that on GHC
+  9.10+ the `Backtraces` annotation attached by the runtime (e.g. from
+  `HasCallStack`) is recorded in `exception.stacktrace`. (#239)
+
 ## 1.0.0.0 - 2026-05-29
 
 - Promoted to 1.0.0.0 for the hs-opentelemetry 1.0 release.

--- a/utils/exceptions/src/OpenTelemetry/Utils/Exceptions.hs
+++ b/utils/exceptions/src/OpenTelemetry/Utils/Exceptions.hs
@@ -23,7 +23,7 @@ import OpenTelemetry.Context.ThreadLocal (adjustContext)
 import qualified OpenTelemetry.Context.ThreadLocal as TraceCore.SpanContext
 import OpenTelemetry.SemanticsConfig (codeOption, getSemanticsOptions)
 import qualified OpenTelemetry.Trace as Trace
-import OpenTelemetry.Trace.Core (ToAttribute (..), codeAttributes, endSpan, recordException, setStatus, whenSpanIsRecording)
+import OpenTelemetry.Trace.Core (ToAttribute (..), codeAttributes, endSpan, recordSomeException, setStatus, whenSpanIsRecording)
 import qualified OpenTelemetry.Trace.Core as TraceCore
 
 
@@ -103,9 +103,9 @@ inSpanM'' t cs n args f = bracketError' before after (f . snd)
       pure (lookupSpan ctx, s)
 
     after e (parent, s) = do
-      forM_ e $ \(MonadMask.SomeException inner) -> do
+      forM_ e $ \someEx@(MonadMask.SomeException inner) -> do
         setStatus s $ Trace.Error $ T.pack $ MonadMask.displayException inner
-        recordException s [("exception.escaped", toAttribute True)] Nothing inner
+        recordSomeException s [("exception.escaped", toAttribute True)] Nothing someEx
       endSpan s Nothing
       adjustContext $ \ctx ->
         maybe (removeSpan ctx) (`insertSpan` ctx) parent


### PR DESCRIPTION
This uses the new backtraces mechanism to report whatever backtraces are
collected by GHC.

To make this work, we have to be a bit careful about `SomeException`.
Naively unwrapping it can discard the exception context, which we don't
want.

Fixes #239.
