### PR TITLE
fix(otlp/grpc): reconnect after connection drops, fix endpoint parsing, define GRPC_ENABLED

### DIFF
--- a/exporters/otlp/ChangeLog.md
+++ b/exporters/otlp/ChangeLog.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **gRPC: exporters now reconnect after the connection drops.** ([#305](https://github.com/iand675/hs-opentelemetry/issues/305))
+  `grpcOtlpSpanExporter`, `grpcOtlpMetricExporter`, and `grpcOtlpLogRecordExporter`
+  previously opened their grapesy connection with the default `DontReconnect`
+  policy, so a collector restart or idle-connection close permanently broke
+  export for the rest of the process lifetime. The exporters now use an
+  indefinite reconnect policy with capped exponential backoff (1s doubling up
+  to 30s); grapesy resets the policy after each successful connection.
+- **gRPC: fixed endpoint parsing for scheme-prefixed URLs.**
+  `http://localhost:4317` (including the documented default endpoint) was
+  parsed to host `/localhost`, so every connection attempt failed. The scheme
+  and any URL path are now stripped correctly.
+- **The `grpc` cabal flag now defines `GRPC_ENABLED`.**
+  Previously the flag exposed `OpenTelemetry.Exporter.OTLP.GRPC` but did not
+  set the CPP define, so `Protocol` was still missing the `GRpc` constructor
+  and `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` was rejected as unsupported unless
+  consumers passed `-DGRPC_ENABLED` themselves.
+
 ## 1.0.0.0 - 2026-05-29
 
 - **Spec: `Retry-After` now supports HTTP-date format in addition to delay-seconds.**

--- a/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
+++ b/exporters/otlp/hs-opentelemetry-exporter-otlp.cabal
@@ -64,6 +64,7 @@ library
   if flag(grpc)
     exposed-modules:
         OpenTelemetry.Exporter.OTLP.GRPC
+    cpp-options: -DGRPC_ENABLED
     build-depends:
         grapesy
 

--- a/exporters/otlp/package.yaml
+++ b/exporters/otlp/package.yaml
@@ -54,6 +54,7 @@ library:
   - condition: flag(grpc)
     exposed-modules:
     - OpenTelemetry.Exporter.OTLP.GRPC
+    cpp-options: -DGRPC_ENABLED
     dependencies:
     - grapesy
 

--- a/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/GRPC.hs
+++ b/exporters/otlp/src/OpenTelemetry/Exporter/OTLP/GRPC.hs
@@ -26,6 +26,7 @@ module OpenTelemetry.Exporter.OTLP.GRPC (
 ) where
 
 import Control.Applicative ((<|>))
+import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException (..), catch)
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -36,6 +37,11 @@ import Data.Vector (Vector)
 import Network.GRPC.Client (
   Address (..),
   CertificateStoreSpec,
+  ConnParams (..),
+  Reconnect (..),
+  ReconnectDecision (..),
+  ReconnectPolicy (..),
+  ReconnectTo (..),
   Server (..),
   ServerValidation (..),
   certStoreFromPath,
@@ -110,12 +116,11 @@ type instance ResponseTrailingMetadata (Protobuf LogsService meth) = NoMetadata
 
 parseGrpcAddress :: String -> Address
 parseGrpcAddress url =
-  let stripped = dropScheme url
-      (host, portPart) = break (== ':') stripped
+  let authority = takeWhile (/= '/') (dropScheme url)
+      (host, portPart) = break (== ':') authority
       port = case portPart of
         ':' : rest -> case reads rest of
           [(p, "")] -> p
-          [(p, "/")] -> p
           _ -> 4317
         _ -> 4317
   in Address
@@ -124,9 +129,33 @@ parseGrpcAddress url =
        , addressAuthority = Nothing
        }
   where
-    dropScheme s = case break (== '/') (drop 1 $ dropWhile (/= ':') s) of
-      (_, '/' : rest) -> rest
+    dropScheme s = case break (== ':') s of
+      (_, ':' : '/' : '/' : rest) -> rest
       _ -> s
+
+
+{- | Connection parameters shared by the gRPC exporters.
+
+grapesy's default 'ReconnectPolicy' is 'DontReconnect', which means a single
+dropped connection (collector restart, idle timeout, proxy reset) would
+permanently break export for the rest of the process lifetime. Telemetry
+should instead ride out collector outages, so reconnect indefinitely with
+capped exponential backoff. grapesy resets the policy after each successful
+connection, so the backoff always starts small again after a recovery.
+-}
+exporterConnParams :: ConnParams
+exporterConnParams = def {connReconnectPolicy = reconnectPolicy 1}
+  where
+    maxDelaySeconds = 30
+    reconnectPolicy delaySeconds = ReconnectPolicy $ do
+      threadDelay (delaySeconds * 1_000_000)
+      pure $
+        DoReconnect
+          Reconnect
+            { reconnectTo = ReconnectToOriginal
+            , onReconnect = Nothing
+            , nextPolicy = reconnectPolicy (min maxDelaySeconds (delaySeconds * 2))
+            }
 
 
 resolveGrpcServer :: Bool -> Maybe FilePath -> String -> Server
@@ -154,7 +183,7 @@ grpcOtlpSpanExporter
 grpcOtlpSpanExporter conf toProto = liftIO $ do
   let endpoint = grpcTracesEndpoint conf
       server = resolveGrpcServer (otlpTracesInsecure conf || otlpInsecure conf) (otlpTracesCertificate conf <|> otlpCertificate conf) endpoint
-  conn <- openConnection def server
+  conn <- openConnection exporterConnParams server
   shutdownRef <- newIORef False
   pure $
     SpanExporter
@@ -197,7 +226,7 @@ grpcOtlpMetricExporter
 grpcOtlpMetricExporter conf toProto = liftIO $ do
   let endpoint = grpcMetricsEndpoint conf
       server = resolveGrpcServer (otlpMetricsInsecure conf || otlpInsecure conf) (otlpMetricsCertificate conf <|> otlpCertificate conf) endpoint
-  conn <- openConnection def server
+  conn <- openConnection exporterConnParams server
   shutdownRef <- newIORef False
   pure $
     MetricExporter
@@ -240,7 +269,7 @@ grpcOtlpLogRecordExporter
 grpcOtlpLogRecordExporter conf toProto = liftIO $ do
   let endpoint = grpcLogsEndpoint conf
       server = resolveGrpcServer (otlpLogsInsecure conf || otlpInsecure conf) (otlpLogsCertificate conf <|> otlpCertificate conf) endpoint
-  conn <- openConnection def server
+  conn <- openConnection exporterConnParams server
   shutdownRef <- newIORef False
   mkLogRecordExporter
     LogRecordExporterArguments


### PR DESCRIPTION
## Summary

Three fixes that make the OTLP/gRPC exporters (behind the `grpc` cabal flag) usable in production:

### 1. Reconnect after the connection drops (fixes #305)

`grpcOtlpSpanExporter`, `grpcOtlpMetricExporter`, and `grpcOtlpLogRecordExporter` open their grapesy connection with `def` `ConnParams`, whose `ReconnectPolicy` is `DontReconnect`. A collector restart, idle-connection close, or proxy reset therefore permanently breaks export for the rest of the process lifetime — every subsequent export logs `gRPC trace export failed` and returns `Failure`.

The exporters now open connections with an indefinite reconnect policy using capped exponential backoff (1s doubling to a 30s cap). grapesy resets the policy to its initial state after each successful connection (see `stayConnected` in `Network.GRPC.Client.Run`), so the backoff starts small again after every recovery. Telemetry export should ride out collector outages rather than require an app restart, hence indefinite retry rather than a bounded attempt budget.

### 2. Endpoint parsing broke on scheme-prefixed URLs

`parseGrpcAddress`'s `dropScheme` only consumed one of the two slashes in `://`, so any URL with a scheme — including the documented default `http://localhost:4317` and the spec'd `OTEL_EXPORTER_OTLP_ENDPOINT` format — parsed to a host with a leading slash:

```
http://localhost:4317        ->  host "/localhost"
https://collector.corp:4317  ->  host "/collector.corp"
```

which makes every connection attempt fail on DNS resolution. The parser now strips the scheme correctly and also ignores any URL path after the authority (e.g. a trailing `/`).

### 3. The `grpc` flag never defined `GRPC_ENABLED`

`OpenTelemetry.Exporter.OTLP.Internal.Config` guards the `GRpc` constructor of `Protocol` (and its `readProtocol` case) behind `#ifdef GRPC_ENABLED`, but the `grpc` cabal flag only exposed the GRPC module without setting the define. So even with the flag enabled, `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` was rejected with `Unsupported protocol 'grpc'` unless consumers passed `-DGRPC_ENABLED` themselves via `ghc-options`. The flag now sets `cpp-options: -DGRPC_ENABLED`.

## Testing

Verified against a local `otel/opentelemetry-collector` with `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` and `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`:

- spans arrive at the collector (broken before fix 2),
- after `docker restart` of the collector, export resumes on the next batches without an app restart (broken before fix 1, the scenario from #305).
